### PR TITLE
docs(readme): document skill validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ This project is compatible with any tool that supports `Commands`, `Agents`, `Sk
 
 Review the [project workflows guide](./documentation/guides/GETTING-STARTED-WORKFLOWS.md) for prompting, agent-driven engineering, and pipeline workflows.
 
+## Skill Validations
+
+Every push runs skill-focused checks in [CI Builds](./.github/workflows/maven.yaml). Each validation regenerates the current agent skills from `skills-generator` before scanning `.agents/skills`, so CI verifies generated output rather than stale checked-in content:
+
+- `skill-check` validates the generated `SKILL.md` structure and metadata with `npx skill-check@latest .agents/skills --no-security-scan --format github`.
+- `cisco-ai-skill-scanner` runs a behavioral scan with the strict policy and fails on high-severity findings.
+- SkillSpector generates a no-LLM Markdown report for additional skill quality inspection and uploads it as a workflow artifact.
+
+For local development, run `./mvnw clean verify -pl skills-generator` before invoking the scanners. Release-only validation for the public `skills/` directory is documented in [CONTRIBUTING.md](./CONTRIBUTING.md) and [AGENTS.md](./AGENTS.md).
+
 ## Limitations
 
 ### Lack of determinism

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Review the [project workflows guide](./documentation/guides/GETTING-STARTED-WORK
 
 ## Skill Validations
 
-Every push runs skill-focused checks in [CI Builds](./.github/workflows/maven.yaml). Each validation regenerates the current agent skills from `skills-generator` before scanning `.agents/skills`, so CI verifies generated output rather than stale checked-in content:
+Every push runs skill-focused checks in [CI Builds](./.github/workflows/maven.yaml) to maintain quality and correctness:
 
 - `skill-check` validates the generated `SKILL.md` structure and metadata with `npx skill-check@latest .agents/skills --no-security-scan --format github`.
 - `cisco-ai-skill-scanner` runs a behavioral scan with the strict policy and fails on high-severity findings.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ Every push runs skill-focused checks in [CI Builds](./.github/workflows/maven.ya
 - `cisco-ai-skill-scanner` runs a behavioral scan with the strict policy and fails on high-severity findings.
 - SkillSpector generates a no-LLM Markdown report for additional skill quality inspection and uploads it as a workflow artifact.
 
-For local development, run `./mvnw clean verify -pl skills-generator` before invoking the scanners. Release-only validation for the public `skills/` directory is documented in [CONTRIBUTING.md](./CONTRIBUTING.md) and [AGENTS.md](./AGENTS.md).
-
 ## Limitations
 
 ### Lack of determinism

--- a/README_ES.md
+++ b/README_ES.md
@@ -56,7 +56,7 @@ Consulta la [guía de flujos de trabajo del proyecto](./documentation/guides/GET
 
 ## Validaciones de Skills
 
-Cada push ejecuta validaciones enfocadas en skills dentro de [CI Builds](./.github/workflows/maven.yaml). Cada validación regenera los agent skills actuales desde `skills-generator` antes de analizar `.agents/skills`, por lo que CI verifica la salida generada y no contenido obsoleto en el repositorio:
+Cada push ejecuta validaciones enfocadas en skills dentro de [CI Builds](./.github/workflows/maven.yaml) para mantener la calidad y la corrección:
 
 - `skill-check` valida la estructura y los metadatos de los `SKILL.md` generados con `npx skill-check@latest .agents/skills --no-security-scan --format github`.
 - `cisco-ai-skill-scanner` ejecuta un análisis de comportamiento con la política strict y falla ante hallazgos de severidad alta.

--- a/README_ES.md
+++ b/README_ES.md
@@ -62,8 +62,6 @@ Cada push ejecuta validaciones enfocadas en skills dentro de [CI Builds](./.gith
 - `cisco-ai-skill-scanner` ejecuta un análisis de comportamiento con la política strict y falla ante hallazgos de severidad alta.
 - SkillSpector genera un informe Markdown sin LLM para una inspección adicional de calidad de los skills y lo sube como artefacto del workflow.
 
-Para el desarrollo local, ejecuta `./mvnw clean verify -pl skills-generator` antes de invocar los scanners. Las validaciones exclusivas de release para el directorio público `skills/` están documentadas en [CONTRIBUTING.md](./CONTRIBUTING.md) y [AGENTS.md](./AGENTS.md).
-
 ## Limitaciones
 
 ### Falta de determinismo

--- a/README_ES.md
+++ b/README_ES.md
@@ -54,6 +54,16 @@ Este proyecto es compatible con cualquier herramienta que admita `Commands`, `Ag
 
 Consulta la [guía de flujos de trabajo del proyecto](./documentation/guides/GETTING-STARTED-WORKFLOWS_ES.md) para conocer los flujos de prompting, ingeniería dirigida por agents y pipelines.
 
