### PR TITLE
docs: Add JavaDoc to SumResponse class

### DIFF
--- a/examples/frameworks/spring-boot/src/main/java/info/jab/ms/dto/SumResponse.java
+++ b/examples/frameworks/spring-boot/src/main/java/info/jab/ms/dto/SumResponse.java
@@ -1,4 +1,10 @@
 package info.jab.ms.dto;
 
+/**
+ * Response object for sum operations.
+ * Encapsulates the result of a sum calculation.
+ *
+ * @param result the result of the sum as an Integer
+ */
 public record SumResponse(Integer result) {
 }


### PR DESCRIPTION
### 问题背景
The `SumResponse` class is a public record used in the Spring Boot example, but it lacks JavaDoc comments. This reduces code readability and maintainability, especially for public APIs, making it harder for developers and AI tools to understand its purpose.

### 修改内容
- **修改了什么**: Added a JavaDoc comment to the `SumResponse` record class, describing its purpose and the `result` parameter.
- **为什么这样改**: To enhance code documentation and align with best practices for public API design, improving clarity for users and maintainers.
- **提升**: Improves code quality by providing essential documentation without altering functionality.

### 验证方式
- Existing tests should continue to pass as this change is documentation-only and does not affect behavior.
- No new tests are required since it's a minor doc update.
- Manual verification by reviewing the added JavaDoc for accuracy.

### 其他信息
- No breaking changes.
- No updates to external documentation needed.
- No known limitations.