### PR TITLE
docs(readme): add five-minute getting started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ The project generates a set of deliverables at the end of any iteration.
 
 This project is compatible with any tool that supports `Commands`, `Agents`, `Skills`, `MCP Servers` and `AGENTS.md`.
 
+## Getting Started in 5 minutes
+
+Learn to use this project following the quick guide [Getting Started in 5 minutes](./documentation/guides/GETTING-STARTED-IN-5-MINUTES.md).
+
 ## Workflows
 
 Review the [project workflows guide](./documentation/guides/GETTING-STARTED-WORKFLOWS.md) for prompting, agent-driven engineering, and pipeline workflows.

--- a/README_ES.md
+++ b/README_ES.md
@@ -50,6 +50,10 @@ El proyecto genera un conjunto de entregables al final de cualquier iteración.
 
 Este proyecto es compatible con cualquier herramienta que admita `Commands`, `Agents`, `Skills`, `MCP Servers` y `AGENTS.md`.
 
+## Primeros pasos en 5 minutos
+
+Aprende a usar este proyecto siguiendo la guía rápida [Primeros pasos en 5 minutos](./documentation/guides/GETTING-STARTED-IN-5-MINUTES_ES.md).
+
 ## Flujos de trabajo
 
 Consulta la [guía de flujos de trabajo del proyecto](./documentation/guides/GETTING-STARTED-WORKFLOWS_ES.md) para conocer los flujos de prompting, ingeniería dirigida por agents y pipelines.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -50,6 +50,10 @@
 
 本项目兼容任何支持 `Commands`、`Agents`、`Skills`、`MCP Servers` 与 `AGENTS.md` 的工具。
 
+## 5 分钟快速入门
+
+按照快速指南 [5 分钟快速入门](./documentation/guides/GETTING-STARTED-IN-5-MINUTES_ZH.md) 学习如何使用本项目。
+
 ## 工作流
 
 请参阅[项目工作流指南](./documentation/guides/GETTING-STARTED-WORKFLOWS_ZH.md)，了解提示工程、智能体驱动工程和流水线工作流。

