### PR TITLE
feat(skill): add INVEST validation to user story workflow

### DIFF
--- a/documentation/openspec/changes/archive/2026-04-07-add-invest-criteria-user-story-skill/.openspec.yaml
+++ b/documentation/openspec/changes/archive/2026-04-07-add-invest-criteria-user-story-skill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-07

--- a/documentation/openspec/changes/archive/2026-04-07-add-invest-criteria-user-story-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-04-07-add-invest-criteria-user-story-skill/proposal.md
@@ -1,0 +1,23 @@
+# Add INVEST Criteria to User Story Skill
+
+## Problem Statement
+
+Issue [#540](https://github.com/jabrena/cursor-rules-java/issues/540) identifies a quality gap in the `014-agile-user-story` skill: the guidance does not explicitly require validating stories with the INVEST criteria.
+
+Without an explicit INVEST checkpoint, generated stories can be incomplete or weak in quality dimensions such as independence, estimability, and testability.
+
+## Proposed Solution
+
+Update the `014-agile-user-story` skill guidance to include explicit INVEST criteria as part of the story quality workflow.
+
+The update should:
+- Define each INVEST dimension in practical terms for story authors.
+- Add a validation step before finalizing a story.
+- Include an example that demonstrates INVEST-compliant user story output.
+
+## Success Criteria
+
+- The user story skill includes an explicit INVEST section.
+- The skill workflow requires INVEST validation before final output.
+- INVEST definitions are clear and actionable.
+- Example output shows how a story satisfies INVEST.

--- a/documentation/openspec/changes/archive/2026-04-07-add-invest-criteria-user-story-skill/specs/agile-user-story-quality/spec.md
+++ b/documentation/openspec/changes/archive/2026-04-07-add-invest-criteria-user-story-skill/specs/agile-user-story-quality/spec.md
@@ -1,0 +1,30 @@
+# Agile User Story Quality Specification
+
+## ADDED Requirements
+
+### Requirement: INVEST Criteria Guidance
+The `014-agile-user-story` skill SHALL include explicit INVEST quality criteria guidance for user story authoring.
+
+#### Scenario: INVEST guidance is present
+- **Given** a user is creating a story with the `014-agile-user-story` skill
+- **When** the skill instructions are presented
+- **Then** the skill includes a dedicated INVEST section
+- **And** each INVEST dimension is defined in practical terms
+
+### Requirement: INVEST Validation Step
+The `014-agile-user-story` skill SHALL require an INVEST validation step before final story output.
+
+#### Scenario: Story is validated before finalization
+- **Given** a story draft has been created
+- **When** the workflow reaches finalization
+- **Then** the skill prompts validation against INVEST
+- **And** the final output is confirmed against all INVEST dimensions
+
+### Requirement: INVEST-Compliant Example
+The `014-agile-user-story` skill SHALL provide an example showing how a user story satisfies INVEST.
+
+#### Scenario: Example demonstrates criteria
+- **Given** a user reviews the skill documentation
+- **When** they reach examples
+- **Then** at least one example references INVEST compliance
+- **And** the example is traceable to Independent, Negotiable, Valuable, Estimable, Small, and Testable qualities

--- a/documentation/openspec/changes/archive/2026-04-07-add-invest-criteria-user-story-skill/tasks.md
+++ b/documentation/openspec/changes/archive/2026-04-07-add-invest-criteria-user-story-skill/tasks.md
@@ -1,0 +1,8 @@
+# Tasks: Add INVEST Criteria to User Story Skill
+
+- [x] Review current `014-agile-user-story` skill content and identify insertion points for INVEST guidance.
+- [x] Add an explicit INVEST section to the skill documentation.
+- [x] Document each INVEST criterion (Independent, Negotiable, Valuable, Estimable, Small, Testable) with practical author guidance.
+- [x] Update the skill workflow to require INVEST validation before finalizing artifacts.
+- [x] Add or update an example user story showing INVEST compliance.
+- [x] Validate consistency with existing skill style and constraints.

--- a/documentation/openspec/specs/agile-user-story-quality/spec.md
+++ b/documentation/openspec/specs/agile-user-story-quality/spec.md
@@ -1,0 +1,32 @@
+# agile-user-story-quality Specification
+
+## Purpose
+TBD - created by archiving change add-invest-criteria-user-story-skill. Update Purpose after archive.
+## Requirements
+### Requirement: INVEST Criteria Guidance
+The `014-agile-user-story` skill SHALL include explicit INVEST quality criteria guidance for user story authoring.
+
+#### Scenario: INVEST guidance is present
+- **Given** a user is creating a story with the `014-agile-user-story` skill
+- **When** the skill instructions are presented
+- **Then** the skill includes a dedicated INVEST section
+- **And** each INVEST dimension is defined in practical terms
+
+### Requirement: INVEST Validation Step
+The `014-agile-user-story` skill SHALL require an INVEST validation step before final story output.
+
+#### Scenario: Story is validated before finalization
+- **Given** a story draft has been created
+- **When** the workflow reaches finalization
+- **Then** the skill prompts validation against INVEST
+- **And** the final output is confirmed against all INVEST dimensions
+
+### Requirement: INVEST-Compliant Example
+The `014-agile-user-story` skill SHALL provide an example showing how a user story satisfies INVEST.
+
+#### Scenario: Example demonstrates criteria
+- **Given** a user reviews the skill documentation
+- **When** they reach examples
+- **Then** at least one example references INVEST compliance
+- **And** the example is traceable to Independent, Negotiable, Valuable, Estimable, Small, and Testable qualities
+

--- a/documentation/openspec/specs/compatibility-planning/spec.md
+++ b/documentation/openspec/specs/compatibility-planning/spec.md
@@ -1,36 +1,46 @@
 # compatibility-planning Specification
 
 ## Purpose
-TBD - created by archiving change phase-0-decision-compatibility. Update Purpose after archive.
+Define the ongoing compatibility policy for this project so contributors can evolve Skills, Agents, AGENTS.md guidance, and OpenSpec workflows without creating avoidable downstream breakage. This specification establishes how compatibility targets are identified, how breaking changes are communicated, and which repository artifacts must stay aligned when compatibility-impacting decisions are made.
 ## Requirements
-### Requirement: Breaking Change Policy
-The project SHALL establish a clear breaking change policy for the rules-to-skills migration.
+### Requirement: Compatibility Surface Definition
+The project SHALL maintain a clear, documented compatibility surface aligned with the repository goal and deliverables.
 
-#### Scenario: Version bump planning
-- **Given** the migration removes `.cursor/rules` support
-- **When** planning the release
-- **Then** a major version bump to v0.14.0 is planned
-- **And** breaking change documentation is prepared
-- **And** migration guidance is created for users
+#### Scenario: Compatibility targets are explicit
+- **Given** contributors are planning a change that affects generated guidance or project workflows
+- **When** they evaluate compatibility impact
+- **Then** they identify impacted surfaces across `skills/`, `.cursor/agents`, `AGENTS.md` conventions, and OpenSpec-based planning artifacts
+- **And** they document which user-facing contracts are expected to remain stable
+- **And** they record any intentionally unsupported legacy behavior as out of scope
 
-### Requirement: Dependency Inventory
-The project SHALL maintain a complete inventory of systems dependent on the current architecture.
+### Requirement: Breaking Change Governance
+The project SHALL apply explicit governance for breaking changes that affect supported compatibility surfaces.
 
-#### Scenario: Complete dependency mapping
-- **Given** the migration is being planned
-- **When** conducting the dependency audit
-- **Then** all references to `system-prompts-generator` are identified
-- **And** all references to `.cursor/rules` are catalogued
-- **And** all site templates and CI dependencies are mapped
-- **And** all example projects are inventoried
+#### Scenario: Breaking change is proposed
+- **Given** a proposed change alters expected behavior for supported consumers
+- **When** the change is reviewed
+- **Then** the change is marked as breaking
+- **And** semantic versioning impact is documented before release
+- **And** migration guidance is written for downstream users
+- **And** related ADR and/or OpenSpec change records are linked
 
-### Requirement: Artifact Naming Strategy
-The project SHALL define a clear naming strategy for the merged generator module.
+### Requirement: Ecosystem and Dependency Impact Mapping
+The project SHALL evaluate ecosystem and repository dependencies before compatibility-impacting changes are accepted.
 
-#### Scenario: Naming decisions documented
-- **Given** the generators will be merged
-- **When** making naming decisions
-- **Then** the final artifact name is decided
-- **And** Maven coordinates are confirmed
-- **And** backward compatibility implications are understood
+#### Scenario: Impact assessment is completed
+- **Given** a compatibility-relevant change is in planning
+- **When** maintainers perform impact analysis
+- **Then** they map affected documentation, CI workflows, examples, and generator modules
+- **And** they identify downstream usage assumptions that may fail after the change
+- **And** they capture mitigation actions in tasks or migration notes
+
+### Requirement: Documentation and Delivery Alignment
+The project SHALL keep public documentation and validated delivery outputs aligned with the compatibility policy.
+
+#### Scenario: Release preparation validates compatibility communication
+- **Given** compatibility-impacting work is ready for release
+- **When** release preparation is performed
+- **Then** `README.md` and relevant getting-started/contributor documentation reflect the current supported workflow
+- **And** generated deliverables remain consistent with the documented compatibility surface
+- **And** verification commands used by the project continue to pass for the supported pipeline
 

--- a/skills-generator/src/main/resources/skills/014-skill.xml
+++ b/skills-generator/src/main/resources/skills/014-skill.xml
@@ -21,6 +21,7 @@ Guide the agent to ask targeted questions to gather details for a user story and
 - Gherkin feature file: Feature name, background steps, scenarios
 - Acceptance criteria: Given / When / Then with data examples
 - File naming and linking between user story and feature file
+- INVEST quality validation before finalization (Independent, Negotiable, Valuable, Estimable, Small, Testable)
 ]]></goal>
 
   <constraints>
