### PR TITLE
feat(skill): simplify 111 dependency questions

### DIFF
--- a/skills-generator/src/main/resources/skill-indexes/111-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/111-skill.xml
@@ -28,7 +28,7 @@ Add essential Maven dependencies that enhance code quality and safety through a 
     <constraint-list>
       <constraint>**MANDATORY**: Run `./mvnw validate` or `mvn validate` before any changes</constraint>
       <constraint>**SAFETY**: If validation fails, stop and ask the user to fix issues—do not proceed until resolved</constraint>
-      <constraint><![CDATA[**BEFORE READING DEPENDENCY REFERENCES**: Run the question flow embedded in this SKILL.md first. Ask questions one-by-one in strict order (JSpecify → Enhanced Compiler Analysis (conditional) → Package Name (conditional) → VAVR → ArchUnit), then read only the dependency references selected by the user's answers. Use consultative language, present trade-offs, and wait for user responses before implementing]]></constraint>
+      <constraint><![CDATA[**BEFORE READING DEPENDENCY REFERENCES**: Run the question flow embedded in this SKILL.md first. Ask one consolidated dependency-selection question, then ask only conditional follow-up questions required by the selected options. Read only the dependency references selected by the user's answers. Use consultative language, present trade-offs, and wait for user responses before implementing]]></constraint>
     </constraint-list>
   </constraints>
 
@@ -50,7 +50,7 @@ Add essential Maven dependencies that enhance code quality and safety through a 
     <step number="2">
       <step-title>Ask dependency assessment questions before reading references</step-title>
       <step-content><![CDATA[
-Run this XML-included question flow before reading any dependency implementation reference. Ask one question at a time, wait for the user's answer, and record selected dependency families before continuing.
+Run this XML-included question flow before reading any dependency implementation reference. Ask the consolidated dependency-selection question first, wait for the user's answer, and record selected dependency families before continuing. Ask conditional follow-up questions only when required by the selected dependencies.
 
 ]]><xi:include href="../skill-references/assets/questions/111-java-maven-dependencies-questions.xml"/><![CDATA[
 

--- a/skills-generator/src/main/resources/skill-references/assets/questions/111-java-maven-dependencies-questions.xml
+++ b/skills-generator/src/main/resources/skill-references/assets/questions/111-java-maven-dependencies-questions.xml
@@ -1,62 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<question-flow>
-**Question 1**: Do you want to add JSpecify for enhanced nullness annotations?
+<question-flow><![CDATA[
+**Question 1**: Which code-quality dependencies do you want to add?
 
-JSpecify provides modern nullness annotations that help prevent null pointer exceptions at compile time. It's particularly useful for new projects or those looking to improve null safety.
+Options:
+- JSpecify (modern nullness annotations, `provided` scope; recommended for new projects)
+- Error Prone + NullAway (enhanced compiler analysis and compile-time nullness checking; requires JSpecify)
+- VAVR (functional programming support with Try/Either and immutable collections)
+- ArchUnit (architecture testing with JUnit 5, `test` scope)
+- None
+- Other (specify)
 
-**Options**:
-- **y** - Add JSpecify dependency (recommended for new projects)
-- **n** - Skip JSpecify dependency
+**Recommendation**: Select JSpecify for better null-safety annotations. Add Error Prone + NullAway when you want stronger compile-time analysis. Add VAVR only when functional programming patterns are useful for the project. Add ArchUnit when you want automated architecture governance.
 
-**Recommendation**: Choose 'y' for better null safety and modern annotation support.
-
----
-
-**Note**: This question is asked ONLY if you selected 'y' for JSpecify.
-
-**Question 2**: Do you want to enable enhanced compiler analysis with Error Prone and NullAway?
-
-This adds Error Prone static analysis and NullAway nullness checking to your build process. It will catch more potential issues at compile time but may initially show warnings in existing code.
-
-**Options**:
-- **y** - Enable enhanced analysis with Error Prone and NullAway (recommended)
-- **n** - Just add JSpecify dependency without enhanced analysis
-
-**Recommendation**: Choose 'y' to get the full benefit of nullness checking and additional static analysis.
+**Selection notes**:
+- If Error Prone + NullAway is selected, also select JSpecify unless the project already has equivalent nullness annotations configured.
+- If None is selected, do not add dependency-family references.
 
 ---
 
-**Note**: This question is asked ONLY if you selected enhanced compiler analysis.
+**Question 2** (conditional): What is your main project package name?
 
-**Question 3**: What is your main project package name?
+**Note**: This question is asked only if Error Prone + NullAway was selected.
 
 This is needed to configure NullAway to analyze your code. For example, if your classes are in `com.example.myproject`, enter `com.example.myproject`.
 
 **Format**: Use dot notation (e.g., `com.example.myproject` or `org.mycompany.myapp`)
 
 **Example**: `com.example.myproject`
-
----
-
-**Question 4**: Do you want to add VAVR for functional programming support?
-
-VAVR is a functional programming library for Java that provides immutable data types, functional control structures (Try and Either), and immutable collections. It helps write more robust and expressive code using functional programming patterns.
-
-**Options**:
-- **y** - Add VAVR dependency for functional programming (recommended for functional style)
-- **n** - Skip VAVR dependency
-
-**Recommendation**: Choose 'y' if you want to use functional programming patterns, immutable data structures, or need better error handling with Try/Either monads.
-
----
-
-**Question 5**: Do you want to add ArchUnit for architecture testing?
-
-ArchUnit lets you write unit tests that enforce architectural constraints, such as layering rules, naming conventions, dependency directions, and package structure, directly in your test suite. It integrates with JUnit 5 and runs as part of the normal test lifecycle.
-
-**Options**:
-- **y** - Add ArchUnit JUnit 5 dependency (recommended for architecture governance)
-- **n** - Skip ArchUnit dependency
-
-**Recommendation**: Choose 'y' if you want to prevent architecture erosion and enforce design rules automatically on every build.
-</question-flow>
+]]></question-flow>


### PR DESCRIPTION
## Summary

- Consolidates skill 111 dependency selection into a single question
- Keeps only the package-name follow-up conditional for Error Prone + NullAway
- Aligns skill 111 question flow with the simplified skill 112 experience

Closes #787

## Verification

- xmllint --noout skills-generator/src/main/resources/skill-indexes/111-skill.xml
- xmllint --noout skills-generator/src/main/resources/skill-references/assets/questions/111-java-maven-dependencies-questions.xml
- ./mvnw clean install -pl skills-generator
- ./mvnw clean verify
