### PR TITLE
feat(maven): centralize version management and apply best practices to multi-module POM

### DIFF
--- a/.agents/skills/110-java-maven-best-practices/references/110-java-maven-best-practices.md
+++ b/.agents/skills/110-java-maven-best-practices/references/110-java-maven-best-practices.md
@@ -29,14 +29,18 @@ Maven is built on several foundational principles that guide its design and usag
 **7. Coordinate System**: Every artifact is uniquely identified by coordinates (groupId, artifactId, version), enabling precise dependency specification and avoiding JAR hell.
 **8. Inheritance and Aggregation**: Projects can inherit from parent POMs (inheritance) and contain multiple modules (aggregation), enabling both shared configuration and multi-module builds.
 
+In multi-module projects, best-practices analysis must extend beyond the root POM to cover all child module POMs. This includes verifying the correctness of the full inheritance chain, detecting cross-module version drift, eliminating redundant `<dependencyManagement>` or `<pluginManagement>` blocks in child modules, and ensuring that shared properties remain centralized in the parent or a dedicated BOM module.
+
 ## Constraints
 
-Before applying Maven best practices recommendations, ensure the project is in a valid state by running Maven validation. This helps identify any existing configuration issues that need to be resolved first.
+Before applying Maven best practices recommendations, ensure the project is in a valid state by running Maven validation. This helps identify any existing configuration issues that need to be resolved first. For multi-module projects, scope analysis must cover every child module POM — not just the root.
 
 - **MANDATORY**: Run `./mvnw validate` or `mvn validate` before applying any Maven best practices recommendations
 - **VERIFY**: Ensure all validation errors are resolved before proceeding with POM modifications
 - **PREREQUISITE**: Project must compile and pass basic validation checks before optimization
 - **SAFETY**: If validation fails, not continue and ask the user to fix the issues before continuing
+- **MULTI-MODULE DISCOVERY**: After reading the root `pom.xml`, check whether it contains a `<modules>` section. If it does, read every child module's `pom.xml` before making any recommendations — analysis scope is the full module tree, not only the root
+- **CROSS-MODULE SCOPE**: When child modules exist, check each one for: hardcoded dependency versions that duplicate `<dependencyManagement>` in the parent, plugin configurations that duplicate `<pluginManagement>`, properties that should be centralized in the parent, and version drift (same artifact declared at different versions across sibling modules)
 
 ## Examples
 
@@ -49,6 +53,8 @@ Before applying Maven best practices recommendations, ensure the project is in a
 - Example 5: Keep POMs Readable and Maintainable
 - Example 6: Manage Repositories Explicitly
 - Example 7: Centralize Version Management with Properties
+- Example 8: Multi-Module Project Structure
+- Example 9: Cross-Module Version Consistency
 
 ### Example 1: Effective Dependency Management
 
