### PR TITLE
feat(skills): add MongoDB non-relational database skill

### DIFF
--- a/skills-generator/src/main/resources/skill-indexes/705-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/705-skill.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="https://jabrena.github.io/pml/schemas/0.7.0/pml.xsd"
+      id="705-technologies-non-relational-databases-mongodb">
+  <metadata>
+    <author>Juan Antonio Breña Moral</author>
+    <version>0.16.0</version>
+    <license>Apache-2.0</license>
+    <description>Use when you need framework-agnostic MongoDB and non-relational database query guidance — document schema design, collection modeling, JSON Schema validation, indexes, aggregation pipelines, query performance, consistency trade-offs, transactions, and operational safety — without choosing Spring Boot, Quarkus, or Micronaut. This should trigger for requests such as Design MongoDB document schemas; Review MongoDB queries and indexes; Improve aggregation pipeline performance; Model non-relational data access patterns; Review NoSQL consistency and transaction trade-offs.</description>
+  </metadata>
+
+  <title>Non-relational database query best practices</title>
+  <goal><![CDATA[
+Help teams design maintainable, secure, and performant **MongoDB and non-relational database queries** for Java applications.
+
+**What is covered in this Skill?**
+
+- Document modeling for aggregates, embedded documents, references, arrays, and bounded growth
+- MongoDB JSON Schema validation and compatibility-aware schema evolution
+- Query design: explicit predicates, projections, sort stability, pagination, collation, and read concerns
+- Index strategy: compound indexes, covering queries, partial indexes, TTL indexes, unique constraints, and lifecycle review
+- Aggregation pipelines: stage ordering, `$match` pushdown, `$project`, `$lookup`, `$unwind`, `$group`, and memory controls
+- Consistency, transactions, idempotency, migration safety, testing, observability, and production diagnostics
+
+**Scope:** Framework-agnostic MongoDB and non-relational data modeling. For Java framework integrations, defer to the matching Spring Boot, Quarkus, or Micronaut MongoDB skill.
+]]></goal>
+
+  <constraints>
+    <constraints-description>Keep recommendations at the database-modeling and query layer unless the user explicitly asks for Java framework integration. After editing this repository's XML sources, regenerate skills and verify the build.</constraints-description>
+    <constraint-list>
+      <constraint>**MANDATORY**: Run `./mvnw compile` or `mvn compile` before proposing Java or Maven changes in the same change set</constraint>
+      <constraint>**INJECTION**: Never concatenate untrusted input into query documents, aggregation stages, JSON strings, JavaScript expressions, or `$where`; use driver/framework query builders and validated parameters</constraint>
+      <constraint>**SCHEMA**: Prefer explicit document contracts, bounded arrays, stable identifiers, and validation rules over unconstrained document growth</constraint>
+      <constraint>**PERFORMANCE**: Review `explain()` plans, scanned/returned ratios, sort coverage, and index selectivity before claiming a query is optimized</constraint>
+      <constraint>**FRAMEWORK**: Defer Spring MongoDB to `@315-frameworks-spring-mongodb`, Quarkus MongoDB to `@415-frameworks-quarkus-mongodb`, Micronaut MongoDB to `@515-frameworks-micronaut-mongodb`, and Mongock migrations to the matching framework migration skill</constraint>
+      <constraint>**MANDATORY**: Regenerate skills with `./mvnw clean install -pl skills-generator` after editing skill or system-prompt XML in this repo</constraint>
+      <constraint>**VERIFY**: Run `./mvnw clean verify` or `mvn clean verify` before promoting changes</constraint>
+      <constraint>**EDGE CASE**: If the target database, version, shard topology, read/write concern, data volume, or latency requirement is missing and affects the recommendation, ask a clarifying question before editing queries or schemas</constraint>
+      <constraint>**EDGE CASE**: If requested changes conflict with data safety, backwards compatibility, zero-downtime deployment, or retention requirements, explain the trade-off and ask for confirmation</constraint>
+    </constraint-list>
+  </constraints>
+
+  <triggers>
+    <trigger-list>
+        <trigger>Design MongoDB document schemas</trigger>
+        <trigger>Review MongoDB queries and indexes</trigger>
+        <trigger>Improve aggregation pipeline performance</trigger>
+        <trigger>Model non-relational data access patterns</trigger>
+        <trigger>Review NoSQL consistency and transaction trade-offs</trigger>
+    </trigger-list>
+  </triggers>
+  <steps>
+    <step number="1"><step-title>Read reference and assess data context</step-title><step-content>Read `references/705-technologies-non-relational-databases-mongodb.md` and inspect current collections, schemas, indexes, queries, aggregation pipelines, tests, and database configuration before proposing changes.</step-content></step>
+    <step number="2"><step-title>Identify workload and operational constraints</step-title><step-content>Confirm query patterns, cardinality, data volume, document growth, consistency requirements, shard topology, and migration constraints that shape the non-relational design.</step-content></step>
+    <step number="3"><step-title>Apply database-aligned changes</step-title><step-content>Implement or refactor database artifacts following the reference patterns and project conventions, keeping Java framework integration out of scope unless explicitly requested.</step-content></step>
+    <step number="4"><step-title>Run verification and report results</step-title><step-content>Execute appropriate build, schema validation, query-plan, migration, and test checks; summarize what changed, what was verified, and any remaining database risks.</step-content></step>
+  </steps>
+</prompt>

