### PR TITLE
feat(mcp): removed maven-tools mpc and github mcp

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,30 +1,7 @@
 {
     "mcpServers": {
-        "maven-tools": {
-            "command": "docker",
-            "args": [
-                "run",
-                "-i",
-                "--rm",
-                "arvindand/maven-tools-mcp:latest"
-            ]
-        },
         "javadocs": {
             "url": "https://www.javadocs.dev/mcp"
-        },
-        "github": {
-            "command": "docker",
-            "args": [
-                "run",
-                "-i",
-                "--rm",
-                "-e",
-                "GITHUB_PERSONAL_ACCESS_TOKEN",
-                "ghcr.io/github/github-mcp-server:latest"
-            ],
-            "env": {
-                "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN_HERE"
-            }
         },
         "serena": {
             "command": "docker",


### PR DESCRIPTION
# Rationale for this change

removew few mcp

- maven-tools replaced with @114-java-maven-search 
- github mcp with @021-tooling-github 

# What changes are included in this PR?

Updated mcp.json

# Are these changes tested?

Yes

# Are there any user-facing changes?

No
