### PR TITLE
feat(config): share MCP config with Claude via symlink

### DIFF
--- a/.claude/mcp.json
+++ b/.claude/mcp.json
@@ -1,0 +1,1 @@
+../.cursor/mcp.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ target/
 .idea/
 .vscode/
 .classpath
-.claude
 .agents
 dependency-reduced-pom.xml
 docs-local/


### PR DESCRIPTION
## Summary
- add `.claude/mcp.json` as a symlink to `../.cursor/mcp.json` so Claude reuses the same MCP configuration
- remove `.claude` from `.gitignore` so the symlink is tracked in git
- keep MCP configuration source of truth in one file to reduce duplication and drift

## Test plan
- [x] verify symlink exists: `ls -la .claude`
- [x] verify link target: `readlink .claude/mcp.json`
- [x] confirm clean working tree after commit: `git status --short`

Made with [Cursor](https://cursor.com)