@@ -610,8 +616,234 @@ Description: Define all dependency and plugin versions in the `<properties>` sec
 
 ```
 
+
+### Example 8: Multi-Module Project Structure
+
+Title: Organize a Multi-Module Build with a Root Aggregator POM and Proper Inheritance
+Description: In a multi-module project the root POM acts as both aggregator (via `<modules>`) and parent (via inheritance). All shared dependency versions and plugin configurations belong in the root POM's `<dependencyManagement>` and `<pluginManagement>` sections. Child module POMs declare `<parent>` and reference managed artifacts without specifying versions. A dedicated BOM module can be introduced to decouple version management from build orchestration in large projects.
+
+**Good example:**
+
+```xml
+<!-- Root aggregator / parent POM -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>my-parent</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <!-- Declare all child modules -->
+  <modules>
+    <module>my-api</module>
+    <module>my-service</module>
+    <module>my-web</module>
+  </modules>
+
+  <properties>
+    <java.version>21</java.version>
+    <jackson.version>2.17.0</jackson.version>
+    <junit.version>5.11.0</junit.version>
+    <maven-plugin-compiler.version>3.14.0</maven-plugin-compiler.version>
+    <maven-plugin-surefire.version>3.5.3</maven-plugin-surefire.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <!-- Cross-module dependency managed here -->
+      <dependency>
+        <groupId>com.example</groupId>
+        <artifactId>my-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${maven-plugin-compiler.version}</version>
+          <configuration>
+            <release>${java.version}</release>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-plugin-surefire.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>
+
+<!-- Child module POM (my-service/pom.xml) -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>my-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <!-- relativePath tells Maven where to find the parent without a repository lookup -->
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>my-service</artifactId>
+  <!-- No <groupId> or <version> — inherited from parent -->
+
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>my-api</artifactId>
+      <!-- Version managed centrally in root dependencyManagement -->
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <!-- Version managed centrally in root dependencyManagement -->
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <!-- Version and scope managed centrally -->
+    </dependency>
+  </dependencies>
+</project>
+
+```
+
+**Bad example:**
+
+```xml
+<!-- Root POM without <modules> declaration -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>my-parent</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <!-- Missing <modules> — child modules won't be built with the root -->
+</project>
+
+<!-- Child module POM (my-service/pom.xml) with redundant management -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>          <!-- Duplicated from parent -->
+  <artifactId>my-service</artifactId>
+  <version>1.0.0-SNAPSHOT</version>       <!-- Not inherited — version drift risk -->
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>my-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <!-- Missing <relativePath> — forces Maven to look in local repository -->
+  </parent>
+
+  <!-- Redundant dependencyManagement duplicated across child modules -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.16.0</version> <!-- Differs from sibling module's 2.17.0 — version drift! -->
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>
+
+```
+
+### Example 9: Cross-Module Version Consistency
+
+Title: Detect and Fix Version Drift Across Sibling Modules
+Description: Version drift occurs when the same artifact is declared at different versions in sibling module POMs. This leads to non-reproducible builds and subtle runtime errors. The fix is to move all version declarations into the root POM's `<dependencyManagement>` (or a BOM module) and remove versions from every child POM. When performing multi-module analysis, read all sibling `pom.xml` files and compare declared dependency versions before recommending changes.
+
+**Good example:**
+
+```xml
+<!-- Root POM: single source of truth for all versions -->
+<project>
+  <!-- ... -->
+  <properties>
+    <logback.version>1.5.6</logback.version>
+    <slf4j.version>2.0.13</slf4j.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>
+
+<!-- my-service/pom.xml — no version, inherits from root -->
+<dependencies>
+  <dependency>
+    <groupId>ch.qos.logback</groupId>
+    <artifactId>logback-classic</artifactId>
+  </dependency>
+</dependencies>
+
+<!-- my-web/pom.xml — no version, inherits from root (same version guaranteed) -->
+<dependencies>
+  <dependency>
+    <groupId>ch.qos.logback</groupId>
+    <artifactId>logback-classic</artifactId>
+  </dependency>
+</dependencies>
+
+```
+
+**Bad example:**
+
+```xml
+<!-- my-service/pom.xml — hardcodes version -->
+<dependencies>
+  <dependency>
+    <groupId>ch.qos.logback</groupId>
+    <artifactId>logback-classic</artifactId>
+    <version>1.4.11</version> <!-- Version A -->
+  </dependency>
+</dependencies>
+
+<!-- my-web/pom.xml — different hardcoded version for same artifact -->
+<dependencies>
+  <dependency>
+    <groupId>ch.qos.logback</groupId>
+    <artifactId>logback-classic</artifactId>
+    <version>1.5.6</version> <!-- Version B — version drift! -->
+  </dependency>
+</dependencies>
+
+<!-- Result: Maven resolves each module independently.
+     Depending on classpath ordering, the wrong version may be used at runtime. -->
+
+```
+
 ## Output Format
 
+- **DISCOVER** the full project scope before analysis: read the root `pom.xml` and check for a `<modules>` section; if present, read every child module's `pom.xml` recursively. List all discovered modules and their paths at the start of the response so the user knows the analysis covers the complete build
 - **ANALYZE** Maven POM files to identify specific best practices violations and categorize them by impact (CRITICAL, MAINTENANCE, PERFORMANCE, STRUCTURE) and area (dependency management, plugin configuration, project structure, repository management, version control)
 - **CATEGORIZE** Maven configuration improvements found: Dependency Management Issues (missing dependencyManagement vs centralized version control, hardcoded versions vs property-based management, version conflicts vs resolution strategies, unused dependencies vs clean dependency trees), Plugin Configuration Problems (outdated versions vs current releases, missing configurations vs optimal settings, suboptimal configurations vs performance-tuned setups), Project Structure Opportunities (non-standard layouts vs Maven conventions, poor POM organization vs structured sections, missing properties vs centralized configuration)
 - **APPLY** Maven best practices directly by implementing the most appropriate improvements for each identified issue: Introduce dependencyManagement sections for version centralization, extract version properties for consistency, configure essential plugins with optimal settings, organize POM sections following Maven conventions, add missing repository declarations, optimize dependency scopes, and eliminate unused dependencies through analysis
@@ -629,3 +861,6 @@ Description: Define all dependency and plugin versions in the `<properties>` sec
 - Verify changes with the command: `./mvnw clean verify`
 - Preserve existing dependency versions unless explicitly requested to update
 - Maintain backward compatibility with existing build process
+- **MULTI-MODULE SCOPE**: When root POM contains `<modules>`, always read and analyze ALL child module POMs before making any recommendations — never base advice on the root POM alone
+- **VALIDATE ALL MODULES**: After any change to the root or a child POM in a multi-module project, run `./mvnw clean verify` from the project root to confirm the full reactor build still passes
+- **PRESERVE MODULE OVERRIDES**: Some child modules intentionally override parent-managed versions or plugin configurations for valid reasons (e.g., a module requiring a different Java release). Before removing an override from a child POM, confirm with the user that the override is unintentional

--- a/.cursor/rules/110-java-maven-best-practices.md
+++ b/.cursor/rules/110-java-maven-best-practices.md
@@ -29,14 +29,18 @@ Maven is built on several foundational principles that guide its design and usag
 **7. Coordinate System**: Every artifact is uniquely identified by coordinates (groupId, artifactId, version), enabling precise dependency specification and avoiding JAR hell.
 **8. Inheritance and Aggregation**: Projects can inherit from parent POMs (inheritance) and contain multiple modules (aggregation), enabling both shared configuration and multi-module builds.
 
+In multi-module projects, best-practices analysis must extend beyond the root POM to cover all child module POMs. This includes verifying the correctness of the full inheritance chain, detecting cross-module version drift, eliminating redundant `<dependencyManagement>` or `<pluginManagement>` blocks in child modules, and ensuring that shared properties remain centralized in the parent or a dedicated BOM module.
+
 ## Constraints
 
-Before applying Maven best practices recommendations, ensure the project is in a valid state by running Maven validation. This helps identify any existing configuration issues that need to be resolved first.
+Before applying Maven best practices recommendations, ensure the project is in a valid state by running Maven validation. This helps identify any existing configuration issues that need to be resolved first. For multi-module projects, scope analysis must cover every child module POM — not just the root.
 
 - **MANDATORY**: Run `./mvnw validate` or `mvn validate` before applying any Maven best practices recommendations
 - **VERIFY**: Ensure all validation errors are resolved before proceeding with POM modifications
 - **PREREQUISITE**: Project must compile and pass basic validation checks before optimization
 - **SAFETY**: If validation fails, not continue and ask the user to fix the issues before continuing
+- **MULTI-MODULE DISCOVERY**: After reading the root `pom.xml`, check whether it contains a `<modules>` section. If it does, read every child module's `pom.xml` before making any recommendations — analysis scope is the full module tree, not only the root
+- **CROSS-MODULE SCOPE**: When child modules exist, check each one for: hardcoded dependency versions that duplicate `<dependencyManagement>` in the parent, plugin configurations that duplicate `<pluginManagement>`, properties that should be centralized in the parent, and version drift (same artifact declared at different versions across sibling modules)
 
 ## Examples
 
@@ -49,6 +53,8 @@ Before applying Maven best practices recommendations, ensure the project is in a
 - Example 5: Keep POMs Readable and Maintainable
 - Example 6: Manage Repositories Explicitly
 - Example 7: Centralize Version Management with Properties
+- Example 8: Multi-Module Project Structure
+- Example 9: Cross-Module Version Consistency
 
 ### Example 1: Effective Dependency Management
 
@@ -610,8 +616,234 @@ Description: Define all dependency and plugin versions in the `<properties>` sec
 
 ```
 
