### PR TITLE
docs(readme): restore badges and workflow images

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Stargazers over time
 
-[Stargazers over time](https://starchart.cc/jabrena/cursor-rules-java)
+[![Stargazers over time](https://starchart.cc/jabrena/cursor-rules-java.svg?variant=adaptive)](https://starchart.cc/jabrena/cursor-rules-java)
 
-[CI Builds](https://github.com/jabrena/cursor-rules-java/actions/workflows/maven.yaml)
+[![CI Builds](https://github.com/jabrena/cursor-rules-java/actions/workflows/maven.yaml/badge.svg)](https://github.com/jabrena/cursor-rules-java/actions/workflows/maven.yaml)
 
 ## Goal
 
@@ -39,10 +39,10 @@ This project is compatible with any Tool compatible with `Skills`, `Agents` or `
 
 Read the following comprehensive guides to use this project today.
 
-- [Getting started with `System prompts for Java](./documentation/GETTING-STARTED-SYSTEM-PROMPTS.md)`
-- [Getting started with `Skills for Java](./documentation/GETTING-STARTED-SKILLS.md)`
-- [Getting started with `Pipelines and AI](./documentation/GETTING-STARTED-PIPELINES.md)`
-- [Getting started with `Agents](./documentation/GETTING-STARTED-AGENTS.md)`
+- [Getting started with `System prompts for Java`](./documentation/GETTING-STARTED-SYSTEM-PROMPTS.md)
+- [Getting started with `Skills for Java`](./documentation/GETTING-STARTED-SKILLS.md)
+- [Getting started with `Pipelines and AI`](./documentation/GETTING-STARTED-PIPELINES.md)
+- [Getting started with `Agents`](./documentation/GETTING-STARTED-AGENTS.md)
 
 ## How to use them?
 
@@ -52,15 +52,19 @@ The SDLC has evolved with the arrival of this new set of AI tooling, enhancing t
 
 In this workflow, the Software engineer interact with models using `User prompts` and in an incremental way you delegate a delegate completely a task or ask help in certain moments. You could use this project to refactor the code generated or delegate the task and associate a System prompt / Skills to that task.
 
-
+![](./documentation/images/workflow-prompts.png)
 
 ### Agent Workflow
 
 `Agents for Java Enterprise development` were designed to help the Software engineer in the implementation phase. The software engineer define good `Specs` and that Specifications are delegated to Agents.
 
+![](./documentation/images/workflow-agents.png)
+
 ### Pipelines Workflow
 
 Adding AI tools to your pipeline can provide new opportunities to deliver more value (examples: automatic coding, code refactoring, continuous profiling, and others).
+
+![](./documentation/images/workflow-pipelines.png)
 
 ## Limitations
 
@@ -93,7 +97,6 @@ The repository includes [a collection of examples](./examples/) where you can ex
 | 2025-09-16 | ADR-003 | [Website Generation](./documentation/adr/ADR-003-website-generation.md)                                                                 |
 | 2025-07-10 | ADR-002 | [Cursor Rules scope configuration](./documentation/adr/ADR-002-configure-cursor-rules-manual-scope.md)                                  |
 | 2025-07-08 | ADR-001 | [Cursor Rules generation from XML Files](./documentation/adr/ADR-001-generate-cursor-rules-from-xml-files.md)                           |
-
 
 ## Changelog
 


### PR DESCRIPTION
## Summary
- restore README badges for stargazers and CI builds
- fix the four getting-started markdown links to valid formatting
- re-add workflow images for prompting, agent, and pipeline sections

## Test plan
- [x] verify README renders badge images again
- [x] verify getting-started links are clickable and valid markdown
- [x] verify workflow images are present in README sections

Made with [Cursor](https://cursor.com)