+## Validaciones de Skills
+
+Cada push ejecuta validaciones enfocadas en skills dentro de [CI Builds](./.github/workflows/maven.yaml). Cada validación regenera los agent skills actuales desde `skills-generator` antes de analizar `.agents/skills`, por lo que CI verifica la salida generada y no contenido obsoleto en el repositorio:
+
+- `skill-check` valida la estructura y los metadatos de los `SKILL.md` generados con `npx skill-check@latest .agents/skills --no-security-scan --format github`.
+- `cisco-ai-skill-scanner` ejecuta un análisis de comportamiento con la política strict y falla ante hallazgos de severidad alta.
+- SkillSpector genera un informe Markdown sin LLM para una inspección adicional de calidad de los skills y lo sube como artefacto del workflow.
+
+Para el desarrollo local, ejecuta `./mvnw clean verify -pl skills-generator` antes de invocar los scanners. Las validaciones exclusivas de release para el directorio público `skills/` están documentadas en [CONTRIBUTING.md](./CONTRIBUTING.md) y [AGENTS.md](./AGENTS.md).
+
 ## Limitaciones
 
 ### Falta de determinismo

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -56,7 +56,7 @@
 
 ## Skill 验证
 
-每次 push 都会在 [CI Builds](./.github/workflows/maven.yaml) 中运行面向 skills 的检查。每项验证都会先从 `skills-generator` 重新生成当前 agent skills，再扫描 `.agents/skills`，因此 CI 验证的是生成后的输出，而不是仓库中过期的内容：
+每次 push 都会在 [CI Builds](./.github/workflows/maven.yaml) 中运行面向 skills 的检查，以维护质量和正确性：
 
 - `skill-check` 使用 `npx skill-check@latest .agents/skills --no-security-scan --format github` 验证生成的 `SKILL.md` 结构和元数据。
 - `cisco-ai-skill-scanner` 使用 strict policy 执行行为扫描，并在发现高严重级别问题时失败。

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -62,8 +62,6 @@
 - `cisco-ai-skill-scanner` 使用 strict policy 执行行为扫描，并在发现高严重级别问题时失败。
 - SkillSpector 生成不依赖 LLM 的 Markdown 报告，用于进一步检查 skill 质量，并将报告上传为 workflow artifact。
 
-本地开发时，请先运行 `./mvnw clean verify -pl skills-generator`，再调用这些 scanners。面向公开 `skills/` 目录的 release-only 验证记录在 [CONTRIBUTING.md](./CONTRIBUTING.md) 与 [AGENTS.md](./AGENTS.md) 中。
-
 ## 局限性
 
 ### 缺乏确定性

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -54,6 +54,16 @@
 
 请参阅[项目工作流指南](./documentation/guides/GETTING-STARTED-WORKFLOWS_ZH.md)，了解提示工程、智能体驱动工程和流水线工作流。
 
+## Skill 验证
+
+每次 push 都会在 [CI Builds](./.github/workflows/maven.yaml) 中运行面向 skills 的检查。每项验证都会先从 `skills-generator` 重新生成当前 agent skills，再扫描 `.agents/skills`，因此 CI 验证的是生成后的输出，而不是仓库中过期的内容：
+
+- `skill-check` 使用 `npx skill-check@latest .agents/skills --no-security-scan --format github` 验证生成的 `SKILL.md` 结构和元数据。
+- `cisco-ai-skill-scanner` 使用 strict policy 执行行为扫描，并在发现高严重级别问题时失败。
+- SkillSpector 生成不依赖 LLM 的 Markdown 报告，用于进一步检查 skill 质量，并将报告上传为 workflow artifact。
+
+本地开发时，请先运行 `./mvnw clean verify -pl skills-generator`，再调用这些 scanners。面向公开 `skills/` 目录的 release-only 验证记录在 [CONTRIBUTING.md](./CONTRIBUTING.md) 与 [AGENTS.md](./AGENTS.md) 中。
+
 ## 局限性
 
 ### 缺乏确定性


### PR DESCRIPTION
## Summary
- Add a README section that explains the generated skill validation checks run in CI.
- Keep Spanish and Chinese README translations aligned with the English source.
- Link skill validation behavior to the local `skills-generator` verification step and release validation docs.

## Test plan
- [x] `jbang .github/scripts/MarkdownValidator.java --verbose .`
- [x] Commit hook conventional commit validation passed

Closes #824

Made with [Cursor](https://cursor.com)