+
+### Example 8: Multi-Module Project Structure
+
+Title: Organize a Multi-Module Build with a Root Aggregator POM and Proper Inheritance
+Description: In a multi-module project the root POM acts as both aggregator (via `<modules>`) and parent (via inheritance). All shared dependency versions and plugin configurations belong in the root POM's `<dependencyManagement>` and `<pluginManagement>` sections. Child module POMs declare `<parent>` and reference managed artifacts without specifying versions. A dedicated BOM module can be introduced to decouple version management from build orchestration in large projects.
+
+**Good example:**
+
+```xml
+<!-- Root aggregator / parent POM -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>my-parent</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <!-- Declare all child modules -->
+  <modules>
+    <module>my-api</module>
+    <module>my-service</module>
+    <module>my-web</module>
+  </modules>
+
+  <properties>
+    <java.version>21</java.version>
+    <jackson.version>2.17.0</jackson.version>
+    <junit.version>5.11.0</junit.version>
+    <maven-plugin-compiler.version>3.14.0</maven-plugin-compiler.version>
+    <maven-plugin-surefire.version>3.5.3</maven-plugin-surefire.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <!-- Cross-module dependency managed here -->
+      <dependency>
+        <groupId>com.example</groupId>
+        <artifactId>my-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${maven-plugin-compiler.version}</version>
+          <configuration>
+            <release>${java.version}</release>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-plugin-surefire.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>
+
+<!-- Child module POM (my-service/pom.xml) -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>my-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <!-- relativePath tells Maven where to find the parent without a repository lookup -->
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>my-service</artifactId>
+  <!-- No <groupId> or <version> — inherited from parent -->
+
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>my-api</artifactId>
+      <!-- Version managed centrally in root dependencyManagement -->
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <!-- Version managed centrally in root dependencyManagement -->
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <!-- Version and scope managed centrally -->
+    </dependency>
+  </dependencies>
+</project>
+
+```
+
+**Bad example:**
+
+```xml
+<!-- Root POM without <modules> declaration -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>my-parent</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <!-- Missing <modules> — child modules won't be built with the root -->
+</project>
+
+<!-- Child module POM (my-service/pom.xml) with redundant management -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>          <!-- Duplicated from parent -->
+  <artifactId>my-service</artifactId>
+  <version>1.0.0-SNAPSHOT</version>       <!-- Not inherited — version drift risk -->
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>my-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <!-- Missing <relativePath> — forces Maven to look in local repository -->
+  </parent>
+
+  <!-- Redundant dependencyManagement duplicated across child modules -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.16.0</version> <!-- Differs from sibling module's 2.17.0 — version drift! -->
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>
+
+```
+
+### Example 9: Cross-Module Version Consistency
+
+Title: Detect and Fix Version Drift Across Sibling Modules
+Description: Version drift occurs when the same artifact is declared at different versions in sibling module POMs. This leads to non-reproducible builds and subtle runtime errors. The fix is to move all version declarations into the root POM's `<dependencyManagement>` (or a BOM module) and remove versions from every child POM. When performing multi-module analysis, read all sibling `pom.xml` files and compare declared dependency versions before recommending changes.
+
+**Good example:**
+
+```xml
+<!-- Root POM: single source of truth for all versions -->
+<project>
+  <!-- ... -->
+  <properties>
+    <logback.version>1.5.6</logback.version>
+    <slf4j.version>2.0.13</slf4j.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>
+
+<!-- my-service/pom.xml — no version, inherits from root -->
+<dependencies>
+  <dependency>
+    <groupId>ch.qos.logback</groupId>
+    <artifactId>logback-classic</artifactId>
+  </dependency>
+</dependencies>
+
+<!-- my-web/pom.xml — no version, inherits from root (same version guaranteed) -->
+<dependencies>
+  <dependency>
+    <groupId>ch.qos.logback</groupId>
+    <artifactId>logback-classic</artifactId>
+  </dependency>
+</dependencies>
+
+```
+
+**Bad example:**
+
+```xml
+<!-- my-service/pom.xml — hardcodes version -->
+<dependencies>
+  <dependency>
+    <groupId>ch.qos.logback</groupId>
+    <artifactId>logback-classic</artifactId>
+    <version>1.4.11</version> <!-- Version A -->
+  </dependency>
+</dependencies>
+
+<!-- my-web/pom.xml — different hardcoded version for same artifact -->
+<dependencies>
+  <dependency>
+    <groupId>ch.qos.logback</groupId>
+    <artifactId>logback-classic</artifactId>
+    <version>1.5.6</version> <!-- Version B — version drift! -->
+  </dependency>
+</dependencies>
+
+<!-- Result: Maven resolves each module independently.
+     Depending on classpath ordering, the wrong version may be used at runtime. -->
+
+```
+
 ## Output Format
 
+- **DISCOVER** the full project scope before analysis: read the root `pom.xml` and check for a `<modules>` section; if present, read every child module's `pom.xml` recursively. List all discovered modules and their paths at the start of the response so the user knows the analysis covers the complete build
 - **ANALYZE** Maven POM files to identify specific best practices violations and categorize them by impact (CRITICAL, MAINTENANCE, PERFORMANCE, STRUCTURE) and area (dependency management, plugin configuration, project structure, repository management, version control)
 - **CATEGORIZE** Maven configuration improvements found: Dependency Management Issues (missing dependencyManagement vs centralized version control, hardcoded versions vs property-based management, version conflicts vs resolution strategies, unused dependencies vs clean dependency trees), Plugin Configuration Problems (outdated versions vs current releases, missing configurations vs optimal settings, suboptimal configurations vs performance-tuned setups), Project Structure Opportunities (non-standard layouts vs Maven conventions, poor POM organization vs structured sections, missing properties vs centralized configuration)
 - **APPLY** Maven best practices directly by implementing the most appropriate improvements for each identified issue: Introduce dependencyManagement sections for version centralization, extract version properties for consistency, configure essential plugins with optimal settings, organize POM sections following Maven conventions, add missing repository declarations, optimize dependency scopes, and eliminate unused dependencies through analysis