@@ -30,6 +31,7 @@ Guide the agent to ask targeted questions to gather details for a user story and
       <constraint>**MUST**: Read the reference template fresh and use exact wording—do not use cached questions</constraint>
       <constraint>**MUST**: Wait for user response after each question or block before proceeding</constraint>
       <constraint>**MUST**: Repeat scenario questions for each additional scenario when user indicates more scenarios</constraint>
+      <constraint>**MUST**: Validate the final user story against INVEST and present a pass/fail checkpoint for each criterion before finalizing</constraint>
     </constraint-list>
   </constraints>
 

--- a/skills-generator/src/main/resources/system-prompts/014-agile-user-story.xml
+++ b/skills-generator/src/main/resources/system-prompts/014-agile-user-story.xml
@@ -67,6 +67,15 @@ See: [Relative path to Gherkin file]
 ## Notes
 
 [Additional notes if provided]
+
+## INVEST Validation
+
+- **Independent**: [How this story can be delivered without depending on another unfinished story]
+- **Negotiable**: [What parts can be discussed/refined while preserving intent]
+- **Valuable**: [Clear user/business value delivered by this story]
+- **Estimable**: [Why the team can estimate size/effort with current information]
+- **Small**: [Why this can fit in a single iteration]
+- **Testable**: [How acceptance checks prove completion]
 ```
 
 **Gherkin Feature File**
@@ -108,6 +117,7 @@ For multiple scenarios, add each as a separate Scenario block. Use Scenario Outl
                     <step-constraint>**MUST** ensure each scenario has Given, When, Then steps</step-constraint>
                     <step-constraint>**MUST** use docstrings or Example tables for complex data when user provided examples</step-constraint>
                     <step-constraint>**MUST** use filenames provided by the user for the generated content</step-constraint>
+                    <step-constraint>**MUST** include an INVEST validation section in the user story output with practical evidence for each criterion</step-constraint>
                 </step-constraint-list>
             </step-constraints>
         </step>
@@ -122,6 +132,12 @@ Before finalizing, verify:
 - [ ] Exactly one scenario is `@acceptance-test` (happy path); all others are `@integration-test`
 - [ ] Each scenario has Given, When, Then
 - [ ] Complex data uses docstrings or Example tables
+- [ ] Independent: story can be delivered without unresolved dependencies on another unfinished story
+- [ ] Negotiable: scope details can be refined without losing user value
+- [ ] Valuable: user/business value is explicit and concrete
+- [ ] Estimable: acceptance criteria are concrete enough for sizing
+- [ ] Small: scope is feasible for one iteration
+- [ ] Testable: completion can be objectively verified through acceptance criteria
             ]]></step-content>
         </step>
     </steps>

--- a/skills/014-agile-user-story/SKILL.md
+++ b/skills/014-agile-user-story/SKILL.md
@@ -16,6 +16,7 @@ Guide the agent to ask targeted questions to gather details for a user story and
 - Gherkin feature file: Feature name, background steps, scenarios
 - Acceptance criteria: Given / When / Then with data examples
 - File naming and linking between user story and feature file
+- INVEST quality validation before finalization (Independent, Negotiable, Valuable, Estimable, Small, Testable)
 
 ## Constraints
 
@@ -25,6 +26,7 @@ Before generating artifacts, gather all required information through structured 
 - **MUST**: Read the reference template fresh and use exact wording—do not use cached questions
 - **MUST**: Wait for user response after each question or block before proceeding
 - **MUST**: Repeat scenario questions for each additional scenario when user indicates more scenarios
+- **MUST**: Validate the final user story against INVEST and present a pass/fail checkpoint for each criterion before finalizing
 
 ## When to use this skill
 

--- a/skills/014-agile-user-story/references/014-agile-user-story.md
+++ b/skills/014-agile-user-story/references/014-agile-user-story.md
@@ -160,6 +160,15 @@ See: [Relative path to Gherkin file]
 ## Notes
 
 [Additional notes if provided]
+
+## INVEST Validation
+
+- **Independent**: [How this story can be delivered without depending on another unfinished story]
+- **Negotiable**: [What parts can be discussed/refined while preserving intent]
+- **Valuable**: [Clear user/business value delivered by this story]
+- **Estimable**: [Why the team can estimate size/effort with current information]
+- **Small**: [Why this can fit in a single iteration]
+- **Testable**: [How acceptance checks prove completion]
 ```
 
 **Gherkin Feature File**
