### PR TITLE
feat(skills): add 702-technologies-wiremock

### DIFF
--- a/documentation/openspec/changes/archive/2026-04-07-add-702-technologies-wiremock/.openspec.yaml
+++ b/documentation/openspec/changes/archive/2026-04-07-add-702-technologies-wiremock/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-07

--- a/documentation/openspec/changes/archive/2026-04-07-add-702-technologies-wiremock/proposal.md
+++ b/documentation/openspec/changes/archive/2026-04-07-add-702-technologies-wiremock/proposal.md
@@ -1,0 +1,25 @@
+# Add 702 Technologies — WireMock Best Practices
+
+## Problem Statement
+
+Issue [#544](https://github.com/jabrena/cursor-rules-java/issues/544) requests WireMock best-practices support. Today, WireMock guidance is embedded primarily in integration-test–oriented skills (`132`, `322`, `422`, `522`). There is no **framework-agnostic** skill under the **technologies** band (`700`–`799`) for HTTP stubbing, mapping lifecycle, and verification patterns, so agents lack a single trigger for portable WireMock work without choosing Spring Boot, Quarkus, or Micronaut first.
+
+Without a structured OpenSpec change, numbering (`702`), scope boundaries, and verification expectations can drift.
+
+## Proposed Solution
+
+Introduce **`702-technologies-wiremock`**: a PML system prompt and matching agent skill that cover **WireMock** as the artifact (stub design, request matching, response fixtures, isolation, lifecycle, verification, common pitfalls), explicitly **deferring** framework-specific test bootstrap and extension wiring to `132` / `322` / `422` / `522`.
+
+Reserve **`702`** for cross-cutting **WireMock** guidance alongside **`701`** for OpenAPI (`701-technologies-openapi`), and register the new id in both generator inventories.
+
+## Impact Assessment
+
+- **Breaking changes:** None for consumers of existing skills; this is additive.
+- **Cross-tool compatibility:** Generated skills output only; no change to legacy Cursor rule paths unless the project later wires them.
+- **Migration:** None required. Contributors implementing stubs in tests may prefer **702** for WireMock patterns and framework integration skills for full-stack test setup.
+
+## Success Criteria
+
+- OpenSpec requirements fix the skill id as **`702-technologies-wiremock`** and describe framework-agnostic vs framework-delegation behavior.
+- Tasks checklist covers XML sources, inventory registration, build verification.
+- `openspec validate --all` passes for this change.

--- a/documentation/openspec/changes/archive/2026-04-07-add-702-technologies-wiremock/specs/technologies-wiremock/spec.md
+++ b/documentation/openspec/changes/archive/2026-04-07-add-702-technologies-wiremock/specs/technologies-wiremock/spec.md
@@ -1,0 +1,47 @@
+# Technologies — WireMock Specification
+
+## ADDED Requirements
+
+### Requirement: Skill Identifier
+
+The repository SHALL define the framework-agnostic WireMock guidance skill identifier as `702-technologies-wiremock`.
+
+#### Scenario: Skill identifier is standardized
+
+- **Given** maintainers implement WireMock best-practices guidance in generator sources
+- **When** they create or reference the skill in XML, inventories, or documentation
+- **Then** the identifier used is `702-technologies-wiremock`
+- **And** references are consistent across OpenSpec artifacts and GitHub issue [#544](https://github.com/jabrena/cursor-rules-java/issues/544)
+
+### Requirement: Framework-Agnostic Scope
+
+The `702-technologies-wiremock` system prompt and skill SHALL focus on WireMock topics that apply regardless of Java HTTP framework or test bootstrap.
+
+#### Scenario: Guidance does not require a framework choice
+
+- **Given** a user asks for WireMock best practices without naming Spring Boot, Quarkus, or Micronaut
+- **When** the agent applies `702-technologies-wiremock`
+- **Then** recommendations address portable stubbing concerns (for example isolation, mapping structure, matching rules, response bodies, lifecycle, verification, and test flakiness avoidance)
+- **And** framework-specific test integration (for example `@SpringBootTest`, `@QuarkusTest`, `@MicronautTest`, extension-specific setup) is deferred to `@132-java-testing-integration-testing`, `@322-frameworks-spring-boot-testing-integration-tests`, `@422-frameworks-quarkus-testing-integration-tests`, or `@522-frameworks-micronaut-testing-integration-tests` where relevant
+
+### Requirement: Complement Existing Integration-Test Skills
+
+The new skill SHALL complement, not replace, framework integration-test skills: those skills MAY continue to document WireMock in their stack context; **702** SHALL emphasize **cross-stack** WireMock practices shared across tests.
+
+#### Scenario: Clear separation from OpenAPI technology skill
+
+- **Given** a contributor searches for HTTP contract or stubbing guidance
+- **When** they compare skill descriptions and triggers
+- **Then** `702-technologies-wiremock` is distinct from `701-technologies-openapi` (stub server behavior vs OpenAPI contract artifact design)
+- **And** inventory entries describe non-overlapping primary use cases
+
+### Requirement: Generator Integration
+
+New sources for **702** MUST be registered in both `skill-inventory.json` and `system-prompt-inventory.json`, and the `skills-generator` module MUST build successfully after the change.
+
+#### Scenario: Maven verify passes
+
+- **Given** the XML sources and inventory entries for **702** are added
+- **When** a maintainer runs `./mvnw clean verify -pl skills-generator`
+- **Then** the build completes without failure
+- **And** regenerated skill output reflects the new id where the pipeline emits skills

--- a/documentation/openspec/changes/archive/2026-04-07-add-702-technologies-wiremock/tasks.md
+++ b/documentation/openspec/changes/archive/2026-04-07-add-702-technologies-wiremock/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: Add 702 Technologies — WireMock Best Practices
+
+- [x] Add `skills-generator/src/main/resources/system-prompts/702-technologies-wiremock.xml` following PML schema and repository conventions for system prompts.
+- [x] Add `skills-generator/src/main/resources/skills/702-skill.xml` with `id="702-technologies-wiremock"` aligned to the system prompt scope and triggers.
+- [x] Register skill id `702` in `skills-generator/src/main/resources/skill-inventory.json` and `skills-generator/src/main/resources/system-prompt-inventory.json`.
+- [x] Run `./mvnw clean verify -pl skills-generator` and `./mvnw clean install -pl skills-generator`; confirm generated `skills/` artifacts include the new skill where applicable.
+- [x] Run `npx skill-check skills` if generated skills are updated in the working tree.

--- a/documentation/openspec/specs/technologies-wiremock/spec.md
+++ b/documentation/openspec/specs/technologies-wiremock/spec.md
@@ -1,0 +1,51 @@
+# technologies-wiremock Specification
+
+## Purpose
+
+Define requirements for **`702-technologies-wiremock`**: framework-agnostic WireMock guidance in `skills-generator`, distinct from framework integration-test skills (`322` / `422` / `522`), from framework-agnostic integration testing with WireMock (`132`), and from OpenAPI contract design (`701`).
+
+## Requirements
+### Requirement: Skill Identifier
+
+The repository SHALL define the framework-agnostic WireMock guidance skill identifier as `702-technologies-wiremock`.
+
+#### Scenario: Skill identifier is standardized
+
+- **Given** maintainers implement WireMock best-practices guidance in generator sources
+- **When** they create or reference the skill in XML, inventories, or documentation
+- **Then** the identifier used is `702-technologies-wiremock`
+- **And** references are consistent across OpenSpec artifacts and GitHub issue [#544](https://github.com/jabrena/cursor-rules-java/issues/544)
+
+### Requirement: Framework-Agnostic Scope
+
+The `702-technologies-wiremock` system prompt and skill SHALL focus on WireMock topics that apply regardless of Java HTTP framework or test bootstrap.
+
+#### Scenario: Guidance does not require a framework choice
+
+- **Given** a user asks for WireMock best practices without naming Spring Boot, Quarkus, or Micronaut
+- **When** the agent applies `702-technologies-wiremock`
+- **Then** recommendations address portable stubbing concerns (for example isolation, mapping structure, matching rules, response bodies, lifecycle, verification, and test flakiness avoidance)
+- **And** framework-specific test integration (for example `@SpringBootTest`, `@QuarkusTest`, `@MicronautTest`, extension-specific setup) is deferred to `@132-java-testing-integration-testing`, `@322-frameworks-spring-boot-testing-integration-tests`, `@422-frameworks-quarkus-testing-integration-tests`, or `@522-frameworks-micronaut-testing-integration-tests` where relevant
+
+### Requirement: Complement Existing Integration-Test Skills
+
+The new skill SHALL complement, not replace, framework integration-test skills: those skills MAY continue to document WireMock in their stack context; **702** SHALL emphasize **cross-stack** WireMock practices shared across tests.
+
+#### Scenario: Clear separation from OpenAPI technology skill
+
+- **Given** a contributor searches for HTTP contract or stubbing guidance
+- **When** they compare skill descriptions and triggers
+- **Then** `702-technologies-wiremock` is distinct from `701-technologies-openapi` (stub server behavior vs OpenAPI contract artifact design)
+- **And** inventory entries describe non-overlapping primary use cases
+
+### Requirement: Generator Integration
+
+New sources for **702** MUST be registered in both `skill-inventory.json` and `system-prompt-inventory.json`, and the `skills-generator` module MUST build successfully after the change.
+
+#### Scenario: Maven verify passes
+
+- **Given** the XML sources and inventory entries for **702** are added
+- **When** a maintainer runs `./mvnw clean verify -pl skills-generator`
+- **Then** the build completes without failure
+- **And** regenerated skill output reflects the new id where the pipeline emits skills
+

--- a/skills-generator/src/main/resources/skill-inventory.json
+++ b/skills-generator/src/main/resources/skill-inventory.json
@@ -62,5 +62,6 @@
   {"id": "521", "xml": true},
   {"id": "522", "xml": true},
   {"id": "523", "xml": true},
-  {"id": "701", "xml": true}
+  {"id": "701", "xml": true},
+  {"id": "702", "xml": true}
 ]

--- a/skills-generator/src/main/resources/skills/702-skill.xml
+++ b/skills-generator/src/main/resources/skills/702-skill.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="https://jabrena.github.io/pml/schemas/0.7.0/pml.xsd"
+      id="702-technologies-wiremock">
+  <metadata>
+    <author>Juan Antonio Breña Moral</author>
+    <version>0.14.0-SNAPSHOT</version>
+    <license>Apache-2.0</license>
+    <description>Use when you need framework-agnostic WireMock guidance — stub design, JSON or programmatic mappings, precise request matching, response bodies and faults, classpath fixtures, isolation and reset between tests, verification of calls, dynamic ports and base URLs, and avoiding flaky stubs — without choosing Spring Boot, Quarkus, or Micronaut.</description>
+  </metadata>
+
+  <title>WireMock best practices</title>
+  <goal><![CDATA[
+Help teams use **WireMock** effectively for HTTP dependency stubbing with **stable, isolated** tests.
+
+**What is covered in this Skill?**
+
+- Stub **isolation**: per-test registration, `resetAll()`, avoiding leaked global stubs
+- **Request matching**: method, path, headers, query, body patterns; when broad patterns are acceptable
+- **Responses**: status, headers, JSON/XML bodies, `bodyFileName` / classpath fixtures, fault simulation (delays, errors)
+- **Dynamic ports** and propagating base URLs into the system under test
+- **Verification** of outbound HTTP calls and debugging unmatched requests
+- Clear **delegation** to framework integration-test skills for test class layout and extensions
+
+**Scope:** Portable WireMock behavior only. For **`BaseIntegrationTest`**, `WireMockExtension`, and stack-specific integration tests, use `@132-java-testing-integration-testing`, `@322-frameworks-spring-boot-testing-integration-tests`, `@422-frameworks-quarkus-testing-integration-tests`, or `@522-frameworks-micronaut-testing-integration-tests`. For **OpenAPI** contract quality, use `@701-technologies-openapi`.
+]]></goal>
+
+  <constraints>
+    <constraints-description>Keep recommendations at the WireMock and HTTP-stub layer unless the user explicitly asks for framework integration. After editing this repository's XML sources, regenerate skills and verify the build.</constraints-description>
+    <constraint-list>
+      <constraint>**MANDATORY**: Run `./mvnw compile` or `mvn compile` before proposing Java or Maven changes in the same change set</constraint>
+      <constraint>**FRAMEWORK**: Defer `@SpringBootTest` / `@QuarkusTest` / `@MicronautTest` and extension setup to `@132-java-testing-integration-testing` or the matching `322` / `422` / `522` integration-test skill</constraint>
+      <constraint>**CONTRACTS**: Defer OpenAPI document structure and linting to `@701-technologies-openapi`</constraint>
+      <constraint>**MANDATORY**: Regenerate skills with `./mvnw clean install -pl skills-generator` after editing skill or system-prompt XML in this repo</constraint>
+      <constraint>**VERIFY**: Run `./mvnw clean verify` or `mvn clean verify` before promoting changes</constraint>
+    </constraint-list>
+  </constraints>
+
+  <triggers>
+    <trigger-list>
+        <trigger>Design or review WireMock stubs (JSON mappings or Java DSL)</trigger>
+        <trigger>Improve request matching, isolation, or reset strategy for HTTP mocks</trigger>
+        <trigger>Add or fix verification of outbound HTTP calls to a WireMock server</trigger>
+        <trigger>Debug flaky tests involving WireMock or unmatched request journals</trigger>
+        <trigger>Stub external HTTP APIs in tests with stable fixtures and dynamic ports</trigger>
+    </trigger-list>
+  </triggers>
+
+  <references>
+    <reference-list>
+        <reference>references/702-technologies-wiremock.md</reference>
+    </reference-list>
+  </references>
+</prompt>

--- a/skills-generator/src/main/resources/system-prompt-inventory.json
+++ b/skills-generator/src/main/resources/system-prompt-inventory.json
@@ -64,6 +64,7 @@
   {"name": "522-frameworks-micronaut-testing-integration-tests"},
   {"name": "523-frameworks-micronaut-testing-acceptance-tests"},
   {"name": "701-technologies-openapi"},
+  {"name": "702-technologies-wiremock"},
   {"name": "behaviour-consultative-interaction"},
   {"name": "behaviour-progressive-learning"},
   {"name": "behaviour-article-writer"}

--- a/skills-generator/src/main/resources/system-prompts/702-technologies-wiremock.xml
+++ b/skills-generator/src/main/resources/system-prompts/702-technologies-wiremock.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <metadata>
+        <author>Juan Antonio Breña Moral</author>
+        <version>0.14.0-SNAPSHOT</version>
+        <license>Apache-2.0</license>
+        <title>WireMock best practices</title>
+        <description>Use when you need framework-agnostic WireMock guidance — stub design, JSON or programmatic mappings, precise request matching, response bodies and faults, classpath fixtures, isolation and reset between tests, verification of calls, dynamic ports and base URLs, and avoiding flaky stubs — without choosing Spring Boot, Quarkus, or Micronaut.</description>
+    </metadata>
+
+    <role>You are a senior test engineer with deep experience in HTTP service virtualization, WireMock, and integration testing in Java ecosystems</role>
+
+    <goal>
+        Apply **framework-agnostic** WireMock best practices so tests stay deterministic, isolated, and easy to reason about.
+
+        1. **Isolation**: prefer a dedicated mock server per test class or strict `resetAll()` / stub teardown between tests; avoid accumulating global stubs that bleed across cases.
+        2. **Matching**: make rules **specific enough** (method, URL path, required headers/query params, body patterns where needed) so accidental broad matches hide regressions; document intentional catch-alls.
+        3. **Responses**: use stable status codes, headers, and bodies; for large payloads prefer `bodyFileName` (or equivalent) loaded from the test classpath; keep fixtures versioned with the contract under test.
+        4. **Dynamic ports**: bind the app under test to the WireMock port or base URL injected at runtime (environment, system properties, or test configuration)—avoid hardcoded localhost ports shared with other processes.
+        5. **Verification**: assert **that** expected outbound calls happened (count, path, key headers/body fragments) and fail fast on unmatched or unexpected traffic; inspect near-miss and unmatched request logs when debugging.
+        6. **Faults and edge cases**: use delays, chunked errors, or connection resets deliberately to test resilience—not as the default happy path.
+        7. **Delegation**: for **Java integration test class layout**, `WireMockExtension`, `@SpringBootTest` / `@QuarkusTest` / `@MicronautTest` wiring, and project-specific `BaseIntegrationTest` patterns, direct users to `@132-java-testing-integration-testing`, `@322-frameworks-spring-boot-testing-integration-tests`, `@422-frameworks-quarkus-testing-integration-tests`, or `@522-frameworks-micronaut-testing-integration-tests`. For **OpenAPI contract design**, use `@701-technologies-openapi`.
+
+        Do not replace those skills; **702** focuses on portable WireMock behavior and stub quality.
+    </goal>
+
+    <constraints>
+        <constraints-description>
+            Before recommending structural or build changes, ensure the workspace builds. Compilation failure is a blocking condition for Java-side edits.
+        </constraints-description>
+        <constraint-list>
+            <constraint>**MANDATORY**: Run `./mvnw compile` or `mvn compile` before changing Java or build descriptors alongside stubbing strategy</constraint>
+            <constraint>**SCOPE**: Stay within WireMock usage patterns and HTTP stub design; defer framework test bootstrap to 132/322/422/522</constraint>
+            <constraint>**MANDATORY**: After editing generator XML, run `./mvnw clean install -pl skills-generator` and `./mvnw clean verify` as appropriate</constraint>
+        </constraint-list>
+    </constraints>
+
+    <examples>
+        <toc auto-generate="true" />
+
+        <example number="1" id="stub-isolation">
+            <example-header>
+                <example-title>Per-test stubs and reset</example-title>
+                <example-subtitle>avoid leaked state across examples</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Register stubs in the narrowest scope (per test method or a fresh rule set) or reset WireMock between tests. Leaked stubs cause **order-dependent** failures and masked assertions.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="text"><![CDATA[
+                // Conceptual: register stubs inside each test OR reset before each test
+                // - Before each test: reset all stubs and request journal
+                // - Register only what this scenario needs
+                ]]></code-block>
+                </good-example>
+                <bad-example>
+                    <code-block language="text"><![CDATA[
+                // Anti-pattern: @BeforeAll registers many stubs shared by all tests
+                // without reset — later tests depend on accidental overlap
+                ]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="2" id="matching-and-verification">
+            <example-header>
+                <example-title>Precise matching and verify</example-title>
+                <example-subtitle>catch missing or wrong outbound calls</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Pair **specific** `urlPath`, HTTP method, and required headers with **verify** (or journal checks) so the test proves the collaboration you care about. Overly broad `urlMatching` can let tests pass when the client never called the dependency correctly.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="json"><![CDATA[{
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/v1/orders/550e8400-e29b-41d4-a716-446655440000",
+    "headers": { "Accept": { "equalTo": "application/json" } }
+  },
+  "response": {
+    "status": 200,
+    "headers": { "Content-Type": "application/json" },
+    "jsonBody": { "id": "550e8400-e29b-41d4-a716-446655440000", "status": "OPEN" }
+  }
+}]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="json"><![CDATA[{
+  "request": {
+    "method": "GET",
+    "urlPattern": ".*"
+  },
+  "response": { "status": 200, "body": "{}" }
+}]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+    </examples>
+
+    <output-format>
+        <output-format-list>
+            <output-format-item>**REVIEW** stub definitions for isolation, specificity, and maintainability</output-format-item>
+            <output-format-item>**LIST** risks: flaky ordering, accidental broad match, missing verification, hardcoded ports</output-format-item>
+            <output-format-item>**PROPOSE** concrete mapping snippets or DSL patterns that fix the issue</output-format-item>
+            <output-format-item>**POINT** to the right integration-test skill when the user needs framework wiring or base test classes</output-format-item>
+        </output-format-list>
+    </output-format>
+</prompt>

--- a/skills/702-technologies-wiremock/SKILL.md
+++ b/skills/702-technologies-wiremock/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: 702-technologies-wiremock
+description: Use when you need framework-agnostic WireMock guidance — stub design, JSON or programmatic mappings, precise request matching, response bodies and faults, classpath fixtures, isolation and reset between tests, verification of calls, dynamic ports and base URLs, and avoiding flaky stubs — without choosing Spring Boot, Quarkus, or Micronaut. Part of the skills-for-java project
+license: Apache-2.0
+metadata:
+  author: Juan Antonio Breña Moral
+  version: 0.14.0-SNAPSHOT
+---
+# WireMock best practices
+
+Help teams use **WireMock** effectively for HTTP dependency stubbing with **stable, isolated** tests.
+
+**What is covered in this Skill?**
+
+- Stub **isolation**: per-test registration, `resetAll()`, avoiding leaked global stubs
+- **Request matching**: method, path, headers, query, body patterns; when broad patterns are acceptable
+- **Responses**: status, headers, JSON/XML bodies, `bodyFileName` / classpath fixtures, fault simulation (delays, errors)
+- **Dynamic ports** and propagating base URLs into the system under test
+- **Verification** of outbound HTTP calls and debugging unmatched requests
+- Clear **delegation** to framework integration-test skills for test class layout and extensions
+
+**Scope:** Portable WireMock behavior only. For **`BaseIntegrationTest`**, `WireMockExtension`, and stack-specific integration tests, use `@132-java-testing-integration-testing`, `@322-frameworks-spring-boot-testing-integration-tests`, `@422-frameworks-quarkus-testing-integration-tests`, or `@522-frameworks-micronaut-testing-integration-tests`. For **OpenAPI** contract quality, use `@701-technologies-openapi`.
+
+## Constraints
+
+Keep recommendations at the WireMock and HTTP-stub layer unless the user explicitly asks for framework integration. After editing this repository's XML sources, regenerate skills and verify the build.
+
+- **MANDATORY**: Run `./mvnw compile` or `mvn compile` before proposing Java or Maven changes in the same change set
+- **FRAMEWORK**: Defer `@SpringBootTest` / `@QuarkusTest` / `@MicronautTest` and extension setup to `@132-java-testing-integration-testing` or the matching `322` / `422` / `522` integration-test skill
+- **CONTRACTS**: Defer OpenAPI document structure and linting to `@701-technologies-openapi`
+- **MANDATORY**: Regenerate skills with `./mvnw clean install -pl skills-generator` after editing skill or system-prompt XML in this repo
+- **VERIFY**: Run `./mvnw clean verify` or `mvn clean verify` before promoting changes
+
+## When to use this skill
+
+- Design or review WireMock stubs (JSON mappings or Java DSL)
+- Improve request matching, isolation, or reset strategy for HTTP mocks
+- Add or fix verification of outbound HTTP calls to a WireMock server
+- Debug flaky tests involving WireMock or unmatched request journals
+- Stub external HTTP APIs in tests with stable fixtures and dynamic ports
+
+## Reference
+
+For detailed guidance, examples, and constraints, see [references/702-technologies-wiremock.md](references/702-technologies-wiremock.md).

--- a/skills/702-technologies-wiremock/references/702-technologies-wiremock.md
+++ b/skills/702-technologies-wiremock/references/702-technologies-wiremock.md
@@ -1,0 +1,105 @@
+---
+name: 702-technologies-wiremock
+description: Use when you need framework-agnostic WireMock guidance — stub design, JSON or programmatic mappings, precise request matching, response bodies and faults, classpath fixtures, isolation and reset between tests, verification of calls, dynamic ports and base URLs, and avoiding flaky stubs — without choosing Spring Boot, Quarkus, or Micronaut.
+license: Apache-2.0
+metadata:
+  author: Juan Antonio Breña Moral
+  version: 0.14.0-SNAPSHOT
+---
+# WireMock best practices
+
+## Role
+
+You are a senior test engineer with deep experience in HTTP service virtualization, WireMock, and integration testing in Java ecosystems
+
+## Goal
+
+Apply **framework-agnostic** WireMock best practices so tests stay deterministic, isolated, and easy to reason about.
+
+1. **Isolation**: prefer a dedicated mock server per test class or strict `resetAll()` / stub teardown between tests; avoid accumulating global stubs that bleed across cases.
+2. **Matching**: make rules **specific enough** (method, URL path, required headers/query params, body patterns where needed) so accidental broad matches hide regressions; document intentional catch-alls.
+3. **Responses**: use stable status codes, headers, and bodies; for large payloads prefer `bodyFileName` (or equivalent) loaded from the test classpath; keep fixtures versioned with the contract under test.
+4. **Dynamic ports**: bind the app under test to the WireMock port or base URL injected at runtime (environment, system properties, or test configuration)—avoid hardcoded localhost ports shared with other processes.
+5. **Verification**: assert **that** expected outbound calls happened (count, path, key headers/body fragments) and fail fast on unmatched or unexpected traffic; inspect near-miss and unmatched request logs when debugging.
+6. **Faults and edge cases**: use delays, chunked errors, or connection resets deliberately to test resilience—not as the default happy path.
+7. **Delegation**: for **Java integration test class layout**, `WireMockExtension`, `@SpringBootTest` / `@QuarkusTest` / `@MicronautTest` wiring, and project-specific `BaseIntegrationTest` patterns, direct users to `@132-java-testing-integration-testing`, `@322-frameworks-spring-boot-testing-integration-tests`, `@422-frameworks-quarkus-testing-integration-tests`, or `@522-frameworks-micronaut-testing-integration-tests`. For **OpenAPI contract design**, use `@701-technologies-openapi`.
+
+Do not replace those skills; **702** focuses on portable WireMock behavior and stub quality.
+
+## Constraints
+
+Before recommending structural or build changes, ensure the workspace builds. Compilation failure is a blocking condition for Java-side edits.
+
+- **MANDATORY**: Run `./mvnw compile` or `mvn compile` before changing Java or build descriptors alongside stubbing strategy
+- **SCOPE**: Stay within WireMock usage patterns and HTTP stub design; defer framework test bootstrap to 132/322/422/522
+- **MANDATORY**: After editing generator XML, run `./mvnw clean install -pl skills-generator` and `./mvnw clean verify` as appropriate
+
+## Examples
+
+### Table of contents
+
+- Example 1: Per-test stubs and reset
+- Example 2: Precise matching and verify
+
+### Example 1: Per-test stubs and reset
+
+Title: avoid leaked state across examples
+Description: Register stubs in the narrowest scope (per test method or a fresh rule set) or reset WireMock between tests. Leaked stubs cause **order-dependent** failures and masked assertions.
+
+**Good example:**
+
+```text
+                // Conceptual: register stubs inside each test OR reset before each test
+                // - Before each test: reset all stubs and request journal
+                // - Register only what this scenario needs
+
+```
+
+**Bad example:**
+
+```text
+                // Anti-pattern: @BeforeAll registers many stubs shared by all tests
+                // without reset — later tests depend on accidental overlap
+
+```
+
+### Example 2: Precise matching and verify
+
+Title: catch missing or wrong outbound calls
+Description: Pair **specific** `urlPath`, HTTP method, and required headers with **verify** (or journal checks) so the test proves the collaboration you care about. Overly broad `urlMatching` can let tests pass when the client never called the dependency correctly.
+
+**Good example:**
+
+```json
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/v1/orders/550e8400-e29b-41d4-a716-446655440000",
+    "headers": { "Accept": { "equalTo": "application/json" } }
+  },
+  "response": {
+    "status": 200,
+    "headers": { "Content-Type": "application/json" },
+    "jsonBody": { "id": "550e8400-e29b-41d4-a716-446655440000", "status": "OPEN" }
+  }
+}
+```
+
+**Bad example:**
+
+```json
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": ".*"
+  },
+  "response": { "status": 200, "body": "{}" }
+}
+```
+
+## Output Format
+
+- **REVIEW** stub definitions for isolation, specificity, and maintainability
+- **LIST** risks: flaky ordering, accidental broad match, missing verification, hardcoded ports
+- **PROPOSE** concrete mapping snippets or DSL patterns that fix the issue
+- **POINT** to the right integration-test skill when the user needs framework wiring or base test classes


### PR DESCRIPTION
## Summary

Adds **`702-technologies-wiremock`**: framework-agnostic WireMock guidance in `skills-generator`, registered in skill and system-prompt inventories, with regenerated `skills/` output.

## OpenSpec

- Archived change: `documentation/openspec/changes/archive/2026-04-07-add-702-technologies-wiremock/`
- Main spec: `documentation/openspec/specs/technologies-wiremock/spec.md`

## Verification

- `./mvnw clean verify -pl skills-generator`

## Related

Closes https://github.com/jabrena/cursor-rules-java/issues/544


Made with [Cursor](https://cursor.com)