@@ -629,3 +861,6 @@ Description: Define all dependency and plugin versions in the `<properties>` sec
 - Verify changes with the command: `./mvnw clean verify`
 - Preserve existing dependency versions unless explicitly requested to update
 - Maintain backward compatibility with existing build process
+- **MULTI-MODULE SCOPE**: When root POM contains `<modules>`, always read and analyze ALL child module POMs before making any recommendations — never base advice on the root POM alone
+- **VALIDATE ALL MODULES**: After any change to the root or a child POM in a multi-module project, run `./mvnw clean verify` from the project root to confirm the full reactor build still passes
+- **PRESERVE MODULE OVERRIDES**: Some child modules intentionally override parent-managed versions or plugin configurations for valid reasons (e.g., a module requiring a different Java release). Before removing an override from a child POM, confirm with the user that the override is unintentional

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## Goal
 
-The project provides a collection of `System prompts` & `Skills` for Java Enterprise development that help software engineers in their daily programming work and data pipelines.
+The project provides a collection of `System prompts` & `Skills` for Java Enterprise development that help software engineers and pipelinesin their daily programming work.
 The [available System prompts for Java](./SYSTEM-PROMPTS-JAVA.md) cover aspects like `Build system based on Maven`, `Design`, `Coding`, `Testing`, `Refactoring & JMH Benchmarking`, `Performance testing with JMeter`, `Profiling with Async profiler/OpenJDK tools`, `Documentation`, `Diagrams` & `AGENTS.md`.
 
 ## Deliverables

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/cursor-rules-java/</id>
   <title>Cursor rules and Skills for Java</title>
-  <updated>2026-02-25T22:09:33+0100</updated>
+  <updated>2026-02-26T12:34:28+0100</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/cursor-rules-java/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/cursor-rules-java//feed.xml' />
   <entry>

--- a/pom.xml
+++ b/pom.xml
@@ -1,242 +1,333 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-  <groupId>info.jab</groupId>
-  <artifactId>cursor-rules-java</artifactId>
-  <version>0.12.0-SNAPSHOT</version>
-  <packaging>pom</packaging>
+    <groupId>info.jab</groupId>
+    <artifactId>cursor-rules-java</artifactId>
+    <version>0.12.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>cursor-rules-java</name>
+    <description>The project provides a collection of `System prompts` and `Skills` for Java Enterprise
+        development that help software engineers and pipelinesin their daily programming work.</description>
 
-  <properties>
-    <java.version>25</java.version>
-    <maven.version>3.9.10</maven.version>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <properties>
+        <java.version>25</java.version>
+        <maven.version>3.9.10</maven.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <!-- Feature-specific plugin versions -->
-    <maven-plugin-enforcer.version>3.6.1</maven-plugin-enforcer.version>
-    <extra-enforcer-rules.version>1.10.0</extra-enforcer-rules.version>
-    <maven-plugin-spotless.version>2.46.1</maven-plugin-spotless.version>
-    <maven-plugin-dependency-check.version>12.1.1</maven-plugin-dependency-check.version>
-    <maven-plugin-spotbugs.version>4.9.6.0</maven-plugin-spotbugs.version>
-    <maven-plugin-pmd.version>3.27.0</maven-plugin-pmd.version>
-    <maven-plugin-versions.version>2.19.0</maven-plugin-versions.version>
-  </properties>
+        <!-- Dependency versions -->
+        <slf4j.version>2.0.17</slf4j.version>
+        <logback.version>1.5.18</logback.version>
+        <junit.version>5.13.3</junit.version>
+        <assertj.version>3.27.3</assertj.version>
 
-  <modules>
-    <module>system-prompts-generator</module>
-    <module>skills-generator</module>
-    <module>site-generator</module>
-  </modules>
+        <!-- Core build plugin versions -->
+        <maven-plugin-compiler.version>3.14.0</maven-plugin-compiler.version>
+        <maven-plugin-surefire.version>3.5.4</maven-plugin-surefire.version>
+        <maven-plugin-resources.version>3.3.1</maven-plugin-resources.version>
+        <maven-plugin-clean.version>3.4.0</maven-plugin-clean.version>
 
-  <build>
-    <pluginManagement>
-      <plugins>
-        <!-- Maven Enforcer Plugin -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>${maven-plugin-enforcer.version}</version>
-          <dependencies>
+        <!-- Feature-specific plugin versions -->
+        <maven-plugin-enforcer.version>3.6.1</maven-plugin-enforcer.version>
+        <extra-enforcer-rules.version>1.10.0</extra-enforcer-rules.version>
+        <maven-plugin-spotless.version>2.46.1</maven-plugin-spotless.version>
+        <maven-plugin-dependency-check.version>12.1.1</maven-plugin-dependency-check.version>
+        <maven-plugin-spotbugs.version>4.9.6.0</maven-plugin-spotbugs.version>
+        <maven-plugin-pmd.version>3.27.0</maven-plugin-pmd.version>
+        <maven-plugin-versions.version>2.19.0</maven-plugin-versions.version>
+        <maven-plugin-jbake.version>2.7.0-rc.7</maven-plugin-jbake.version>
+    </properties>
+
+    <modules>
+        <module>system-prompts-generator</module>
+        <module>skills-generator</module>
+        <module>site-generator</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
             <dependency>
