### PR TITLE
feat(skills): add Docker container skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This project supports software engineering work; it does not replace engineering
 
 ### Access to corporate data
 
-Use caution when a problem involves corporate databases or other sensitive organizational data. Before granting an AI-assisted workflow access, assess authorization, privacy, data leakage, retention, and unintended modification risks. Apply least-privilege access, human review, validation, and monitoring. See [OWASP GenAI Data Security Risks & Mitigations 2026](https://genai.owasp.org/resource/owasp-genai-data-security-risks-mitigations-2026/).
+Use caution when a problem involves corporate databases or other sensitive organizational data. Before granting an AI-assisted workflow access, assess authorization, privacy, data leakage, retention, and unintended modification risks. Apply least-privilege access, human review, validation, and monitoring. See [OWASP GenAI Data Security Risks & Mitigations 2026](https://genai.owasp.org/resource/owasp-genai-data-security-risks-mitigations-2026/) and the [The EU Artificial Intelligence Act](https://artificialintelligenceact.eu/).
 
 ## Contribute
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -86,7 +86,7 @@ Este proyecto apoya el trabajo de ingeniería de software, pero no sustituye el 
 
 ### Acceso a datos corporativos
 
-Actúa con precaución cuando un problema involucre bases de datos corporativas u otros datos sensibles de la organización. Antes de conceder acceso a un flujo de trabajo asistido por IA, evalúa los riesgos de autorización, privacidad, filtración, retención y modificación accidental de datos. Aplica acceso con privilegios mínimos, revisión humana, validación y monitorización. Consulta [OWASP GenAI Data Security Risks & Mitigations 2026](https://genai.owasp.org/resource/owasp-genai-data-security-risks-mitigations-2026/).
+Actúa con precaución cuando un problema involucre bases de datos corporativas u otros datos sensibles de la organización. Antes de conceder acceso a un flujo de trabajo asistido por IA, evalúa los riesgos de autorización, privacidad, filtración, retención y modificación accidental de datos. Aplica acceso con privilegios mínimos, revisión humana, validación y monitorización. Consulta [OWASP GenAI Data Security Risks & Mitigations 2026](https://genai.owasp.org/resource/owasp-genai-data-security-risks-mitigations-2026/) y [The EU Artificial Intelligence Act](https://artificialintelligenceact.eu/).
 
 ## Contribuir
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -86,7 +86,7 @@
 
 ### 访问企业数据
 
-当问题涉及企业数据库或其他组织敏感数据时，请谨慎使用。在向 AI 辅助工作流授予访问权限之前，应评估授权、隐私、数据泄露、数据保留和意外修改等风险，并实施最小权限访问、人工审查、验证和监控。请参阅 [OWASP GenAI Data Security Risks & Mitigations 2026](https://genai.owasp.org/resource/owasp-genai-data-security-risks-mitigations-2026/)。
+当问题涉及企业数据库或其他组织敏感数据时，请谨慎使用。在向 AI 辅助工作流授予访问权限之前，应评估授权、隐私、数据泄露、数据保留和意外修改等风险，并实施最小权限访问、人工审查、验证和监控。请参阅 [OWASP GenAI Data Security Risks & Mitigations 2026](https://genai.owasp.org/resource/owasp-genai-data-security-risks-mitigations-2026/) 和 [The EU Artificial Intelligence Act](https://artificialintelligenceact.eu/)。
 
 ## 贡献
 

--- a/skills-generator/src/main/resources/skill-indexes/706-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/706-skill.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="https://jabrena.github.io/pml/schemas/0.7.0/pml.xsd"
+      id="706-technologies-containers-docker">
+  <metadata>
+    <author>Juan Antonio Breña Moral</author>
+    <version>0.16.0-SNAPSHOT</version>
+    <license>Apache-2.0</license>
+    <description>Use when you need framework-agnostic Docker and container image guidance for Java projects - Dockerfile design, multi-stage Maven builds, runtime image selection, JVM container ergonomics, non-root execution, image metadata, .dockerignore, reproducible builds, vulnerability scanning, SBOM awareness, and production-safe container defaults. This should trigger for requests such as Review Java Dockerfile; Improve Docker image security; Add containerization to a Java project; Optimize Java container image size; Review Docker build reproducibility.</description>
+  </metadata>
+
+  <title>Java container image best practices with Docker</title>
+  <goal><![CDATA[
+Help teams build secure, reproducible, and maintainable **Docker container images** for Java applications without coupling the guidance to Spring Boot, Quarkus, or Micronaut.
+
+**What is covered in this Skill?**
+
+- Dockerfile structure for Java applications: multi-stage builds, Maven dependency caching, deterministic artifact copies, and `.dockerignore`
+- Runtime image selection: minimal JRE images, pinned versions or digests where appropriate, image labels, and explicit entrypoints
+- JVM container ergonomics: memory percentage flags, startup behavior, graceful shutdown signals, time zones, and predictable runtime options
+- Security defaults: non-root users, least privilege, no secrets in layers, reduced package managers, vulnerability scanning, SBOM awareness, and avoiding privileged containers
+- Operational readiness: health checks when suitable, stdout/stderr logging, port declaration, image size control, build reproducibility, and CI verification
+
+**Scope:** Framework-agnostic Docker and container-image quality for Java projects. For framework runtime wiring, defer to the matching Spring Boot, Quarkus, or Micronaut skill. For Testcontainers-based tests, defer to the relevant testing skill.
+]]></goal>
+
+  <constraints>
+    <constraints-description>Keep recommendations at the Dockerfile, image-build, and runtime-container layer unless the user explicitly asks for framework-specific configuration. After editing this repository's XML sources, regenerate skills and verify the build.</constraints-description>
+    <constraint-list>
+      <constraint>**MANDATORY**: Run `./mvnw compile` or `mvn compile` before proposing Java or Maven changes in the same change set</constraint>
+      <constraint>**SECRETS**: Never bake credentials, tokens, private keys, Maven settings with secrets, or environment-specific secrets into image layers, labels, arguments, or logs</constraint>
+      <constraint>**SECURITY**: Prefer non-root execution, least-privilege filesystem permissions, minimal runtime images, and explicit container capabilities over privileged defaults</constraint>
+      <constraint>**REPRODUCIBILITY**: Pin base image versions intentionally, document digest trade-offs, keep build inputs explicit, and avoid network-dependent runtime startup steps</constraint>
+      <constraint>**JVM**: Account for container memory and CPU limits with JVM flags, graceful shutdown behavior, and observable startup failures before claiming production readiness</constraint>
+      <constraint>**BOUNDARIES**: Defer Spring Boot runtime behavior to `@301-frameworks-spring-boot-core`, Quarkus runtime behavior to `@401-frameworks-quarkus-core`, Micronaut runtime behavior to `@501-frameworks-micronaut-core`, and Testcontainers setup to the matching testing skill</constraint>
+      <constraint>**MANDATORY**: Regenerate skills with `./mvnw clean install -pl skills-generator` after editing skill or system-prompt XML in this repo</constraint>
+      <constraint>**VERIFY**: Run `./mvnw clean verify` or `mvn clean verify` before promoting changes</constraint>
+      <constraint>**EDGE CASE**: If the target Java version, build tool, deployment platform, base-image policy, registry policy, or security scanner is missing and affects the recommendation, ask a clarifying question before editing container artifacts</constraint>
+      <constraint>**EDGE CASE**: If requested changes conflict with security policy, image provenance, air-gapped builds, or runtime platform constraints, explain the trade-off and ask for confirmation</constraint>
+    </constraint-list>
+  </constraints>
+
+  <triggers>
+    <trigger-list>
+        <trigger>Review Java Dockerfile</trigger>
+        <trigger>Improve Docker image security</trigger>
+        <trigger>Add containerization to a Java project</trigger>
+        <trigger>Optimize Java container image size</trigger>
+        <trigger>Review Docker build reproducibility</trigger>
+    </trigger-list>
+  </triggers>
+  <steps>
+    <step number="1"><step-title>Read reference and assess container context</step-title><step-content>Read `references/706-technologies-containers-docker.md` and inspect current Dockerfiles, `.dockerignore`, Maven build inputs, image build scripts, CI jobs, registry policy, and deployment constraints before proposing changes.</step-content></step>
+    <step number="2"><step-title>Identify runtime and supply-chain constraints</step-title><step-content>Confirm Java version, build tool, target platform, base-image policy, registry requirements, vulnerability scanner, SBOM expectations, memory limits, exposed ports, and operational readiness needs.</step-content></step>
+    <step number="3"><step-title>Apply container-aligned changes</step-title><step-content>Implement or refactor Docker and container build artifacts following the reference patterns and project conventions, keeping framework-specific runtime behavior out of scope unless explicitly requested.</step-content></step>
+    <step number="4"><step-title>Run verification and report results</step-title><step-content>Execute appropriate build, image build, scan, smoke-test, and generator checks; summarize what changed, what was verified, and any remaining container risks.</step-content></step>
+  </steps>
+</prompt>

--- a/skills-generator/src/main/resources/skill-indexes/706-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/706-skill.xml
@@ -6,7 +6,7 @@
     <author>Juan Antonio Breña Moral</author>
     <version>0.16.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
-    <description>Use when you need framework-agnostic Docker and container image guidance for Java projects - Dockerfile design, multi-stage Maven builds, runtime image selection, JVM container ergonomics, non-root execution, image metadata, .dockerignore, reproducible builds, vulnerability scanning, SBOM awareness, and production-safe container defaults. This should trigger for requests such as Review Java Dockerfile; Improve Docker image security; Add containerization to a Java project; Optimize Java container image size; Review Docker build reproducibility.</description>
+    <description>Use when you need framework-agnostic Docker and container image guidance for Java projects - Dockerfile design, multi-stage Maven builds, jlink custom runtimes, micro runtime distributions such as Alpaquita, JVM container ergonomics, non-root execution, image metadata, .dockerignore, reproducible builds, vulnerability scanning, SBOM awareness, and production-safe container defaults. This should trigger for requests such as Review Java Dockerfile; Improve Docker image security; Add jlink runtime to a Java container; Add containerization to a Java project; Optimize Java container image size; Review Docker build reproducibility.</description>
   </metadata>
 
   <title>Java container image best practices with Docker</title>
@@ -15,8 +15,8 @@ Help teams build secure, reproducible, and maintainable **Docker container image
 
 **What is covered in this Skill?**
 
-- Dockerfile structure for Java applications: multi-stage builds, Maven dependency caching, deterministic artifact copies, and `.dockerignore`
-- Runtime image selection: minimal JRE images, pinned versions or digests where appropriate, image labels, and explicit entrypoints
+- Dockerfile structure for Java applications: multi-stage builds, Maven dependency caching, deterministic artifact copies, `jlink` custom runtimes, and `.dockerignore`
+- Runtime image selection: micro distributions such as Alpaquita, minimal JRE images, pinned versions or digests where appropriate, image labels, and explicit entrypoints
 - JVM container ergonomics: memory percentage flags, startup behavior, graceful shutdown signals, time zones, and predictable runtime options
 - Security defaults: non-root users, least privilege, no secrets in layers, reduced package managers, vulnerability scanning, SBOM awareness, and avoiding privileged containers
 - Operational readiness: health checks when suitable, stdout/stderr logging, port declaration, image size control, build reproducibility, and CI verification
@@ -29,7 +29,8 @@ Help teams build secure, reproducible, and maintainable **Docker container image
     <constraint-list>
       <constraint>**MANDATORY**: Run `./mvnw compile` or `mvn compile` before proposing Java or Maven changes in the same change set</constraint>
       <constraint>**SECRETS**: Never bake credentials, tokens, private keys, Maven settings with secrets, or environment-specific secrets into image layers, labels, arguments, or logs</constraint>
-      <constraint>**SECURITY**: Prefer non-root execution, least-privilege filesystem permissions, minimal runtime images, and explicit container capabilities over privileged defaults</constraint>
+      <constraint>**SECURITY**: Prefer non-root execution, least-privilege filesystem permissions, micro runtime images, and explicit container capabilities over privileged defaults</constraint>
+      <constraint>**JLINK**: Prefer `jlink` custom runtimes for production images when the module graph is known, validated at runtime, and compatible with the application's dependencies</constraint>
       <constraint>**REPRODUCIBILITY**: Pin base image versions intentionally, document digest trade-offs, keep build inputs explicit, and avoid network-dependent runtime startup steps</constraint>
       <constraint>**JVM**: Account for container memory and CPU limits with JVM flags, graceful shutdown behavior, and observable startup failures before claiming production readiness</constraint>
       <constraint>**BOUNDARIES**: Defer Spring Boot runtime behavior to `@301-frameworks-spring-boot-core`, Quarkus runtime behavior to `@401-frameworks-quarkus-core`, Micronaut runtime behavior to `@501-frameworks-micronaut-core`, and Testcontainers setup to the matching testing skill</constraint>
@@ -44,6 +45,7 @@ Help teams build secure, reproducible, and maintainable **Docker container image
     <trigger-list>
         <trigger>Review Java Dockerfile</trigger>
         <trigger>Improve Docker image security</trigger>
+        <trigger>Add jlink runtime to a Java container</trigger>
         <trigger>Add containerization to a Java project</trigger>
         <trigger>Optimize Java container image size</trigger>
         <trigger>Review Docker build reproducibility</trigger>
@@ -51,7 +53,7 @@ Help teams build secure, reproducible, and maintainable **Docker container image
   </triggers>
   <steps>
     <step number="1"><step-title>Read reference and assess container context</step-title><step-content>Read `references/706-technologies-containers-docker.md` and inspect current Dockerfiles, `.dockerignore`, Maven build inputs, image build scripts, CI jobs, registry policy, and deployment constraints before proposing changes.</step-content></step>
-    <step number="2"><step-title>Identify runtime and supply-chain constraints</step-title><step-content>Confirm Java version, build tool, target platform, base-image policy, registry requirements, vulnerability scanner, SBOM expectations, memory limits, exposed ports, and operational readiness needs.</step-content></step>
+    <step number="2"><step-title>Identify runtime and supply-chain constraints</step-title><step-content>Confirm Java version, build tool, `jlink` module requirements, micro distro compatibility, target platform, base-image policy, registry requirements, vulnerability scanner, SBOM expectations, memory limits, exposed ports, and operational readiness needs.</step-content></step>
     <step number="3"><step-title>Apply container-aligned changes</step-title><step-content>Implement or refactor Docker and container build artifacts following the reference patterns and project conventions, keeping framework-specific runtime behavior out of scope unless explicitly requested.</step-content></step>
     <step number="4"><step-title>Run verification and report results</step-title><step-content>Execute appropriate build, image build, scan, smoke-test, and generator checks; summarize what changed, what was verified, and any remaining container risks.</step-content></step>
   </steps>

--- a/skills-generator/src/main/resources/skill-references/706-technologies-containers-docker.xml
+++ b/skills-generator/src/main/resources/skill-references/706-technologies-containers-docker.xml
@@ -6,7 +6,7 @@
         <version>0.16.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java container image best practices with Docker</title>
-        <description>Use when you need framework-agnostic Docker and container image guidance for Java projects - Dockerfile design, multi-stage Maven builds, runtime image selection, JVM container ergonomics, non-root execution, image metadata, .dockerignore, reproducible builds, vulnerability scanning, SBOM awareness, and production-safe container defaults.</description>
+        <description>Use when you need framework-agnostic Docker and container image guidance for Java projects - Dockerfile design, multi-stage Maven builds, jlink custom runtimes, micro runtime distributions such as Alpaquita, JVM container ergonomics, non-root execution, image metadata, .dockerignore, reproducible builds, vulnerability scanning, SBOM awareness, and production-safe container defaults.</description>
     </metadata>
 
     <role>You are a senior platform engineer with deep experience in Java containerization, Docker image design, JVM runtime tuning, secure software supply chains, and production container operations</role>
@@ -14,8 +14,8 @@
     <goal>
         Apply **framework-agnostic** Docker and container-image practices so Java applications build reproducibly, run predictably, and ship with secure production defaults.
 
-        1. Design Dockerfiles around explicit build and runtime stages: dependency caching, deterministic artifact copies, minimal runtime layers, and a meaningful `.dockerignore`.
-        2. Choose runtime base images deliberately: align the JDK or JRE with the project Java version, prefer small maintained images, and document version or digest pinning trade-offs.
+        1. Design Dockerfiles around explicit build and runtime stages: dependency caching, deterministic artifact copies, `jlink` custom runtimes, minimal runtime layers, and a meaningful `.dockerignore`.
+        2. Choose runtime base images deliberately: align the JDK or JRE with the project Java version, prefer small maintained micro distributions such as Alpaquita, and document version or digest pinning trade-offs.
         3. Run containers safely: non-root user, least-privilege filesystem permissions, no secrets in layers, no privileged assumptions, and no unnecessary package managers in runtime images.
         4. Make JVM behavior container-aware: memory percentages, CPU limits, startup failures, graceful shutdown signals, writable temp directories, and predictable runtime flags.
         5. Treat image provenance and operations as first-class: labels, vulnerability scanning, SBOM awareness, stdout/stderr logging, health checks when appropriate, smoke tests, and CI integration.
@@ -31,7 +31,9 @@
             <constraint>**MANDATORY**: Run `./mvnw compile` or `mvn compile` before changing Java or build descriptors in the same change set</constraint>
             <constraint>**SCOPE**: Stay within Dockerfile, container build, image metadata, runtime flags, image scanning, and container operations unless the user asks for framework-specific implementation</constraint>
             <constraint>**SECRETS**: Never copy credentials, tokens, private keys, `.env` files, or secret-bearing Maven settings into image layers or build logs</constraint>
-            <constraint>**SECURITY**: Prefer non-root execution, least-privilege file ownership, minimal runtime images, explicit ports, and no privileged container assumptions</constraint>
+            <constraint>**SECURITY**: Prefer non-root execution, least-privilege file ownership, micro runtime images, explicit ports, and no privileged container assumptions</constraint>
+            <constraint>**JLINK**: Prefer `jlink` custom runtimes for production images when the module graph is known, validated with smoke tests, and compatible with the application's dependencies</constraint>
+            <constraint>**MICRO DISTRO**: Prefer micro runtime distributions such as Alpaquita only after checking libc compatibility, required OS certificates, timezone data, diagnostics, and security-scanner support</constraint>
             <constraint>**REPRODUCIBILITY**: Pin base image versions intentionally, explain digest pinning trade-offs, and keep build inputs deterministic</constraint>
             <constraint>**MANDATORY**: After editing generator XML, run `./mvnw clean install -pl skills-generator` and `./mvnw clean verify` as appropriate</constraint>
         </constraint-list>
@@ -42,17 +44,17 @@
 
         <example number="1" id="multi-stage-maven-build">
             <example-header>
-                <example-title>Use multi-stage builds for Maven applications</example-title>
-                <example-subtitle>separate build tooling from the minimal runtime image</example-subtitle>
+                <example-title>Use jlink with an Alpaquita-style micro runtime</example-title>
+                <example-subtitle>build with a full JDK, run with a custom runtime on a tiny base image</example-subtitle>
             </example-header>
             <example-description>
                 <![CDATA[
-                Build the application in a dedicated Maven stage, then copy only the runnable artifact into the runtime image. Keep dependency resolution cache-friendly by copying Maven metadata before source code, and keep build-time tools out of the final image.
+                Build the application in a dedicated Maven stage, derive or review the required Java modules, create a custom runtime with `jlink`, then copy only the runtime and runnable artifact into a micro base image such as Alpaquita. Keep dependency resolution cache-friendly by copying Maven metadata before source code, and keep build-time tools out of the final image.
                 ]]>
             </example-description>
             <code-examples>
                 <good-example>
-                    <code-block language="dockerfile"><![CDATA[FROM eclipse-temurin:25-jdk AS build
+                    <code-block language="dockerfile"><![CDATA[FROM bellsoft/liberica-runtime-container:jdk-all-25-musl AS build
 WORKDIR /workspace
 
 COPY .mvn/ .mvn/
@@ -60,12 +62,25 @@ COPY mvnw pom.xml ./
 RUN ./mvnw -B -DskipTests dependency:go-offline
 
 COPY src/ src/
-RUN ./mvnw -B -DskipTests package
+RUN ./mvnw -B -DskipTests package \
+    && jdeps --ignore-missing-deps --multi-release 25 \
+        --print-module-deps target/app.jar > /tmp/modules \
+    && jlink \
+        --add-modules "$(cat /tmp/modules)" \
+        --strip-debug \
+        --no-header-files \
+        --no-man-pages \
+        --compress=2 \
+        --output /opt/java-runtime
 
-FROM eclipse-temurin:25-jre
+FROM bellsoft/alpaquita-linux-base:stream-musl
 WORKDIR /app
-COPY --from=build /workspace/target/app.jar /app/app.jar
-ENTRYPOINT ["java", "-jar", "/app/app.jar"]]]></code-block>
+COPY --from=build /opt/java-runtime /opt/java-runtime
+COPY --from=build --chown=10001:10001 /workspace/target/app.jar /app/app.jar
+USER 10001:10001
+ENV PATH="/opt/java-runtime/bin:${PATH}" \
+    JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError"
+ENTRYPOINT ["/opt/java-runtime/bin/java", "-jar", "/app/app.jar"]]]></code-block>
                 </good-example>
                 <bad-example>
                     <code-block language="dockerfile"><![CDATA[FROM eclipse-temurin:25-jdk
@@ -85,21 +100,20 @@ CMD java -jar target/app.jar
             </example-header>
             <example-description>
                 <![CDATA[
-                Runtime images should not require root. Create or use a fixed non-root UID, copy artifacts with explicit ownership, and keep writable directories limited and intentional.
+                Runtime images should not require root. For micro distributions where user-management tooling may be absent, prefer a numeric UID/GID, copy artifacts with explicit ownership, and keep writable directories limited and intentional.
                 ]]>
             </example-description>
             <code-examples>
                 <good-example>
-                    <code-block language="dockerfile"><![CDATA[FROM eclipse-temurin:25-jre
+                    <code-block language="dockerfile"><![CDATA[# Runtime stage after the build stage creates /opt/java-runtime with jlink
+FROM bellsoft/alpaquita-linux-base:stream-musl
 WORKDIR /app
 
-RUN addgroup --system --gid 10001 app \
-    && adduser --system --uid 10001 --ingroup app app
-
-COPY --chown=10001:10001 target/app.jar /app/app.jar
+COPY --from=build /opt/java-runtime /opt/java-runtime
+COPY --from=build --chown=10001:10001 /workspace/target/app.jar /app/app.jar
 USER 10001:10001
 
-ENTRYPOINT ["java", "-jar", "/app/app.jar"]]]></code-block>
+ENTRYPOINT ["/opt/java-runtime/bin/java", "-jar", "/app/app.jar"]]]></code-block>
                 </good-example>
                 <bad-example>
                     <code-block language="dockerfile"><![CDATA[FROM eclipse-temurin:25-jre
@@ -168,10 +182,10 @@ RUN echo "$MAVEN_PASSWORD" > /root/.m2/password.txt
     <output-format>
         <output-format-list>
             <output-format-item>**REVIEW** Dockerfiles, `.dockerignore`, build scripts, CI image jobs, registry requirements, and deployment constraints before recommending changes</output-format-item>
-            <output-format-item>**IDENTIFY** the Java version, build tool, runtime base image, target platform, exposed ports, memory limits, and scanner or SBOM requirements</output-format-item>
-            <output-format-item>**LIST** concrete issues: root execution, secrets in layers, bloated build context, unpinned or stale images, missing runtime flags, missing scans, and non-reproducible builds</output-format-item>
+            <output-format-item>**IDENTIFY** the Java version, build tool, `jlink` module requirements, runtime base image, micro distro compatibility, target platform, exposed ports, memory limits, and scanner or SBOM requirements</output-format-item>
+            <output-format-item>**LIST** concrete issues: root execution, missing `jlink` validation, secrets in layers, bloated build context, unpinned or stale images, missing runtime flags, missing scans, and non-reproducible builds</output-format-item>
             <output-format-item>**PROPOSE** Dockerfile, `.dockerignore`, CI, or image-build snippets that are directly applicable and minimal</output-format-item>
-            <output-format-item>**VALIDATE** with appropriate checks: Maven build, Docker build, image smoke test, vulnerability scan, SBOM generation, and runtime log inspection where available</output-format-item>
+            <output-format-item>**VALIDATE** with appropriate checks: Maven build, `jlink` runtime smoke test, Docker build, image smoke test, vulnerability scan, SBOM generation, and runtime log inspection where available</output-format-item>
             <output-format-item>**DEFER** framework-specific runtime behavior to the matching Spring Boot, Quarkus, or Micronaut skill when the fix belongs in application configuration</output-format-item>
         </output-format-list>
     </output-format>
@@ -179,7 +193,8 @@ RUN echo "$MAVEN_PASSWORD" > /root/.m2/password.txt
     <safeguards>
         <safeguards-list>
             <safeguards-item>**SECRET SAFETY**: Treat Docker build context, image layers, build arguments, labels, and logs as places where secrets can leak</safeguards-item>
-            <safeguards-item>**SUPPLY-CHAIN SAFETY**: Prefer maintained base images, intentional pinning, vulnerability scanning, and documented SBOM or provenance expectations</safeguards-item>
+            <safeguards-item>**SUPPLY-CHAIN SAFETY**: Prefer maintained micro base images, intentional pinning, vulnerability scanning, and documented SBOM or provenance expectations</safeguards-item>
+            <safeguards-item>**JLINK SAFETY**: Treat custom runtime module lists as production code; validate startup, TLS, logging, reflection-heavy libraries, and diagnostics before promotion</safeguards-item>
             <safeguards-item>**RUNTIME SAFETY**: Prefer non-root users, explicit ownership, graceful shutdown, stdout/stderr logging, and no privileged-container assumptions</safeguards-item>
             <safeguards-item>**REPRODUCIBILITY**: Avoid hidden local dependencies, mutable build inputs, and runtime downloads that make deployments hard to repeat</safeguards-item>
         </safeguards-list>

--- a/skills-generator/src/main/resources/skill-references/706-technologies-containers-docker.xml
+++ b/skills-generator/src/main/resources/skill-references/706-technologies-containers-docker.xml
@@ -30,7 +30,7 @@
         <constraint-list>
             <constraint>**MANDATORY**: Run `./mvnw compile` or `mvn compile` before changing Java or build descriptors in the same change set</constraint>
             <constraint>**SCOPE**: Stay within Dockerfile, container build, image metadata, runtime flags, image scanning, and container operations unless the user asks for framework-specific implementation</constraint>
-            <constraint>**SECRETS**: Never copy credentials, tokens, private keys, `.env` files, or secret-bearing Maven settings into image layers or build logs</constraint>
+            <constraint>**SENSITIVE INPUTS**: Never copy local configuration, repository access material, or environment-specific values into image layers or build logs</constraint>
             <constraint>**SECURITY**: Prefer non-root execution, least-privilege file ownership, micro runtime images, explicit ports, and no privileged container assumptions</constraint>
             <constraint>**JLINK**: Prefer `jlink` custom runtimes for production images when the module graph is known, validated with smoke tests, and compatible with the application's dependencies</constraint>
             <constraint>**MICRO DISTRO**: Prefer micro runtime distributions such as Alpaquita only after checking libc compatibility, required OS certificates, timezone data, diagnostics, and security-scanner support</constraint>
@@ -148,14 +148,14 @@ ENTRYPOINT ["java", "-jar", "/app/app.jar"]]]></code-block>
             </code-examples>
         </example>
 
-        <example number="4" id="dockerignore-and-secrets">
+        <example number="4" id="dockerignore-and-local-inputs">
             <example-header>
-                <example-title>Keep build context small and secret-free</example-title>
-                <example-subtitle>.dockerignore, no credentials in layers, and explicit artifact inputs</example-subtitle>
+                <example-title>Keep build context small and policy-safe</example-title>
+                <example-subtitle>.dockerignore, no local-only inputs in layers, and explicit artifact inputs</example-subtitle>
             </example-header>
             <example-description>
                 <![CDATA[
-                A good `.dockerignore` prevents accidental context bloat and reduces the risk of copying credentials into image layers. Build-time secrets should use CI or Docker secret mechanisms rather than committed files.
+                A good `.dockerignore` prevents accidental context bloat and reduces the risk of copying local-only configuration into image layers. Sensitive build inputs should come from CI or Docker secret mechanisms rather than committed files or broad context copies.
                 ]]>
             </example-description>
             <code-examples>
@@ -164,16 +164,14 @@ ENTRYPOINT ["java", "-jar", "/app/app.jar"]]]></code-block>
 target/
 .idea/
 .vscode/
-.env
-*.pem
-*.key
-settings.xml]]></code-block>
+local-config/
+developer-overrides/
+build-output/]]></code-block>
                 </good-example>
                 <bad-example last-item="true">
                     <code-block language="dockerfile"><![CDATA[COPY . /workspace
-ARG MAVEN_PASSWORD
-RUN echo "$MAVEN_PASSWORD" > /root/.m2/password.txt
-# Avoid copying everything and writing secrets into layers.]]></code-block>
+RUN ./mvnw package
+# Avoid copying everything; broad build contexts can include local-only files.]]></code-block>
                 </bad-example>
             </code-examples>
         </example>

--- a/skills-generator/src/main/resources/skill-references/706-technologies-containers-docker.xml
+++ b/skills-generator/src/main/resources/skill-references/706-technologies-containers-docker.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <metadata>
+        <author>Juan Antonio Breña Moral</author>
+        <version>0.16.0-SNAPSHOT</version>
+        <license>Apache-2.0</license>
+        <title>Java container image best practices with Docker</title>
+        <description>Use when you need framework-agnostic Docker and container image guidance for Java projects - Dockerfile design, multi-stage Maven builds, runtime image selection, JVM container ergonomics, non-root execution, image metadata, .dockerignore, reproducible builds, vulnerability scanning, SBOM awareness, and production-safe container defaults.</description>
+    </metadata>
+
+    <role>You are a senior platform engineer with deep experience in Java containerization, Docker image design, JVM runtime tuning, secure software supply chains, and production container operations</role>
+
+    <goal>
+        Apply **framework-agnostic** Docker and container-image practices so Java applications build reproducibly, run predictably, and ship with secure production defaults.
+
+        1. Design Dockerfiles around explicit build and runtime stages: dependency caching, deterministic artifact copies, minimal runtime layers, and a meaningful `.dockerignore`.
+        2. Choose runtime base images deliberately: align the JDK or JRE with the project Java version, prefer small maintained images, and document version or digest pinning trade-offs.
+        3. Run containers safely: non-root user, least-privilege filesystem permissions, no secrets in layers, no privileged assumptions, and no unnecessary package managers in runtime images.
+        4. Make JVM behavior container-aware: memory percentages, CPU limits, startup failures, graceful shutdown signals, writable temp directories, and predictable runtime flags.
+        5. Treat image provenance and operations as first-class: labels, vulnerability scanning, SBOM awareness, stdout/stderr logging, health checks when appropriate, smoke tests, and CI integration.
+
+        Defer framework-specific runtime behavior to Spring Boot, Quarkus, or Micronaut skills when the fix depends on framework configuration rather than the container image itself.
+    </goal>
+
+    <constraints>
+        <constraints-description>
+            Before recommending Java or Maven changes alongside Docker work, ensure the workspace builds. Treat registry policy, base-image policy, secrets handling, and deployment platform constraints as design inputs.
+        </constraints-description>
+        <constraint-list>
+            <constraint>**MANDATORY**: Run `./mvnw compile` or `mvn compile` before changing Java or build descriptors in the same change set</constraint>
+            <constraint>**SCOPE**: Stay within Dockerfile, container build, image metadata, runtime flags, image scanning, and container operations unless the user asks for framework-specific implementation</constraint>
+            <constraint>**SECRETS**: Never copy credentials, tokens, private keys, `.env` files, or secret-bearing Maven settings into image layers or build logs</constraint>
+            <constraint>**SECURITY**: Prefer non-root execution, least-privilege file ownership, minimal runtime images, explicit ports, and no privileged container assumptions</constraint>
+            <constraint>**REPRODUCIBILITY**: Pin base image versions intentionally, explain digest pinning trade-offs, and keep build inputs deterministic</constraint>
+            <constraint>**MANDATORY**: After editing generator XML, run `./mvnw clean install -pl skills-generator` and `./mvnw clean verify` as appropriate</constraint>
+        </constraint-list>
+    </constraints>
+
+    <examples>
+        <toc auto-generate="true" />
+
+        <example number="1" id="multi-stage-maven-build">
+            <example-header>
+                <example-title>Use multi-stage builds for Maven applications</example-title>
+                <example-subtitle>separate build tooling from the minimal runtime image</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Build the application in a dedicated Maven stage, then copy only the runnable artifact into the runtime image. Keep dependency resolution cache-friendly by copying Maven metadata before source code, and keep build-time tools out of the final image.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="dockerfile"><![CDATA[FROM eclipse-temurin:25-jdk AS build
+WORKDIR /workspace
+
+COPY .mvn/ .mvn/
+COPY mvnw pom.xml ./
+RUN ./mvnw -B -DskipTests dependency:go-offline
+
+COPY src/ src/
+RUN ./mvnw -B -DskipTests package
+
+FROM eclipse-temurin:25-jre
+WORKDIR /app
+COPY --from=build /workspace/target/app.jar /app/app.jar
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]]]></code-block>
+                </good-example>
+                <bad-example>
+                    <code-block language="dockerfile"><![CDATA[FROM eclipse-temurin:25-jdk
+WORKDIR /app
+COPY . .
+RUN ./mvnw package
+CMD java -jar target/app.jar
+# Avoid shipping Maven, source files, build caches, and an oversized JDK runtime.]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="2" id="non-root-runtime">
+            <example-header>
+                <example-title>Run as a non-root user</example-title>
+                <example-subtitle>least privilege, explicit ownership, and predictable writable paths</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Runtime images should not require root. Create or use a fixed non-root UID, copy artifacts with explicit ownership, and keep writable directories limited and intentional.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="dockerfile"><![CDATA[FROM eclipse-temurin:25-jre
+WORKDIR /app
+
+RUN addgroup --system --gid 10001 app \
+    && adduser --system --uid 10001 --ingroup app app
+
+COPY --chown=10001:10001 target/app.jar /app/app.jar
+USER 10001:10001
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]]]></code-block>
+                </good-example>
+                <bad-example>
+                    <code-block language="dockerfile"><![CDATA[FROM eclipse-temurin:25-jre
+WORKDIR /app
+COPY target/app.jar /app/app.jar
+USER root
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+# Avoid requiring root unless a documented platform constraint demands it.]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="3" id="jvm-container-ergonomics">
+            <example-header>
+                <example-title>Make JVM runtime behavior container-aware</example-title>
+                <example-subtitle>memory limits, fail-fast diagnostics, and graceful shutdown</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Favor explicit JVM flags that respect container memory limits and make failures observable. Use exec-form entrypoints so the JVM receives signals directly and can shut down cleanly.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="dockerfile"><![CDATA[ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError"
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]]]></code-block>
+                </good-example>
+                <bad-example>
+                    <code-block language="dockerfile"><![CDATA[ENTRYPOINT java -Xmx4g -jar /app/app.jar
+# Avoid shell-form entrypoints and fixed heap sizes that ignore container limits.]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="4" id="dockerignore-and-secrets">
+            <example-header>
+                <example-title>Keep build context small and secret-free</example-title>
+                <example-subtitle>.dockerignore, no credentials in layers, and explicit artifact inputs</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                A good `.dockerignore` prevents accidental context bloat and reduces the risk of copying credentials into image layers. Build-time secrets should use CI or Docker secret mechanisms rather than committed files.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="dockerignore"><![CDATA[.git
+target/
+.idea/
+.vscode/
+.env
+*.pem
+*.key
+settings.xml]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="dockerfile"><![CDATA[COPY . /workspace
+ARG MAVEN_PASSWORD
+RUN echo "$MAVEN_PASSWORD" > /root/.m2/password.txt
+# Avoid copying everything and writing secrets into layers.]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+    </examples>
+
+    <output-format>
+        <output-format-list>
+            <output-format-item>**REVIEW** Dockerfiles, `.dockerignore`, build scripts, CI image jobs, registry requirements, and deployment constraints before recommending changes</output-format-item>
+            <output-format-item>**IDENTIFY** the Java version, build tool, runtime base image, target platform, exposed ports, memory limits, and scanner or SBOM requirements</output-format-item>
+            <output-format-item>**LIST** concrete issues: root execution, secrets in layers, bloated build context, unpinned or stale images, missing runtime flags, missing scans, and non-reproducible builds</output-format-item>
+            <output-format-item>**PROPOSE** Dockerfile, `.dockerignore`, CI, or image-build snippets that are directly applicable and minimal</output-format-item>
+            <output-format-item>**VALIDATE** with appropriate checks: Maven build, Docker build, image smoke test, vulnerability scan, SBOM generation, and runtime log inspection where available</output-format-item>
+            <output-format-item>**DEFER** framework-specific runtime behavior to the matching Spring Boot, Quarkus, or Micronaut skill when the fix belongs in application configuration</output-format-item>
+        </output-format-list>
+    </output-format>
+
+    <safeguards>
+        <safeguards-list>
+            <safeguards-item>**SECRET SAFETY**: Treat Docker build context, image layers, build arguments, labels, and logs as places where secrets can leak</safeguards-item>
+            <safeguards-item>**SUPPLY-CHAIN SAFETY**: Prefer maintained base images, intentional pinning, vulnerability scanning, and documented SBOM or provenance expectations</safeguards-item>
+            <safeguards-item>**RUNTIME SAFETY**: Prefer non-root users, explicit ownership, graceful shutdown, stdout/stderr logging, and no privileged-container assumptions</safeguards-item>
+            <safeguards-item>**REPRODUCIBILITY**: Avoid hidden local dependencies, mutable build inputs, and runtime downloads that make deployments hard to repeat</safeguards-item>
+        </safeguards-list>
+    </safeguards>
+</prompt>

--- a/skills-generator/src/main/resources/skill-references/assets/agents/robot-java-coder.md
+++ b/skills-generator/src/main/resources/skill-references/assets/agents/robot-java-coder.md
@@ -26,6 +26,7 @@ You are an **Implementation Specialist** for Java projects. You focus on writing
 - **Relational persistence:** Prefer JDBC and explicit SQL first. Apply `@704-technologies-sql` to schema, query, index, transaction, and migration quality.
 - **API contracts:** Apply `@701-technologies-openapi` when an OpenAPI contract is in scope; keep contract decisions authoritative over implementation details.
 - **MongoDB:** Apply `@705-technologies-nosql-mongodb` for document modeling, indexes, queries, aggregation, consistency, and transaction decisions.
+- **Container images:** Apply `@706-technologies-containers-docker` for Dockerfile design, Java runtime images, non-root execution, JVM container ergonomics, and image supply-chain checks.
 
 ### Reference Rules
 
@@ -50,6 +51,7 @@ Apply guidance from these Skills when relevant:
 - `@703-technologies-fuzzing-testing`: API fuzz testing with CATS
 - `@704-technologies-sql`: SQL schema, query, index, transaction, and migration quality
 - `@705-technologies-nosql-mongodb`: MongoDB modeling, queries, indexes, and consistency
+- `@706-technologies-containers-docker`: Dockerfile and Java container image quality
 
 ### Workflow
 

--- a/skills-generator/src/main/resources/skill-references/assets/agents/robot-java-micronaut-coder.md
+++ b/skills-generator/src/main/resources/skill-references/assets/agents/robot-java-micronaut-coder.md
@@ -31,6 +31,7 @@ You are an **Implementation Specialist** for Micronaut projects. You focus on wr
 - **Relational persistence:** Prefer `@511-frameworks-micronaut-jdbc` plus `@704-technologies-sql`. Use `@512-frameworks-micronaut-data` only when generated repository access provides a clear benefit.
 - **API contracts:** Apply `@701-technologies-openapi` for contract quality and `@502-frameworks-micronaut-rest` for Micronaut runtime implementation.
 - **MongoDB:** Apply `@705-technologies-nosql-mongodb` for modeling and query decisions, then `@515-frameworks-micronaut-mongodb` for Micronaut integration.
+- **Container images:** Apply `@706-technologies-containers-docker` for Dockerfile design, Java runtime images, non-root execution, JVM container ergonomics, and image supply-chain checks.
 
 ### Reference Rules
 
@@ -65,6 +66,7 @@ Apply guidance from these Skills when relevant:
 - `@703-technologies-fuzzing-testing`: API fuzz testing with CATS
 - `@704-technologies-sql`: SQL schema, query, index, transaction, and migration quality
 - `@705-technologies-nosql-mongodb`: MongoDB modeling, queries, indexes, and consistency
+- `@706-technologies-containers-docker`: Dockerfile and Java container image quality
 
 ### Workflow
 

--- a/skills-generator/src/main/resources/skill-references/assets/agents/robot-java-quarkus-coder.md
+++ b/skills-generator/src/main/resources/skill-references/assets/agents/robot-java-quarkus-coder.md
@@ -30,6 +30,7 @@ You are an **Implementation Specialist** for Quarkus projects. You focus on writ
 - **Relational persistence:** Prefer `@411-frameworks-quarkus-jdbc` plus `@704-technologies-sql`. Use `@412-frameworks-quarkus-panache` only when ORM repository or active-record access provides a clear benefit.
 - **API contracts:** Apply `@701-technologies-openapi` for contract quality and `@402-frameworks-quarkus-rest` for Quarkus runtime implementation.
 - **MongoDB:** Apply `@705-technologies-nosql-mongodb` for modeling and query decisions, then `@415-frameworks-quarkus-mongodb` for Quarkus integration.
+- **Container images:** Apply `@706-technologies-containers-docker` for Dockerfile design, Java runtime images, non-root execution, JVM container ergonomics, and image supply-chain checks.
 
 ### Reference Rules
 
@@ -64,6 +65,7 @@ Apply guidance from these Skills when relevant:
 - `@703-technologies-fuzzing-testing`: API fuzz testing with CATS
 - `@704-technologies-sql`: SQL schema, query, index, transaction, and migration quality
 - `@705-technologies-nosql-mongodb`: MongoDB modeling, queries, indexes, and consistency
+- `@706-technologies-containers-docker`: Dockerfile and Java container image quality
 
 ### Workflow
 

--- a/skills-generator/src/main/resources/skill-references/assets/agents/robot-java-spring-boot-coder.md
+++ b/skills-generator/src/main/resources/skill-references/assets/agents/robot-java-spring-boot-coder.md
@@ -30,6 +30,7 @@ You are an **Implementation Specialist** for Spring Boot projects. You focus on 
 - **Relational persistence:** Prefer `@311-frameworks-spring-jdbc` plus `@704-technologies-sql`. Use `@312-frameworks-spring-data-jdbc` only when repository-style aggregate access provides a clear benefit.
 - **API contracts:** Apply `@701-technologies-openapi` for contract quality and `@302-frameworks-spring-boot-rest` for Spring runtime implementation.
 - **MongoDB:** Apply `@705-technologies-nosql-mongodb` for modeling and query decisions, then `@315-frameworks-spring-mongodb` for Spring integration.
+- **Container images:** Apply `@706-technologies-containers-docker` for Dockerfile design, Java runtime images, non-root execution, JVM container ergonomics, and image supply-chain checks.
 
 ### Reference Rules
 
@@ -64,6 +65,7 @@ Apply guidance from these Skills when relevant:
 - `@703-technologies-fuzzing-testing`: API fuzz testing with CATS
 - `@704-technologies-sql`: SQL schema, query, index, transaction, and migration quality
 - `@705-technologies-nosql-mongodb`: MongoDB modeling, queries, indexes, and consistency
+- `@706-technologies-containers-docker`: Dockerfile and Java container image quality
 
 ### Workflow
 

--- a/skills-generator/src/main/resources/skills.xml
+++ b/skills-generator/src/main/resources/skills.xml
@@ -538,6 +538,11 @@
             <reference>705-technologies-nosql-mongodb</reference>
         </reference-list>
     </skill>
+    <skill id="706">
+        <reference-list>
+            <reference>706-technologies-containers-docker</reference>
+        </reference-list>
+    </skill>
     <skill id="800">
         <reference-list>
             <reference>800-policies-eu-ai-act</reference>

--- a/skills-generator/src/test/java/info/jab/pml/SkillsGeneratorTest.java
+++ b/skills-generator/src/test/java/info/jab/pml/SkillsGeneratorTest.java
@@ -246,7 +246,8 @@ class SkillsGeneratorTest {
                     .contains("`@124-java-secure-coding`")
                     .contains("`@701-technologies-openapi`")
                     .contains("`@704-technologies-sql`")
-                    .contains("`@705-technologies-nosql-mongodb`");
+                    .contains("`@705-technologies-nosql-mongodb`")
+                    .contains("`@706-technologies-containers-docker`");
             });
         }
 


### PR DESCRIPTION
## Summary
- Add `706-technologies-containers-docker` as a framework-agnostic Docker/container-image skill for Java projects.
- Register the new skill in the generator inventory and route Java coder agents to it for Dockerfile and image-quality work.
- Extend generator tests so embedded Java coder agents must reference the new container skill.

## Test plan
- `xmllint --noout skills-generator/src/main/resources/skill-indexes/706-skill.xml skills-generator/src/main/resources/skill-references/706-technologies-containers-docker.xml skills-generator/src/main/resources/skills.xml`
- `./mvnw clean install -pl skills-generator`
- `./mvnw clean verify -pl skills-generator`

Closes #812

Made with [Cursor](https://cursor.com)