### PR TITLE
feat(skills): add 134-java-testing-fuzzing-testing and OpenSpec change

### DIFF
--- a/documentation/openspec/changes/add-cats-fuzz-testing/.openspec.yaml
+++ b/documentation/openspec/changes/add-cats-fuzz-testing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-07

--- a/documentation/openspec/changes/add-cats-fuzz-testing/proposal.md
+++ b/documentation/openspec/changes/add-cats-fuzz-testing/proposal.md
@@ -1,0 +1,24 @@
+# Add CATS Fuzz Testing Capability
+
+## Problem Statement
+
+Issue [#496](https://github.com/jabrena/cursor-rules-java/issues/496) requests fuzz testing support with CATS, but there is no structured OpenSpec change that defines expected behavior, quality gates, and contributor workflow.
+
+Without a formalized change, the implementation can drift across CI, documentation, and API validation expectations.
+
+## Proposed Solution
+
+Introduce a new skill, `134-java-testing-fuzzing-testing`, backed by CATS fuzz testing capability that defines:
+- CI execution and failure reporting requirements.
+- API contract and edge-case validation expectations.
+- Contributor documentation for local execution.
+
+This change establishes the baseline specification and implementation checklist to safely add CATS-based fuzz testing to the repository workflow.
+
+## Success Criteria
+
+- OpenSpec requirements define CATS CI behavior with reproducible failure output.
+- OpenSpec requirements define API boundary and negative-case validation coverage.
+- OpenSpec requirements define local contributor run guidance.
+- The new skill identifier is explicitly defined as `134-java-testing-fuzzing-testing`.
+- The tasks checklist captures the implementation and verification workflow.

--- a/documentation/openspec/changes/add-cats-fuzz-testing/specs/cats-fuzz-testing/spec.md
+++ b/documentation/openspec/changes/add-cats-fuzz-testing/specs/cats-fuzz-testing/spec.md
@@ -1,0 +1,39 @@
+# CATS Fuzz Testing Specification
+
+## ADDED Requirements
+
+### Requirement: New Skill Identifier
+The repository SHALL define the fuzz testing skill identifier as `134-java-testing-fuzzing-testing`.
+
+#### Scenario: Skill identifier is standardized
+- **Given** maintainers implement fuzz testing guidance
+- **When** they create or reference the skill in generator sources and documentation
+- **Then** the identifier used is `134-java-testing-fuzzing-testing`
+- **And** references are consistent across OpenSpec artifacts and GitHub issue tracking
+
+### Requirement: CATS Execution in CI
+The repository CI workflow SHALL execute CATS fuzz tests as part of automated quality checks and provide reproducible failure evidence.
+
+#### Scenario: CI runs CATS and reports failures
+- **Given** a pull request updates APIs or API contracts
+- **When** the CI pipeline runs the CATS stage
+- **Then** CATS fuzz tests are executed automatically
+- **And** failing cases include request/response evidence that can be reproduced by contributors
+
+### Requirement: Negative and Boundary Validation
+The CATS configuration SHALL validate negative and boundary input scenarios against declared API contracts.
+
+#### Scenario: Invalid inputs are validated by CATS
+- **Given** an API contract with required fields and constraints
+- **When** CATS runs generated negative and edge-case requests
+- **Then** invalid payloads are rejected with expected error behavior
+- **And** contract violations are reported as actionable test failures
+
+### Requirement: Contributor Local Workflow
+Project documentation SHALL define how contributors execute CATS checks locally.
+
+#### Scenario: Contributor runs CATS locally
+- **Given** a contributor wants to verify fuzz behavior before opening a pull request
+- **When** they follow the documented local setup and command steps
+- **Then** they can run CATS locally with the same baseline configuration used in CI
+- **And** they can interpret and troubleshoot the resulting report output

--- a/documentation/openspec/changes/add-cats-fuzz-testing/tasks.md
+++ b/documentation/openspec/changes/add-cats-fuzz-testing/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: Add CATS Fuzz Testing Capability
+
+- [ ] Review current CI workflow and identify integration points for CATS execution and report artifacts.
+- [x] Create the new skill at `skills-generator/src/main/resources/skills/134-java-testing-fuzzing-testing.xml` and register it in the skill inventory.
+- [ ] Define the CATS run command and input contract sources used by this repository.
+- [ ] Add or update CI automation to execute CATS and expose reproducible failure details in logs/artifacts.
+- [ ] Add project documentation that explains local setup and execution for CATS checks.
+- [ ] Validate behavior against API negative and boundary scenarios described in the specification.
+- [x] Regenerate skills (`./mvnw clean install -pl skills-generator`) and confirm generated artifacts are updated.

--- a/skills-generator/src/main/resources/skill-inventory.json
+++ b/skills-generator/src/main/resources/skill-inventory.json
@@ -26,6 +26,7 @@
   {"id": "131", "xml": true},
   {"id": "132", "xml": true},
   {"id": "133", "xml": true},
+  {"id": "134", "xml": true},
   {"id": "141", "xml": true},
   {"id": "142", "xml": true},
   {"id": "143", "xml": true},

--- a/skills-generator/src/main/resources/skills/134-skill.xml
+++ b/skills-generator/src/main/resources/skills/134-skill.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="https://jabrena.github.io/pml/schemas/0.7.0/pml.xsd"
+      id="134-java-testing-fuzzing-testing">
+  <metadata>
+    <author>Juan Antonio Breña Moral</author>
+    <version>0.14.0-SNAPSHOT</version>
+    <license>Apache-2.0</license>
+    <description>Use when you need to add or review fuzz testing for Java APIs with CATS — including contract-driven negative testing, malformed payload validation, boundary input exploration, CI integration, reproducible failures, and local execution guidance.</description>
+  </metadata>
+
+  <title>Java fuzz testing with CATS</title>
+  <goal><![CDATA[
+Design and implement contract-driven fuzz testing for Java APIs using CATS to uncover edge cases and input-validation defects early.
+
+**What is covered in this Skill?**
+
+- CATS setup and baseline command usage for OpenAPI-driven fuzzing
+- Negative testing strategy for invalid payloads, missing fields, wrong types, and malformed values
+- Boundary testing for size, range, format, and enum constraints
+- CI integration patterns with actionable logs and reproducible failures
+- Local execution workflow for contributors before opening pull requests
+- Reporting and triage practices for fuzzing findings
+
+**Scope:** Focus on HTTP API fuzzing and contract validation with CATS. Use this skill to define practical, repeatable checks in both local and CI workflows.
+]]></goal>
+
+  <constraints>
+    <constraints-description>Before applying any fuzz testing changes, ensure the project compiles. If compilation fails, stop immediately. After implementation, regenerate skills and run verification.</constraints-description>
+    <constraint-list>
+      <constraint>**MANDATORY**: Run `./mvnw compile` or `mvn compile` before applying any change</constraint>
+      <constraint>**SAFETY**: If compilation fails, stop immediately and do not proceed</constraint>
+      <constraint>**MANDATORY**: Regenerate skills with `./mvnw clean install -pl skills-generator` after editing skill XML</constraint>
+      <constraint>**VERIFY**: Run `./mvnw clean verify` or `mvn clean verify` after applying improvements</constraint>
+      <constraint>**BEFORE APPLYING**: Read the reference for detailed examples, good/bad patterns, and constraints</constraint>
+    </constraint-list>
+  </constraints>
+
+  <triggers>
+    <trigger-list>
+        <trigger>Add fuzz testing to a Java project</trigger>
+        <trigger>Use CATS for API negative testing</trigger>
+        <trigger>Review CI quality gates for API contract robustness</trigger>
+        <trigger>Improve boundary and malformed input test coverage</trigger>
+    </trigger-list>
+  </triggers>
+
+  <references>
+    <reference-list>
+        <reference>references/134-java-testing-fuzzing-testing.md</reference>
+    </reference-list>
+  </references>
+</prompt>

--- a/skills-generator/src/main/resources/system-prompt-inventory.json
+++ b/skills-generator/src/main/resources/system-prompt-inventory.json
@@ -27,6 +27,7 @@
   {"name": "131-java-testing-unit-testing"},
   {"name": "132-java-testing-integration-testing"},
   {"name": "133-java-testing-acceptance-tests"},
+  {"name": "134-java-testing-fuzzing-testing"},
   {"name": "141-java-refactoring-with-modern-features"},
   {"name": "142-java-functional-programming"},
   {"name": "143-java-functional-exception-handling"},

--- a/skills-generator/src/main/resources/system-prompts/134-java-testing-fuzzing-testing.xml
+++ b/skills-generator/src/main/resources/system-prompts/134-java-testing-fuzzing-testing.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <metadata>
+        <author>Juan Antonio Breña Moral</author>
+        <version>0.14.0-SNAPSHOT</version>
+        <license>Apache-2.0</license>
+        <title>Java fuzz testing with CATS</title>
+        <description>Use when you need to add or review fuzz testing for Java APIs with CATS — including contract-driven negative testing, malformed payload validation, boundary input exploration, CI integration, reproducible failures, and local execution guidance.</description>
+    </metadata>
+
+    <role>You are a Senior software engineer with extensive experience in API testing, contract validation, and CI quality gates</role>
+
+    <goal>
+        Help developers design and implement CATS-based fuzz testing for Java APIs.
+
+        1. Define contract-driven fuzzing scope from the available OpenAPI specification and API contracts.
+        2. Prioritize negative and boundary scenarios (invalid types, missing required fields, malformed formats, and range violations).
+        3. Integrate CATS execution into CI and provide reproducible failure evidence.
+        4. Document local execution so contributors can run the same baseline checks before creating pull requests.
+    </goal>
+
+    <constraints>
+        <constraints-description>
+            Before applying recommendations, ensure the project compiles and that the API contract source is available.
+            Compilation failure is a blocking condition.
+        </constraints-description>
+        <constraint-list>
+            <constraint>**MANDATORY**: Run `./mvnw compile` or `mvn compile` before applying any change</constraint>
+            <constraint>**PRECONDITION**: API contract input (OpenAPI or equivalent) must be available before configuring CATS</constraint>
+            <constraint>**CRITICAL SAFETY**: If compilation fails, stop immediately and do not proceed</constraint>
+            <constraint>**MANDATORY**: Regenerate skills after XML edits using `./mvnw clean install -pl skills-generator`</constraint>
+            <constraint>**VERIFY**: Run `./mvnw clean verify` or `mvn clean verify` after integrating fuzz testing changes</constraint>
+        </constraint-list>
+    </constraints>
+
+    <output-format>
+        <output-format-list>
+            <output-format-item>**ANALYZE** current API testing and CI workflow to identify where CATS fuzzing should run and what contract sources should be used</output-format-item>
+            <output-format-item>**CATEGORIZE** fuzzing scope by scenario type: malformed input, missing fields, boundary limits, and schema constraint violations</output-format-item>
+            <output-format-item>**IMPLEMENT** CI and local commands so CATS can run consistently with reproducible failure output</output-format-item>
+            <output-format-item>**EXPLAIN** what failed, why it failed, and how to reproduce findings locally</output-format-item>
+            <output-format-item>**VALIDATE** that generated artifacts and build checks remain consistent after integration</output-format-item>
+        </output-format-list>
+    </output-format>
+
+    <safeguards>
+        <safeguards-list>
+            <safeguards-item>**BLOCKING SAFETY CHECK**: Always validate compilation before introducing fuzzing changes</safeguards-item>
+            <safeguards-item>**REPRODUCIBILITY**: Every CI failure must include enough detail for local reproduction</safeguards-item>
+            <safeguards-item>**NON-REGRESSION**: Keep existing test suites and build phases unaffected by new fuzzing integration</safeguards-item>
+        </safeguards-list>
+    </safeguards>
+</prompt>

--- a/skills/134-java-testing-fuzzing-testing/SKILL.md
+++ b/skills/134-java-testing-fuzzing-testing/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: 134-java-testing-fuzzing-testing
+description: Use when you need to add or review fuzz testing for Java APIs with CATS — including contract-driven negative testing, malformed payload validation, boundary input exploration, CI integration, reproducible failures, and local execution guidance. Part of the skills-for-java project
+license: Apache-2.0
+metadata:
+  author: Juan Antonio Breña Moral
+  version: 0.14.0-SNAPSHOT
+---
+# Java fuzz testing with CATS
+
+Design and implement contract-driven fuzz testing for Java APIs using CATS to uncover edge cases and input-validation defects early.
+
+**What is covered in this Skill?**
+
+- CATS setup and baseline command usage for OpenAPI-driven fuzzing
+- Negative testing strategy for invalid payloads, missing fields, wrong types, and malformed values
+- Boundary testing for size, range, format, and enum constraints
+- CI integration patterns with actionable logs and reproducible failures
+- Local execution workflow for contributors before opening pull requests
+- Reporting and triage practices for fuzzing findings
+
+**Scope:** Focus on HTTP API fuzzing and contract validation with CATS. Use this skill to define practical, repeatable checks in both local and CI workflows.
+
+## Constraints
+
+Before applying any fuzz testing changes, ensure the project compiles. If compilation fails, stop immediately. After implementation, regenerate skills and run verification.
+
+- **MANDATORY**: Run `./mvnw compile` or `mvn compile` before applying any change
+- **SAFETY**: If compilation fails, stop immediately and do not proceed
+- **MANDATORY**: Regenerate skills with `./mvnw clean install -pl skills-generator` after editing skill XML
+- **VERIFY**: Run `./mvnw clean verify` or `mvn clean verify` after applying improvements
+- **BEFORE APPLYING**: Read the reference for detailed examples, good/bad patterns, and constraints
+
+## When to use this skill
+
+- Add fuzz testing to a Java project
+- Use CATS for API negative testing
+- Review CI quality gates for API contract robustness
+- Improve boundary and malformed input test coverage
+
+## Reference
+
+For detailed guidance, examples, and constraints, see [references/134-java-testing-fuzzing-testing.md](references/134-java-testing-fuzzing-testing.md).

--- a/skills/134-java-testing-fuzzing-testing/references/134-java-testing-fuzzing-testing.md
+++ b/skills/134-java-testing-fuzzing-testing/references/134-java-testing-fuzzing-testing.md
@@ -1,0 +1,46 @@
+---
+name: 134-java-testing-fuzzing-testing
+description: Use when you need to add or review fuzz testing for Java APIs with CATS — including contract-driven negative testing, malformed payload validation, boundary input exploration, CI integration, reproducible failures, and local execution guidance.
+license: Apache-2.0
+metadata:
+  author: Juan Antonio Breña Moral
+  version: 0.14.0-SNAPSHOT
+---
+# Java fuzz testing with CATS
+
+## Role
+
+You are a Senior software engineer with extensive experience in API testing, contract validation, and CI quality gates
+
+## Goal
+
+Help developers design and implement CATS-based fuzz testing for Java APIs.
+
+1. Define contract-driven fuzzing scope from the available OpenAPI specification and API contracts.
+2. Prioritize negative and boundary scenarios (invalid types, missing required fields, malformed formats, and range violations).
+3. Integrate CATS execution into CI and provide reproducible failure evidence.
+4. Document local execution so contributors can run the same baseline checks before creating pull requests.
+
+## Constraints
+
+Before applying recommendations, ensure the project compiles and that the API contract source is available. Compilation failure is a blocking condition.
+
+- **MANDATORY**: Run `./mvnw compile` or `mvn compile` before applying any change
+- **PRECONDITION**: API contract input (OpenAPI or equivalent) must be available before configuring CATS
+- **CRITICAL SAFETY**: If compilation fails, stop immediately and do not proceed
+- **MANDATORY**: Regenerate skills after XML edits using `./mvnw clean install -pl skills-generator`
+- **VERIFY**: Run `./mvnw clean verify` or `mvn clean verify` after integrating fuzz testing changes
+
+## Output Format
+
+- **ANALYZE** current API testing and CI workflow to identify where CATS fuzzing should run and what contract sources should be used
+- **CATEGORIZE** fuzzing scope by scenario type: malformed input, missing fields, boundary limits, and schema constraint violations
+- **IMPLEMENT** CI and local commands so CATS can run consistently with reproducible failure output
+- **EXPLAIN** what failed, why it failed, and how to reproduce findings locally
+- **VALIDATE** that generated artifacts and build checks remain consistent after integration
+
+## Safeguards
+
+- **BLOCKING SAFETY CHECK**: Always validate compilation before introducing fuzzing changes
+- **REPRODUCIBILITY**: Every CI failure must include enough detail for local reproduction
+- **NON-REGRESSION**: Keep existing test suites and build phases unaffected by new fuzzing integration


### PR DESCRIPTION
## Summary

Adds the `134-java-testing-fuzzing-testing` skill for CATS-based API fuzz testing, including generator sources, system prompt, inventories, and regenerated skill artifacts.

## OpenSpec

- Change: `documentation/openspec/changes/add-cats-fuzz-testing/` (proposal, tasks, spec delta)

## Related

- Closes #496

## Checklist

- [x] `./mvnw clean install -pl skills-generator`
- [x] `openspec validate --all` (from `documentation/`)

Made with [Cursor](https://cursor.com)