### PR TITLE
docs(contributing): clarify human PR policy

### DIFF
--- a/.github/scripts/MarkdownValidator.java
+++ b/.github/scripts/MarkdownValidator.java
@@ -225,8 +225,16 @@ public class MarkdownValidator implements Callable<Integer> {
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            return Optional.of("Remote link check failed: " + uri + " (" + e.getMessage() + ")");
+            return Optional.of("Remote link check failed: " + uri + " (" + describeException(e) + ")");
         }
+    }
+
+    private String describeException(Exception exception) {
+        String message = exception.getMessage();
+        if (message == null || message.isBlank()) {
+            return exception.getClass().getSimpleName();
+        }
+        return message;
     }
 
     private Optional<String> validateRemoteAnchor(URI originalUri, URI requestUri)
@@ -304,8 +312,12 @@ public class MarkdownValidator implements Callable<Integer> {
 
         if (errors.isEmpty()) {
             System.out.println("✅ All markdown files are valid!");
+            System.out.println("VALIDATION_RESULT status=passed errors=0");
         } else {
-            System.out.printf("❌ Found %d validation errors:\n\n", errors.size());
+            System.out.printf("❌ Found %d validation errors.\n\n", errors.size());
+            System.out.println("Human-readable report:");
+            System.out.println("Review each file and reason below, then rerun the validator.");
+            System.out.println();
 
             Map<Path, List<ValidationError>> errorsByFile = new LinkedHashMap<>();
             for (ValidationError error : errors) {
@@ -323,9 +335,25 @@ public class MarkdownValidator implements Callable<Integer> {
                 }
                 System.out.println();
             }
+
+            System.out.println("Agent-readable issue records:");
+            for (ValidationError error : errors) {
+                System.out.printf("MARKDOWN_VALIDATION_ISSUE file=\"%s\" line=%d reason=\"%s\"\n",
+                    escapeConsoleValue(error.file.toString()), error.lineNumber, escapeConsoleValue(error.message));
+            }
+            System.out.println();
+            System.out.printf("VALIDATION_RESULT status=failed errors=%d\n", errors.size());
         }
 
         System.out.println("=".repeat(60));
+    }
+
+    private String escapeConsoleValue(String value) {
+        return value
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\r", "\\r")
+                .replace("\n", "\\n");
     }
 
     private static class ValidationError {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,12 @@ Read [AGENTS.md](./AGENTS.md) for the full contributor guide (tech stack, bounda
 - **Git:** use [Conventional Commits](https://www.conventionalcommits.org/) in the form `type(scope): description`, with types such as `feat`, `fix`, `docs`, `style`, `refactor`, `test`, and `chore` (see AGENTS.md).
 - **Pre-commit (recommended):** this repo includes [pre-commit](https://pre-commit.com/) in [`.pre-commit-config.yaml`](.pre-commit-config.yaml) (YAML checks and a commit-msg hook aligned with the rules above). Install once per clone: `pip install pre-commit` or `brew install pre-commit`, then `pre-commit install --install-hooks`. Details and manual checks are in AGENTS.md under **Pre-commit hooks**.
 
+## Pull Request Policy
+
+Pull requests must be opened by human contributors using human-owned GitHub accounts. The contributor is responsible for understanding, validating, and maintaining the submitted change.
+
+AI coding assistants, generators, and automation may help prepare a contribution, but they must not replace human authorship, review, or accountability. Pull requests opened directly by bots, autonomous agents, or other non-human accounts are not accepted unless they are part of maintainer-approved repository automation.
+
 ## Generator
 
 The unified `skills-generator` module holds all XML sources and Java code used to build **agent skills** under `skills/`.


### PR DESCRIPTION
## Summary
- Add a `CONTRIBUTING.md` pull request policy requiring human-owned accounts and human accountability for contributions.
- Clarify that AI tools may assist, while direct bot/autonomous-agent PRs are not accepted unless maintainer-approved.
- Improve Markdown validator failure output with human-readable sections, agent-readable `MARKDOWN_VALIDATION_ISSUE` records, and final `VALIDATION_RESULT` status lines.

Closes #839

## Test plan
- `jbang .github/scripts/MarkdownValidator.java --directories docs /tmp/markdown-validator-smoke`
- `jbang .github/scripts/MarkdownValidator.java --verbose .`


Made with [Cursor](https://cursor.com)