@@ -201,6 +210,7 @@ For multiple scenarios, add each as a separate Scenario block. Use Scenario Outl
 - **MUST** ensure each scenario has Given, When, Then steps
 - **MUST** use docstrings or Example tables for complex data when user provided examples
 - **MUST** use filenames provided by the user for the generated content
+- **MUST** include an INVEST validation section in the user story output with practical evidence for each criterion
 
 ### Step 3: Output Checklist
 
@@ -212,6 +222,12 @@ Before finalizing, verify:
 - [ ] Exactly one scenario is `@acceptance-test` (happy path); all others are `@integration-test`
 - [ ] Each scenario has Given, When, Then
 - [ ] Complex data uses docstrings or Example tables
+- [ ] Independent: story can be delivered without unresolved dependencies on another unfinished story
+- [ ] Negotiable: scope details can be refined without losing user value
+- [ ] Valuable: user/business value is explicit and concrete
+- [ ] Estimable: acceptance criteria are concrete enough for sizing
+- [ ] Small: scope is feasible for one iteration
+- [ ] Testable: completion can be objectively verified through acceptance criteria
 
 ## Output Format
 


### PR DESCRIPTION
## Summary
- Add explicit INVEST guidance and validation requirements to the `014-agile-user-story` skill sources.
- Update generated skill artifacts to include INVEST criteria definitions and checklist checks.
- Archive the OpenSpec change and add the promoted `agile-user-story-quality` specification.

## Test plan
- [x] Run `./mvnw clean install -pl skills-generator`
- [x] Run `./mvnw clean verify`
- [x] Run `openspec validate --all`

Made with [Cursor](https://cursor.com)