### PR TITLE
docs(site): polish v0.14.0 release post REST skills section

### DIFF
--- a/docs/blog/2026/04/release-0.14.0.html
+++ b/docs/blog/2026/04/release-0.14.0.html
@@ -182,9 +182,8 @@ openspec archive &lt;change-name&gt;
 <ul>
 <li><code>@114-java-maven-search</code></li>
 </ul>
-<h4>Reinforced REST API development with new technologies</h4>
-<p>In the previous release, the project added Agents to implement plans. In this release, you can apply changes in a more granular way, or keep using Plans when the change is small. You can review your REST contracts with <code>@701-technologies-openapi</code>, reinforce your integration tests with <code>@702-technologies-wiremock</code>, and—most significantly for testing—use the new black-box testing capabilities with <code>@703-technologies-fuzzing-testing</code> based on <code>CATS</code>.</p>
-<p>You can run black-box tests against your development environment using your <code>OpenAPI</code> specification.</p>
+<h4>Reinforced REST API desing and testing</h4>
+<p>Now, you can review and harden <strong>OpenAPI 3.x</strong> contracts with <code>@701-technologies-openapi</code> when the specification still needs work. As you develop integration tests, you can strengthen them with <strong>HTTP stubs</strong> from <strong>WireMock</strong> using <code>@702-technologies-wiremock</code>. Finally, if you want <strong>black-box testing</strong> driven by your OpenAPI specification, <code>@703-technologies-fuzzing-testing</code> based on <strong>CATS</strong> can help surface defects through contract-driven negative testing, malformed and boundary inputs, and related edge cases.</p>
 <p><a href="https://endava.github.io/cats/"><img src="/cursor-rules-java/images/2026/4/cats.png" alt="" /></a></p>
 <p>Further information about CATS: <a href="https://github.com/Endava/cats">https://github.com/Endava/cats</a></p>
 <p><strong>Skills</strong></p>

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/cursor-rules-java/</id>
   <title>Skills & Agents for Java</title>
-  <updated>2026-04-11T21:04:25+0200</updated>
+  <updated>2026-04-11T23:53:27+0200</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/cursor-rules-java/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/cursor-rules-java//feed.xml' />
   <entry>

--- a/site-generator/content/blog/2026/04/release-0.14.0.md
+++ b/site-generator/content/blog/2026/04/release-0.14.0.md
@@ -126,11 +126,9 @@ Now it is easier to update or search for dependencies in your `pom.xml` with the
 
 - `@114-java-maven-search`
 
-#### Reinforced REST API development with new technologies
+#### Reinforced REST API desing and testing
 
-In the previous release, the project added Agents to implement plans. In this release, you can apply changes in a more granular way, or keep using Plans when the change is small. You can review your REST contracts with `@701-technologies-openapi`, reinforce your integration tests with `@702-technologies-wiremock`, and—most significantly for testing—use the new black-box testing capabilities with `@703-technologies-fuzzing-testing` based on `CATS`.
-
-You can run black-box tests against your development environment using your `OpenAPI` specification.
+Now, you can review and harden **OpenAPI 3.x** contracts with `@701-technologies-openapi` when the specification still needs work. As you develop integration tests, you can strengthen them with **HTTP stubs** from **WireMock** using `@702-technologies-wiremock`. Finally, if you want **black-box testing** driven by your OpenAPI specification, `@703-technologies-fuzzing-testing` based on **CATS** can help surface defects through contract-driven negative testing, malformed and boundary inputs, and related edge cases.
 
 [![](/cursor-rules-java/images/2026/4/cats.png)](https://endava.github.io/cats/)
 


### PR DESCRIPTION
This pull request updates the v0.14.0 release blog post: clearer wording and corrected grammar for the OpenAPI, WireMock, and CATS skills paragraph, including consistent **WireMock** naming.

The static site output under `docs/` and `docs/feed.xml` was regenerated with the site-generator `site-update` profile so GitHub Pages stays in sync with `site-generator/content/`.