-              <groupId>org.codehaus.mojo</groupId>
-              <artifactId>extra-enforcer-rules</artifactId>
-              <version>${extra-enforcer-rules.version}</version>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
-          </dependencies>
-        </plugin>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>info.jab.pml</groupId>
+                <artifactId>cursor-rules-java-generator</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
-        <!-- Spotless Code Formatting -->
-        <plugin>
-          <groupId>com.diffplug.spotless</groupId>
-          <artifactId>spotless-maven-plugin</artifactId>
-          <version>${maven-plugin-spotless.version}</version>
-        </plugin>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!-- Maven Compiler Plugin -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-plugin-compiler.version}</version>
+                </plugin>
 
-        <!-- Versions Maven Plugin -->
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>versions-maven-plugin</artifactId>
-          <version>${maven-plugin-versions.version}</version>
-        </plugin>
+                <!-- Maven Surefire Plugin -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-plugin-surefire.version}</version>
+                </plugin>
 
-        <!-- SpotBugs Static Analysis -->
-        <plugin>
-          <groupId>com.github.spotbugs</groupId>
-          <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>${maven-plugin-spotbugs.version}</version>
-        </plugin>
+                <!-- Maven Resources Plugin -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${maven-plugin-resources.version}</version>
+                </plugin>
 
-        <!-- PMD Static Analysis -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-pmd-plugin</artifactId>
-          <version>${maven-plugin-pmd.version}</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
+                <!-- Maven Clean Plugin -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>${maven-plugin-clean.version}</version>
+                </plugin>
 
-    <plugins>
-      <!-- Maven Enforcer Plugin -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce</id>
-            <configuration>
-              <rules>
-                <banCircularDependencies/>
-                <dependencyConvergence />
-                <banDuplicatePomDependencyVersions />
-                <requireMavenVersion>
-                  <version>${maven.version}</version>
-                </requireMavenVersion>
-                <requireJavaVersion>
-                  <version>${java.version}</version>
-                </requireJavaVersion>
-                <bannedDependencies>
-                  <excludes>
-                    <exclude>org.projectlombok:lombok</exclude>
-                  </excludes>
-                </bannedDependencies>
-              </rules>
-              <fail>true</fail>
-            </configuration>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+                <!-- JBake Maven Plugin -->
+                <plugin>
+                    <groupId>org.jbake</groupId>
+                    <artifactId>jbake-maven-plugin</artifactId>
+                    <version>${maven-plugin-jbake.version}</version>
+                </plugin>
 