--- a/documentation/guides/GETTING-STARTED-IN-5-MINUTES.md
+++ b/documentation/guides/GETTING-STARTED-IN-5-MINUTES.md
@@ -1,0 +1,102 @@
+# Getting Started in 5 minutes
+
+> **Languages:** [Español](./GETTING-STARTED-IN-5-MINUTES_ES.md) · [中文](./GETTING-STARTED-IN-5-MINUTES_ZH.md)
+
+This path gives first-time users a small, practical start before reading the full project documentation.
+
+## 1. Install Node.js if needed
+
+The Skills.sh CLI runs through `npx`, so you need Node.js available:
+
+```bash
+node --version
+npx --version
+```
+
+If either command is missing, install Node.js with your operating system package manager.
+
+## 2. Choose your agent and download the Skills
+
+Install every skill from the [Skills.sh registry entry](https://skills.sh/jabrena/cursor-rules-java) for this project into the agent you use most often:
+
+```bash
+# Cursor
+npx skills add jabrena/cursor-rules-java --skill '*' --agent cursor -y
+
+# Claude Code
+npx skills add jabrena/cursor-rules-java --skill '*' --agent claude-code -y
+
+# Codex
+npx skills add jabrena/cursor-rules-java --skill '*' --agent codex -y
+
+# GitHub Copilot
+npx skills add jabrena/cursor-rules-java --skill '*' --agent github-copilot -y
+```
+
+To install for every supported agent, use the CLI's all-agent mode:
+
+```bash
+npx skills add jabrena/cursor-rules-java --skill '*' --agent '*' -y
+```
+
+To inspect the available skills first:
+
+```bash
+npx skills add jabrena/cursor-rules-java --list
+```
+
+## 3. Install the project commands
+
+After installing the skills, tell your agent which AI agent harness tool you use: `cursor`, `claude-code`, `codex`, or `github-copilot`.
+
+```text
+install @004-commands-installation cursor
+install @004-commands-installation claude-code
+install @004-commands-installation codex
+install @004-commands-installation github-copilot
+```
+
+The installer copies the embedded project commands into the command directory for your tool. It supports command destinations for Cursor, Claude, Codex, and GitHub Copilot, and it asks before writing files.
+
+Typical command destinations are:
+
+- `.cursor/command`
+- `.claude/commands`
+- `.codex/commands`
+- `.github/commands`
+
+## 4. Install the project agents when your tool supports them
+
+Commands and skills are enough to start. If you also want the predefined robot agents, tell your agent which AI agent harness tool you use: `cursor` or `claude-code`.
+
+```text
+install @005-agents-installation cursor
+install @005-agents-installation claude-code
+```
+
+The installer supports `.cursor/agents` and `.claude/agents`.
+
+## 5. Use the workflow
+
+This project organizes AI-assisted Java work around four building blocks:
+
+- `Commands` are the entry points, such as `/create-issue`, `/update-issue`, `/create-plan`, `/create-spec`, and `/implement-issue`.
+- `Agents` define responsibilities, such as business analysis, architecture, technical leadership, Java implementation, or performance work.
+- `Skills` provide focused Java, framework, testing, documentation, security, and observability practices.
+- `MCP Servers` connect agents to external tools and project context when available.
+
+A common path is:
+
+```text
+/create-issue -> /create-plan or /create-spec -> /implement-issue -> /profile or /benchmark
+```
+
+For documentation-only or planning work, you may stop after the issue, plan, specification, ADR, or diagram is complete.
+
+## Go deeper
+
+- [Commands inventory](./INVENTORY-COMMANDS-JAVA.md)
+- [Agents getting started](./GETTING-STARTED-AGENTS.md)
+- [Skills getting started](./GETTING-STARTED-SKILLS.md)
+- [Project workflows](./GETTING-STARTED-WORKFLOWS.md)
+- [Pipelines getting started](./GETTING-STARTED-PIPELINES.md)

--- a/documentation/guides/GETTING-STARTED-IN-5-MINUTES_ES.md
+++ b/documentation/guides/GETTING-STARTED-IN-5-MINUTES_ES.md
@@ -1,0 +1,102 @@
+# Primeros pasos en 5 minutos
+
+> **Idiomas:** [English](./GETTING-STARTED-IN-5-MINUTES.md) · [中文](./GETTING-STARTED-IN-5-MINUTES_ZH.md)
+
+Esta ruta ofrece a los usuarios nuevos un inicio pequeño y práctico antes de leer toda la documentación del proyecto.
+
+## 1. Instala Node.js si lo necesitas
+
+La CLI de Skills.sh se ejecuta mediante `npx`, así que necesitas tener Node.js disponible:
+
+```bash
+node --version
+npx --version
+```
+
+Si falta alguno de los comandos, instala Node.js con el gestor de paquetes de tu sistema operativo.
+
+## 2. Elige tu agente y descarga los Skills
+
+Instala todos los skills desde la [entrada del registry de Skills.sh](https://skills.sh/jabrena/cursor-rules-java) de este proyecto en el agente que uses con más frecuencia:
+
+```bash
+# Cursor
+npx skills add jabrena/cursor-rules-java --skill '*' --agent cursor -y
+
+# Claude Code
+npx skills add jabrena/cursor-rules-java --skill '*' --agent claude-code -y
+
+# Codex
+npx skills add jabrena/cursor-rules-java --skill '*' --agent codex -y
+
+# GitHub Copilot
+npx skills add jabrena/cursor-rules-java --skill '*' --agent github-copilot -y
+```
+
+Para instalar en todos los agentes soportados, usa el modo multiagente de la CLI:
+
+```bash
+npx skills add jabrena/cursor-rules-java --skill '*' --agent '*' -y
+```
+
+Para revisar primero los skills disponibles:
+
+```bash
+npx skills add jabrena/cursor-rules-java --list
+```
+
+## 3. Instala los commands del proyecto
+
+Después de instalar los skills, indica a tu agente qué AI agent harness usas: `cursor`, `claude-code`, `codex` o `github-copilot`.
+
+```text
+install @004-commands-installation cursor
+install @004-commands-installation claude-code
+install @004-commands-installation codex
+install @004-commands-installation github-copilot
+```
+
+El instalador copia los commands embebidos del proyecto en el directorio de commands de tu herramienta. Soporta destinos para Cursor, Claude, Codex y GitHub Copilot, y pregunta antes de escribir archivos.
+
+Los destinos habituales para commands son:
+
+- `.cursor/command`
+- `.claude/commands`
+- `.codex/commands`
+- `.github/commands`
+
+## 4. Instala los agents del proyecto cuando tu herramienta los soporte
+
+Commands y skills son suficientes para empezar. Si también quieres usar los robot agents predefinidos, indica a tu agente qué AI agent harness usas: `cursor` o `claude-code`.
+
+```text
+install @005-agents-installation cursor
+install @005-agents-installation claude-code
+```
+
+El instalador soporta `.cursor/agents` y `.claude/agents`.
+
+## 5. Usa el workflow
+
+Este proyecto organiza el trabajo Java asistido por IA alrededor de cuatro bloques:
+
+- `Commands` son los puntos de entrada, como `/create-issue`, `/update-issue`, `/create-plan`, `/create-spec` y `/implement-issue`.
+- `Agents` definen responsabilidades, como análisis de negocio, arquitectura, liderazgo técnico, implementación Java o trabajo de rendimiento.
+- `Skills` aportan prácticas enfocadas para Java, frameworks, testing, documentación, seguridad y observabilidad.
+- `MCP Servers` conectan los agentes con herramientas externas y contexto del proyecto cuando están disponibles.
+
+Una ruta habitual es:
+
+```text
+/create-issue -> /create-plan or /create-spec -> /implement-issue -> /profile or /benchmark
+```
+
+Para trabajo solo de documentación o planificación, puedes detenerte cuando el issue, plan, especificación, ADR o diagrama esté completo.
+
+## Profundiza
+
+- [Inventario de commands](./INVENTORY-COMMANDS-JAVA.md)
+- [Primeros pasos con agents](./GETTING-STARTED-AGENTS_ES.md)
+- [Primeros pasos con skills](./GETTING-STARTED-SKILLS_ES.md)
+- [Workflows del proyecto](./GETTING-STARTED-WORKFLOWS_ES.md)
+- [Primeros pasos con pipelines](./GETTING-STARTED-PIPELINES_ES.md)

--- a/documentation/guides/GETTING-STARTED-IN-5-MINUTES_ZH.md
+++ b/documentation/guides/GETTING-STARTED-IN-5-MINUTES_ZH.md
@@ -1,0 +1,102 @@
+# 5 分钟快速入门
+
+> **语言：** [English](./GETTING-STARTED-IN-5-MINUTES.md) · [Español](./GETTING-STARTED-IN-5-MINUTES_ES.md)
+
+这条路径为首次使用者提供一个小而实用的起点，方便你在阅读完整项目文档之前先动手尝试。
+
+## 1. 如果需要，先安装 Node.js
+
+Skills.sh CLI 通过 `npx` 运行，因此你需要可用的 Node.js：
+
+```bash
+node --version
+npx --version
+```
+
+如果其中任一命令不可用，请使用你的操作系统包管理器安装 Node.js。
+
+## 2. 选择你的 agent 并下载 Skills
+
+从本项目的 [Skills.sh registry 条目](https://skills.sh/jabrena/cursor-rules-java) 将所有 skills 安装到你最常用的 agent：
+
+```bash
+# Cursor
+npx skills add jabrena/cursor-rules-java --skill '*' --agent cursor -y
+
+# Claude Code
+npx skills add jabrena/cursor-rules-java --skill '*' --agent claude-code -y
+
+# Codex
+npx skills add jabrena/cursor-rules-java --skill '*' --agent codex -y
+
+# GitHub Copilot
+npx skills add jabrena/cursor-rules-java --skill '*' --agent github-copilot -y
+```
+
+如果要安装到所有受支持的 agent，请使用 CLI 的全 agent 模式：
+
+```bash
+npx skills add jabrena/cursor-rules-java --skill '*' --agent '*' -y
+```
+
+如果想先查看可用 skills：
+
+```bash
+npx skills add jabrena/cursor-rules-java --list
+```
+
+## 3. 安装项目 commands
+
+安装 skills 后，告诉你的 agent 你使用的 AI agent harness 工具：`cursor`、`claude-code`、`codex` 或 `github-copilot`。
+
+```text
+install @004-commands-installation cursor
+install @004-commands-installation claude-code
+install @004-commands-installation codex
+install @004-commands-installation github-copilot
+```
+
+安装器会把项目内嵌 commands 复制到你的工具对应的 command 目录。它支持 Cursor、Claude、Codex 和 GitHub Copilot 的 command 目标目录，并且会在写入文件前询问确认。
+
+常见的 command 目标目录包括：
+
+- `.cursor/command`
+- `.claude/commands`
+- `.codex/commands`
+- `.github/commands`
+
+## 4. 当工具支持时安装项目 agents
+
+Commands 和 skills 已足够开始使用。如果你还想使用预定义的 robot agents，请告诉你的 agent 你使用的 AI agent harness 工具：`cursor` 或 `claude-code`。
+
+```text
+install @005-agents-installation cursor
+install @005-agents-installation claude-code
+```
+
+安装器支持 `.cursor/agents` 和 `.claude/agents`。
+
+## 5. 使用 workflow
+
+本项目围绕四个构建块组织 AI 辅助的 Java 工作：
+
+- `Commands` 是入口点，例如 `/create-issue`、`/update-issue`、`/create-plan`、`/create-spec` 和 `/implement-issue`。
+- `Agents` 定义职责，例如业务分析、架构、技术领导、Java 实现或性能工作。
+- `Skills` 提供面向 Java、框架、测试、文档、安全和可观测性的具体实践。
+- `MCP Servers` 在可用时把 agents 连接到外部工具和项目上下文。
+
+一个常见路径是：
+
+```text
+/create-issue -> /create-plan or /create-spec -> /implement-issue -> /profile or /benchmark
+```
+
+对于只涉及文档或规划的工作，你可以在 issue、plan、specification、ADR 或 diagram 完成后停止。
+
+## 深入了解
+
+- [Commands 清单](./INVENTORY-COMMANDS-JAVA.md)
+- [Agents 快速入门](./GETTING-STARTED-AGENTS_ZH.md)
+- [Skills 快速入门](./GETTING-STARTED-SKILLS_ZH.md)
+- [项目 workflows](./GETTING-STARTED-WORKFLOWS_ZH.md)
+- [Pipelines 快速入门](./GETTING-STARTED-PIPELINES_ZH.md)


### PR DESCRIPTION
## Summary

- Add a concise README entry point for first-time users.
- Add English, Spanish, and Chinese 5-minute getting-started guides.
- Document Skills.sh install commands plus command and agent installation prompts for Cursor, Claude Code, Codex, and GitHub Copilot where supported.

## Test plan

- `./mvnw validate`
- `jbang .github/scripts/MarkdownValidator.java --verbose .`

Closes #811

Made with [Cursor](https://cursor.com)