--- a/skills-generator/src/main/resources/skill-references/705-technologies-non-relational-databases-mongodb.xml
+++ b/skills-generator/src/main/resources/skill-references/705-technologies-non-relational-databases-mongodb.xml
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <metadata>
+        <author>Juan Antonio Breña Moral</author>
+        <version>0.16.0</version>
+        <license>Apache-2.0</license>
+        <title>Non-relational database query best practices</title>
+        <description>Use when you need framework-agnostic MongoDB and non-relational database query guidance — document schema design, collection modeling, JSON Schema validation, indexes, aggregation pipelines, query performance, consistency trade-offs, transactions, and operational safety.</description>
+    </metadata>
+
+    <role>You are a senior database engineer with deep experience in MongoDB, non-relational data modeling, production query performance, and Java application data-access boundaries</role>
+
+    <goal>
+        Apply **framework-agnostic** MongoDB and non-relational database practices so document schemas, queries, indexes, and migrations remain maintainable, performant, and safe in production.
+
+        1. Model documents around access patterns and aggregate boundaries: embed data that is read together, reference data with independent lifecycles, and keep arrays bounded.
+        2. Make schemas explicit with validation where practical: document required fields, allowed values, BSON types, indexes, retention rules, and backwards-compatible evolution.
+        3. Design queries with stable predicates, projections, sort order, pagination, collation, and parameter validation; avoid unbounded scans and application-side filtering.
+        4. Align indexes to real workload shapes: equality prefixes, sort coverage, selectivity, partial filters, unique constraints, TTL retention, and measured lifecycle cleanup.
+        5. Build aggregation pipelines that reduce data early, preserve index use, avoid avoidable fan-out, and expose operational limits such as memory, disk use, and stage cost.
+        6. Treat consistency, transactions, idempotency, sharding, backups, migrations, and observability as first-class design inputs.
+
+        Do not replace framework skills; complement them with database-level guidance only.
+    </goal>
+
+    <constraints>
+        <constraints-description>
+            Before recommending structural or build changes, ensure the workspace builds. Compilation failure is a blocking condition for Java-side edits.
+        </constraints-description>
+        <constraint-list>
+            <constraint>**MANDATORY**: Run `./mvnw compile` or `mvn compile` before changing Java or build descriptors alongside database artifacts</constraint>
+            <constraint>**SCOPE**: Stay within MongoDB/non-relational modeling, query, index, migration, and operational guidance; defer framework wiring to 315/415/515 and Mongock migrations to 316/416/516</constraint>
+            <constraint>**QUERY SAFETY**: Never build queries, aggregation stages, JSON documents, JavaScript expressions, or `$where` clauses by concatenating untrusted input</constraint>
+            <constraint>**EVIDENCE**: Use `explain()` output, index definitions, representative data volume, and query frequency before making performance claims</constraint>
+            <constraint>**MANDATORY**: After editing generator XML, run `./mvnw clean install -pl skills-generator` and `./mvnw clean verify` as appropriate</constraint>
+        </constraint-list>
+    </constraints>
+
+    <examples>
+        <toc auto-generate="true" />
+
+        <example number="1" id="document-modeling">
+            <example-header>
+                <example-title>Model documents around access patterns</example-title>
+                <example-subtitle>bounded embedded data, independent references, explicit lifecycle</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Embed data that is usually read and updated with the aggregate. Reference data that has an independent lifecycle, high cardinality, or unbounded growth. Call out the expected query shape before choosing either option.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="json"><![CDATA[{
+  "_id": "order-1001",
+  "customerId": "customer-42",
+  "status": "PAID",
+  "placedAt": "2026-06-04T10:15:30Z",
+  "shippingAddress": {
+    "country": "ES",
+    "city": "Madrid",
+    "postalCode": "28001"
+  },
+  "lineItems": [
+    {
+      "sku": "book-123",
+      "quantity": 2,
+      "unitPrice": "19.95"
+    }
+  ]
+}]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="json"><![CDATA[{
+  "_id": "customer-42",
+  "orders": [
+    { "orderId": "order-1001", "lineItems": [/* grows forever */] },
+    { "orderId": "order-1002", "lineItems": [/* grows forever */] }
+  ]
+}]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="2" id="schema-validation">
+            <example-header>
+                <example-title>Use JSON Schema validation for important contracts</example-title>
+                <example-subtitle>required fields, BSON types, enums, and compatibility-aware evolution</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                MongoDB collections can stay flexible while still protecting critical invariants. Use validation for required identifiers, state fields, timestamps, and values that downstream code assumes.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="javascript"><![CDATA[db.createCollection("orders", {
+  validator: {
+    $jsonSchema: {
+      bsonType: "object",
+      required: ["customerId", "status", "placedAt", "lineItems"],
+      properties: {
+        customerId: { bsonType: "string" },
+        status: { enum: ["PENDING", "PAID", "CANCELLED"] },
+        placedAt: { bsonType: "date" },
+        lineItems: {
+          bsonType: "array",
+          minItems: 1,
+          items: {
+            bsonType: "object",
+            required: ["sku", "quantity"],
+            properties: {
+              sku: { bsonType: "string" },
+              quantity: { bsonType: "int", minimum: 1 }
+            }
+          }
+        }
+      }
+    }
+  }
+})]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="javascript"><![CDATA[db.createCollection("orders")
+// No validation for fields that application code treats as mandatory.
+// Invalid status values and missing line items can drift into production.]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="3" id="query-and-index-alignment">
+            <example-header>
+                <example-title>Align compound indexes with query shape</example-title>
+                <example-subtitle>equality predicates before range and sort fields</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Indexes should match frequent filters and sorts. Check plans with representative data and remove unused indexes after measuring production usage.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="javascript"><![CDATA[db.orders.createIndex({ customerId: 1, status: 1, placedAt: -1 })
+
+db.orders.find(
+  {
+    customerId: "customer-42",
+    status: "PAID",
+    placedAt: { $gte: ISODate("2026-01-01T00:00:00Z") }
+  },
+  { _id: 1, status: 1, placedAt: 1, total: 1 }
+).sort({ placedAt: -1 }).limit(50).explain("executionStats")]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="javascript"><![CDATA[db.orders.find({ status: "PAID" }).toArray()
+  .filter(order => order.customerId === "customer-42")
+  .sort((left, right) => right.placedAt - left.placedAt)
+// Avoid application-side filtering/sorting after an unbounded collection scan.]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="4" id="aggregation-pipeline">
+            <example-header>
+                <example-title>Reduce data early in aggregation pipelines</example-title>
+                <example-subtitle>push filters forward, project only needed fields, control fan-out</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Place selective `$match` stages early, project only fields needed downstream, and be deliberate with `$lookup` and `$unwind` because they can multiply intermediate result size.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="javascript"><![CDATA[db.orders.aggregate([
+  {
+    $match: {
+      status: "PAID",
+      placedAt: { $gte: ISODate("2026-01-01T00:00:00Z") }
+    }
+  },
+  { $project: { customerId: 1, total: 1, placedAt: 1 } },
+  { $group: { _id: "$customerId", revenue: { $sum: "$total" } } },
+  { $sort: { revenue: -1 } },
+  { $limit: 20 }
+], { allowDiskUse: true })]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="javascript"><![CDATA[db.orders.aggregate([
+  { $lookup: { from: "customers", localField: "customerId", foreignField: "_id", as: "customer" } },
+  { $unwind: "$lineItems" },
+  { $match: { status: "PAID" } }
+])
+// Avoid expensive joins and fan-out before selective filters.]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+    </examples>
+
+    <output-format>
+        <output-format-list>
+            <output-format-item>**IDENTIFY** workload context: read/write paths, cardinality, retention, consistency requirements, data volume, and operational constraints</output-format-item>
+            <output-format-item>**REVIEW** document schemas for aggregate boundaries, bounded growth, validation, lifecycle ownership, and backwards-compatible evolution</output-format-item>
+            <output-format-item>**ANALYZE** queries and aggregation pipelines for predicate selectivity, projection, sort coverage, pagination, collation, and fan-out risk</output-format-item>
+            <output-format-item>**PROPOSE** concrete collection, index, validation, query, and pipeline snippets that match the stated workload</output-format-item>
+            <output-format-item>**CALL OUT** data migration, zero-downtime rollout, rollback, backup, and retention risks before destructive or incompatible changes</output-format-item>
+            <output-format-item>**DELEGATE** framework-specific repository, client, transaction, and test wiring to the matching Spring Boot, Quarkus, or Micronaut MongoDB skill</output-format-item>
+            <output-format-item>**VALIDATE** changes with build checks, representative tests, schema validation, index inspection, and `explain()` evidence when available</output-format-item>
+        </output-format-list>
+    </output-format>
+
+    <safeguards>
+        <safeguards-list>
+            <safeguards-item>**DATA SAFETY**: Back up data and define rollback steps before destructive schema, index, retention, or migration changes</safeguards-item>
+            <safeguards-item>**BOUNDED GROWTH**: Avoid unbounded arrays and oversized documents; model high-cardinality children as separate documents when lifecycle or growth requires it</safeguards-item>
+            <safeguards-item>**QUERY SAFETY**: Validate user-controlled filters, sort fields, projection fields, and pagination limits before constructing database queries</safeguards-item>
+            <safeguards-item>**PERFORMANCE EVIDENCE**: Prefer measured plans and production-like data over intuition when changing indexes or aggregation pipelines</safeguards-item>
+            <safeguards-item>**CONSISTENCY**: Document read concern, write concern, transaction boundaries, and idempotency strategy when correctness depends on them</safeguards-item>
+        </safeguards-list>
+    </safeguards>
+</prompt>

--- a/skills-generator/src/main/resources/skills.xml
+++ b/skills-generator/src/main/resources/skills.xml
@@ -456,4 +456,9 @@
             <reference>704-technologies-sql</reference>
         </reference-list>
     </skill>
+    <skill id="705">
+        <reference-list>
+            <reference>705-technologies-non-relational-databases-mongodb</reference>
+        </reference-list>
+    </skill>
 </skill-inventory>


### PR DESCRIPTION
## Summary
- add skill 705 for framework-agnostic MongoDB/non-relational database query guidance
- register the new skill in the generator inventory
- include modeling, schema validation, indexing, aggregation, and operational safeguards examples

Closes #774

## Verification
- xmllint --noout skills-generator/src/main/resources/skills.xml skills-generator/src/main/resources/skill-indexes/705-skill.xml skills-generator/src/main/resources/skill-references/705-technologies-non-relational-databases-mongodb.xml
- ./mvnw clean verify -pl skills-generator (fails on existing version consistency mismatch: skill 001 metadata version 0.15.0 vs project 0.16.0-SNAPSHOT)