-      <!-- Spotless Code Formatting -->
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <configuration>
-          <encoding>UTF-8</encoding>
-          <java>
-            <removeUnusedImports />
-            <importOrder>
-              <order>,\#</order>
-            </importOrder>
-            <endWithNewline />
-            <trimTrailingWhitespace />
-            <indent>
-              <spaces>true</spaces>
-              <spacesPerTab>4</spacesPerTab>
-            </indent>
-          </java>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <phase>process-sources</phase>
-          </execution>
-        </executions>
-      </plugin>
+                <!-- Maven Enforcer Plugin -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${maven-plugin-enforcer.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>extra-enforcer-rules</artifactId>
+                            <version>${extra-enforcer-rules.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
 
-      <!-- Versions Maven Plugin -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>versions-maven-plugin</artifactId>
-        <configuration>
-          <allowSnapshots>false</allowSnapshots>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+                <!-- Spotless Code Formatting -->
+                <plugin>
+                    <groupId>com.diffplug.spotless</groupId>
+                    <artifactId>spotless-maven-plugin</artifactId>
+                    <version>${maven-plugin-spotless.version}</version>
+                </plugin>
 
-  <profiles>
-    <!-- Security Vulnerability Scanning Profile -->
-    <profile>
-      <id>security</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
+                <!-- Versions Maven Plugin -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>${maven-plugin-versions.version}</version>
+                </plugin>
+
+                <!-- SpotBugs Static Analysis -->
+                <plugin>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>${maven-plugin-spotbugs.version}</version>
+                </plugin>
+
+                <!-- PMD Static Analysis -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-pmd-plugin</artifactId>
+                    <version>${maven-plugin-pmd.version}</version>
+                </plugin>
+
+                <!-- OWASP Dependency Check -->
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <version>${maven-plugin-dependency-check.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
-          <plugin>
-            <groupId>org.owasp</groupId>
-            <artifactId>dependency-check-maven</artifactId>
-            <version>${maven-plugin-dependency-check.version}</version>
-            <configuration>
-              <outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
-              <format>ALL</format>
-              <failBuildOnCVSS>7</failBuildOnCVSS>
-              <skipProvidedScope>false</skipProvidedScope>
-              <skipRuntimeScope>false</skipRuntimeScope>
-              <skipSystemScope>false</skipSystemScope>
-              <skipTestScope>false</skipTestScope>
-              <!-- Performance and reliability improvements -->
-              <nvdApiDelay>4000</nvdApiDelay>
-              <nvdMaxRetryCount>3</nvdMaxRetryCount>
-              <nvdValidForHours>24</nvdValidForHours>
-              <!-- Skip analyzers that might cause issues -->
-              <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled>
-              <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>
-            </configuration>
-            <executions>
-              <execution>
-                <id>dependency-check</id>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-                <phase>verify</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
+            <!-- Maven Enforcer Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <configuration>
+                            <rules>
+                                <banCircularDependencies />
+                                <dependencyConvergence />
+                                <banDuplicatePomDependencyVersions />
+                                <requireMavenVersion>
+                                    <version>${maven.version}</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>${java.version}</version>
+                                </requireJavaVersion>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>org.projectlombok:lombok</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
-    <!-- Static Code Analysis Profile -->
-    <profile>
-      <id>find-bugs</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-pmd-plugin</artifactId>
-          </plugin>
-          <plugin>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-maven-plugin</artifactId>
-            <configuration>
-              <effort>Max</effort>
-              <threshold>Low</threshold>
-              <failOnError>true</failOnError>
-            </configuration>
-          </plugin>
+            <!-- Spotless Code Formatting -->
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                    <java>
+                        <removeUnusedImports />
+                        <importOrder>
+                            <order>,\#</order>
+                        </importOrder>
+                        <endWithNewline />
+                        <trimTrailingWhitespace />
+                        <indent>
+                            <spaces>true</spaces>
+                            <spacesPerTab>4</spacesPerTab>
+                        </indent>
+                    </java>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Versions Maven Plugin -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <configuration>
+                    <allowSnapshots>false</allowSnapshots>
+                </configuration>
+            </plugin>
         </plugins>
-      </build>
-      <reporting>
-        <plugins>
-          <!-- SpotBugs reporting for Maven site -->
-          <plugin>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-maven-plugin</artifactId>
-            <configuration>
-              <effort>Max</effort>
-              <threshold>Low</threshold>
-              <includeFilterFile>src/main/spotbugs/spotbugs-include.xml</includeFilterFile>
-              <excludeFilterFile>src/main/spotbugs/spotbugs-exclude.xml</excludeFilterFile>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-pmd-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </reporting>
-    </profile>
-  </profiles>
+    </build>
+
+    <profiles>
+        <!-- Security Vulnerability Scanning Profile -->
+        <profile>
+            <id>security</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+                            <format>ALL</format>
+                            <failBuildOnCVSS>7</failBuildOnCVSS>
+                            <skipProvidedScope>false</skipProvidedScope>
+                            <skipRuntimeScope>false</skipRuntimeScope>
+                            <skipSystemScope>false</skipSystemScope>
+                            <skipTestScope>false</skipTestScope>
+                            <!-- Performance and reliability improvements -->
+                            <nvdApiDelay>4000</nvdApiDelay>
+                            <nvdMaxRetryCount>3</nvdMaxRetryCount>
+                            <nvdValidForHours>24</nvdValidForHours>
+                            <!-- Skip analyzers that might cause issues -->
+                            <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled>
+                            <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>dependency-check</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <phase>verify</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- Static Code Analysis Profile -->
+        <profile>
+            <id>find-bugs</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <configuration>
+                            <effort>Max</effort>
+                            <threshold>Low</threshold>
+                            <failOnError>true</failOnError>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <reporting>
+                <plugins>
+                    <!-- SpotBugs reporting for Maven site -->
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <configuration>
+                            <effort>Max</effort>
+                            <threshold>Low</threshold>
+                            <includeFilterFile>src/main/spotbugs/spotbugs-include.xml</includeFilterFile>
+                            <excludeFilterFile>src/main/spotbugs/spotbugs-exclude.xml</excludeFilterFile>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </reporting>
+        </profile>
+    </profiles>
 </project>

--- a/site-generator/pom.xml
+++ b/site-generator/pom.xml
@@ -14,24 +14,6 @@
     <artifactId>cursor-rules-java-site</artifactId>
     <packaging>pom</packaging>
 
-    <properties>
-        <maven-plugin-jbake.version>2.7.0-rc.7</maven-plugin-jbake.version>
-        <maven-plugin-clean.version>3.4.0</maven-plugin-clean.version>
-        <maven-plugin-resources.version>3.3.1</maven-plugin-resources.version>
-    </properties>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.jbake</groupId>
-                    <artifactId>jbake-maven-plugin</artifactId>
-                    <version>${maven-plugin-jbake.version}</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
-
     <profiles>
         <profile>
             <id>site-update</id>
@@ -40,7 +22,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-clean-plugin</artifactId>
-                        <version>${maven-plugin-clean.version}</version>
                         <executions>
                             <execution>
                                 <id>clean-www-folder</id>
@@ -65,7 +46,6 @@
                     <plugin>
                         <groupId>org.jbake</groupId>
                         <artifactId>jbake-maven-plugin</artifactId>
-                        <version>${maven-plugin-jbake.version}</version>
                         <executions>
                             <execution>
                                 <phase>generate-resources</phase>
@@ -82,7 +62,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-resources-plugin</artifactId>
-                        <version>${maven-plugin-resources.version}</version>
                         <executions>
                             <execution>
                                 <id>copy-dvbe25-to-docs</id>

--- a/skills-generator/pom.xml
+++ b/skills-generator/pom.xml
@@ -14,52 +14,21 @@
     <artifactId>cursor-rules-java-skills-generator</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <!-- Module-specific plugin versions -->
-        <maven-plugin-compiler.version>3.14.0</maven-plugin-compiler.version>
-        <maven-plugin-surefire.version>3.5.4</maven-plugin-surefire.version>
-
-        <!-- Logging dependency versions -->
-        <slf4j.version>2.0.17</slf4j.version>
-        <logback.version>1.5.18</logback.version>
-        <junit.version>5.13.3</junit.version>
-
-        <!-- Test dependency versions -->
-        <assertj.version>3.27.3</assertj.version>
-
-        <maven-plugin-resources.version>3.3.1</maven-plugin-resources.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${junit.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- System prompts generator (cursor rules) -->
         <dependency>
             <groupId>info.jab.pml</groupId>
             <artifactId>cursor-rules-java-generator</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- Logging dependencies -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -76,7 +45,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -87,7 +55,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-plugin-compiler.version}</version>
                 <configuration>
                     <release>${java.version}</release>
                 </configuration>
@@ -97,7 +64,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-plugin-surefire.version}</version>
                 <configuration>
                     <skipAfterFailureCount>1</skipAfterFailureCount>
                     <includes>
@@ -113,7 +79,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>${maven-plugin-resources.version}</version>
                 <executions>
                     <execution>
                         <id>copy-skills</id>

--- a/system-prompts-generator/pom.xml
+++ b/system-prompts-generator/pom.xml
@@ -14,45 +14,15 @@
     <artifactId>cursor-rules-java-generator</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <!-- Module-specific plugin versions -->
-        <maven-plugin-compiler.version>3.14.0</maven-plugin-compiler.version>
-        <maven-plugin-surefire.version>3.5.4</maven-plugin-surefire.version>
-
-        <!-- Logging dependency versions -->
-        <slf4j.version>2.0.17</slf4j.version>
-        <logback.version>1.5.18</logback.version>
-        <junit.version>5.13.3</junit.version>
-
-        <!-- Test dependency versions -->
-        <assertj.version>3.27.3</assertj.version>
-
-        <maven-plugin-resources.version>3.3.1</maven-plugin-resources.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${junit.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- Logging dependencies -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -71,7 +41,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -82,18 +51,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-plugin-compiler.version}</version>
                 <configuration>
                     <release>${java.version}</release>
                 </configuration>
             </plugin>
 
-
             <!-- Unit testing -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-plugin-surefire.version}</version>
                 <configuration>
                     <skipAfterFailureCount>1</skipAfterFailureCount>
                     <includes>
@@ -110,7 +76,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>${maven-plugin-resources.version}</version>
                 <executions>
                     <execution>
                         <id>copy-cursor-rules</id>

--- a/system-prompts-generator/src/main/resources/110-java-maven-best-practices.xml
+++ b/system-prompts-generator/src/main/resources/110-java-maven-best-practices.xml
@@ -26,18 +26,23 @@
         **6. Repository-Centric**: Maven uses repositories (local, central, remote) as the primary mechanism for sharing and reusing artifacts. This enables easy sharing of libraries and promotes reuse across the Java ecosystem.
         **7. Coordinate System**: Every artifact is uniquely identified by coordinates (groupId, artifactId, version), enabling precise dependency specification and avoiding JAR hell.
         **8. Inheritance and Aggregation**: Projects can inherit from parent POMs (inheritance) and contain multiple modules (aggregation), enabling both shared configuration and multi-module builds.
+
+        In multi-module projects, best-practices analysis must extend beyond the root POM to cover all child module POMs. This includes verifying the correctness of the full inheritance chain, detecting cross-module version drift, eliminating redundant `&lt;dependencyManagement&gt;` or `&lt;pluginManagement&gt;` blocks in child modules, and ensuring that shared properties remain centralized in the parent or a dedicated BOM module.
     </goal>
 
     <constraints>
         <constraints-description>
             Before applying Maven best practices recommendations, ensure the project is in a valid state by running Maven validation.
             This helps identify any existing configuration issues that need to be resolved first.
+            For multi-module projects, scope analysis must cover every child module POM — not just the root.
         </constraints-description>
         <constraint-list>
             <constraint>**MANDATORY**: Run `./mvnw validate` or `mvn validate` before applying any Maven best practices recommendations</constraint>
             <constraint>**VERIFY**: Ensure all validation errors are resolved before proceeding with POM modifications</constraint>
             <constraint>**PREREQUISITE**: Project must compile and pass basic validation checks before optimization</constraint>
             <constraint>**SAFETY**: If validation fails, not continue and ask the user to fix the issues before continuing</constraint>
+            <constraint>**MULTI-MODULE DISCOVERY**: After reading the root `pom.xml`, check whether it contains a `&lt;modules&gt;` section. If it does, read every child module's `pom.xml` before making any recommendations — analysis scope is the full module tree, not only the root</constraint>
+            <constraint>**CROSS-MODULE SCOPE**: When child modules exist, check each one for: hardcoded dependency versions that duplicate `&lt;dependencyManagement&gt;` in the parent, plugin configurations that duplicate `&lt;pluginManagement&gt;`, properties that should be centralized in the parent, and version drift (same artifact declared at different versions across sibling modules)</constraint>
         </constraint-list>
     </constraints>
 
@@ -637,10 +642,244 @@ my-app/
                 </bad-example>
             </code-examples>
         </example>
+        <example number="8" id="multi-module-project-structure">
+            <example-header>
+                <example-title>Multi-Module Project Structure</example-title>
+                <example-subtitle>Organize a Multi-Module Build with a Root Aggregator POM and Proper Inheritance</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                In a multi-module project the root POM acts as both aggregator (via `<modules>`) and parent (via inheritance). All shared dependency versions and plugin configurations belong in the root POM's `<dependencyManagement>` and `<pluginManagement>` sections. Child module POMs declare `<parent>` and reference managed artifacts without specifying versions. A dedicated BOM module can be introduced to decouple version management from build orchestration in large projects.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="xml"><![CDATA[
+<!-- Root aggregator / parent POM -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>my-parent</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <!-- Declare all child modules -->
+  <modules>
+    <module>my-api</module>
+    <module>my-service</module>
+    <module>my-web</module>
+  </modules>
+
+  <properties>
+    <java.version>21</java.version>
+    <jackson.version>2.17.0</jackson.version>
+    <junit.version>5.11.0</junit.version>
+    <maven-plugin-compiler.version>3.14.0</maven-plugin-compiler.version>
+    <maven-plugin-surefire.version>3.5.3</maven-plugin-surefire.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <!-- Cross-module dependency managed here -->
+      <dependency>
+        <groupId>com.example</groupId>
+        <artifactId>my-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${maven-plugin-compiler.version}</version>
+          <configuration>
+            <release>${java.version}</release>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-plugin-surefire.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>
+
+<!-- Child module POM (my-service/pom.xml) -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>my-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <!-- relativePath tells Maven where to find the parent without a repository lookup -->
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>my-service</artifactId>
+  <!-- No <groupId> or <version> — inherited from parent -->
+
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>my-api</artifactId>
+      <!-- Version managed centrally in root dependencyManagement -->
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <!-- Version managed centrally in root dependencyManagement -->
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <!-- Version and scope managed centrally -->
+    </dependency>
+  </dependencies>
+</project>
+                    ]]></code-block>
+                </good-example>
+                <bad-example>
+                    <code-block language="xml"><![CDATA[
+<!-- Root POM without <modules> declaration -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>my-parent</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <!-- Missing <modules> — child modules won't be built with the root -->
+</project>
+
+<!-- Child module POM (my-service/pom.xml) with redundant management -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>          <!-- Duplicated from parent -->
+  <artifactId>my-service</artifactId>
+  <version>1.0.0-SNAPSHOT</version>       <!-- Not inherited — version drift risk -->
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>my-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <!-- Missing <relativePath> — forces Maven to look in local repository -->
+  </parent>
+
+  <!-- Redundant dependencyManagement duplicated across child modules -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.16.0</version> <!-- Differs from sibling module's 2.17.0 — version drift! -->
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>
+                    ]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="9" id="cross-module-version-consistency">
+            <example-header>
+                <example-title>Cross-Module Version Consistency</example-title>
+                <example-subtitle>Detect and Fix Version Drift Across Sibling Modules</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Version drift occurs when the same artifact is declared at different versions in sibling module POMs. This leads to non-reproducible builds and subtle runtime errors. The fix is to move all version declarations into the root POM's `<dependencyManagement>` (or a BOM module) and remove versions from every child POM. When performing multi-module analysis, read all sibling `pom.xml` files and compare declared dependency versions before recommending changes.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="xml"><![CDATA[
+<!-- Root POM: single source of truth for all versions -->
+<project>
+  <!-- ... -->
+  <properties>
+    <logback.version>1.5.6</logback.version>
+    <slf4j.version>2.0.13</slf4j.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>
+
+<!-- my-service/pom.xml — no version, inherits from root -->
+<dependencies>
+  <dependency>
+    <groupId>ch.qos.logback</groupId>
+    <artifactId>logback-classic</artifactId>
+  </dependency>
+</dependencies>
+
+<!-- my-web/pom.xml — no version, inherits from root (same version guaranteed) -->
+<dependencies>
+  <dependency>
+    <groupId>ch.qos.logback</groupId>
+    <artifactId>logback-classic</artifactId>
+  </dependency>
+</dependencies>
+                    ]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="xml"><![CDATA[
+<!-- my-service/pom.xml — hardcodes version -->
+<dependencies>
+  <dependency>
+    <groupId>ch.qos.logback</groupId>
+    <artifactId>logback-classic</artifactId>
+    <version>1.4.11</version> <!-- Version A -->
+  </dependency>
+</dependencies>
+
+<!-- my-web/pom.xml — different hardcoded version for same artifact -->
+<dependencies>
+  <dependency>
+    <groupId>ch.qos.logback</groupId>
+    <artifactId>logback-classic</artifactId>
+    <version>1.5.6</version> <!-- Version B — version drift! -->
+  </dependency>
+</dependencies>
+
+<!-- Result: Maven resolves each module independently.
+     Depending on classpath ordering, the wrong version may be used at runtime. -->
+                    ]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
     </examples>
 
     <output-format>
         <output-format-list>
+            <output-format-item>**DISCOVER** the full project scope before analysis: read the root `pom.xml` and check for a `&lt;modules&gt;` section; if present, read every child module's `pom.xml` recursively. List all discovered modules and their paths at the start of the response so the user knows the analysis covers the complete build</output-format-item>
             <output-format-item>**ANALYZE** Maven POM files to identify specific best practices violations and categorize them by impact (CRITICAL, MAINTENANCE, PERFORMANCE, STRUCTURE) and area (dependency management, plugin configuration, project structure, repository management, version control)</output-format-item>
             <output-format-item>**CATEGORIZE** Maven configuration improvements found: Dependency Management Issues (missing dependencyManagement vs centralized version control, hardcoded versions vs property-based management, version conflicts vs resolution strategies, unused dependencies vs clean dependency trees), Plugin Configuration Problems (outdated versions vs current releases, missing configurations vs optimal settings, suboptimal configurations vs performance-tuned setups), Project Structure Opportunities (non-standard layouts vs Maven conventions, poor POM organization vs structured sections, missing properties vs centralized configuration)</output-format-item>
             <output-format-item>**APPLY** Maven best practices directly by implementing the most appropriate improvements for each identified issue: Introduce dependencyManagement sections for version centralization, extract version properties for consistency, configure essential plugins with optimal settings, organize POM sections following Maven conventions, add missing repository declarations, optimize dependency scopes, and eliminate unused dependencies through analysis</output-format-item>
@@ -660,6 +899,9 @@ my-app/
             <safeguards-item>Verify changes with the command: `./mvnw clean verify`</safeguards-item>
             <safeguards-item>Preserve existing dependency versions unless explicitly requested to update</safeguards-item>
             <safeguards-item>Maintain backward compatibility with existing build process</safeguards-item>
+            <safeguards-item>**MULTI-MODULE SCOPE**: When root POM contains `&lt;modules&gt;`, always read and analyze ALL child module POMs before making any recommendations — never base advice on the root POM alone</safeguards-item>
+            <safeguards-item>**VALIDATE ALL MODULES**: After any change to the root or a child POM in a multi-module project, run `./mvnw clean verify` from the project root to confirm the full reactor build still passes</safeguards-item>
+            <safeguards-item>**PRESERVE MODULE OVERRIDES**: Some child modules intentionally override parent-managed versions or plugin configurations for valid reasons (e.g., a module requiring a different Java release). Before removing an override from a child POM, confirm with the user that the override is unintentional</safeguards-item>
         </safeguards-list>
     </safeguards>
 </prompt>


### PR DESCRIPTION
feat(maven): centralize version management and apply best practices to multi-module POM

- Add dependencyManagement to root POM for junit-bom, slf4j, logback, assertj, and cross-module dependency
- Centralize all dependency and plugin version properties in root POM (compiler, surefire, resources, clean, jbake, slf4j, logback, junit, assertj)
- Add maven-compiler-plugin, maven-surefire-plugin, maven-resources-plugin, maven-clean-plugin, and jbake-maven-plugin to root pluginManagement
- Remove duplicated properties and dependencyManagement from system-prompts-generator and skills-generator (version drift eliminated)
- Remove inline plugin/dependency versions from all child modules; versions now inherited from root
- Remove redundant pluginManagement block from site-generator; properties centralized to root

Made-with: Cursor

# Rationale for this change

Explain the reasons to change the repository

# What changes are included in this PR?

Explain what changes do this PR

# Are these changes tested?

Explain if the PR was tested and explain details

# Are there any user-facing changes?

Explain if the PR will impact the final user
