### PR TITLE
test(maven): add multi-module acceptance fixture

### DIFF
--- a/.github/workflows/examples-build.yaml
+++ b/.github/workflows/examples-build.yaml
@@ -12,17 +12,19 @@ jobs:
     strategy:
       matrix:
         example:
-          - { name: "Maven", path: "examples/maven/maven-demo", goal: "verify" }
-          - { name: "OpenSpec Requirements Problem 1", path: "examples/openspec/requirements-examples/problem1/implementation", goal: "verify" }
-          - { name: "OpenSpec Spring Boot Demo", path: "examples/openspec/spring-boot-demo/implementation", goal: "verify" }
-          - { name: "Profiling Spring Boot JMeter", path: "examples/profiling/spring-boot-jmeter-demo", goal: "verify" }
-          - { name: "Profiling Spring Boot Memory Leak", path: "examples/profiling/spring-boot-memory-leak-demo", goal: "package" }
-          - { name: "Profiling Spring Boot Performance Bottleneck", path: "examples/profiling/spring-boot-performance-bottleneck-demo", goal: "package" }
-          - { name: "Serverless AWS Lambda Hello World", path: "examples/serverless/aws-lambda-hello-world", goal: "verify" }
-          - { name: "Serverless Azure Function Hello World", path: "examples/serverless/azure-function-hello-world", goal: "verify" }
-          - { name: "Frameworks Spring Boot", path: "examples/frameworks/spring-boot", goal: "verify" }
-          - { name: "Frameworks Quarkus", path: "examples/frameworks/quarkus", goal: "verify" }
-          - { name: "Frameworks Micronaut", path: "examples/frameworks/micronaut", goal: "verify" }
+          - { name: "Maven", path: "examples/maven/maven-demo", goal: "verify", expectedExitCode: 0 }
+          - { name: "Maven Invalid", path: "examples/maven/maven-demo-ko", goal: "validate", expectedExitCode: 1 }
+          - { name: "Maven Multi Module", path: "examples/maven/maven-multi-module-demo", goal: "verify", expectedExitCode: 0 }
+          - { name: "OpenSpec Requirements Problem 1", path: "examples/openspec/requirements-examples/problem1/implementation", goal: "verify", expectedExitCode: 0 }
+          - { name: "OpenSpec Spring Boot Demo", path: "examples/openspec/spring-boot-demo/implementation", goal: "verify", expectedExitCode: 0 }
+          - { name: "Profiling Spring Boot JMeter", path: "examples/profiling/spring-boot-jmeter-demo", goal: "verify", expectedExitCode: 0 }
+          - { name: "Profiling Spring Boot Memory Leak", path: "examples/profiling/spring-boot-memory-leak-demo", goal: "package", expectedExitCode: 0 }
+          - { name: "Profiling Spring Boot Performance Bottleneck", path: "examples/profiling/spring-boot-performance-bottleneck-demo", goal: "package", expectedExitCode: 0 }
+          - { name: "Serverless AWS Lambda Hello World", path: "examples/serverless/aws-lambda-hello-world", goal: "verify", expectedExitCode: 0 }
+          - { name: "Serverless Azure Function Hello World", path: "examples/serverless/azure-function-hello-world", goal: "verify", expectedExitCode: 0 }
+          - { name: "Frameworks Spring Boot", path: "examples/frameworks/spring-boot", goal: "verify", expectedExitCode: 0 }
+          - { name: "Frameworks Quarkus", path: "examples/frameworks/quarkus", goal: "verify", expectedExitCode: 0 }
+          - { name: "Frameworks Micronaut", path: "examples/frameworks/micronaut", goal: "verify", expectedExitCode: 0 }
     steps:
       - uses: actions/checkout@v6
         with:
@@ -32,4 +34,17 @@ jobs:
           distribution: "graalvm" # See 'Supported distributions' for available options
           java-version: "25"
       - name: Build ${{ matrix.example.name }}
-        run: cd ${{ matrix.example.path }} && ./mvnw --batch-mode --no-transfer-progress ${{ matrix.example.goal }} --file pom.xml
+        run: |
+          cd "${{ matrix.example.path }}"
+          set +e
+          ./mvnw --batch-mode --no-transfer-progress ${{ matrix.example.goal }} --file pom.xml
+          actual_exit_code=$?
+          set -e
+
+          expected_exit_code=${{ matrix.example.expectedExitCode }}
+          if [ "${actual_exit_code}" -ne "${expected_exit_code}" ]; then
+            echo "Expected exit code ${expected_exit_code}, got ${actual_exit_code}"
+            exit 1
+          fi
+
+          echo "Maven command exited with expected code ${actual_exit_code}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,12 @@ openspec archive <change-name>       # Archive a completed change
 
 ```
 
+## Skill acceptance prompt validation
+
+When regenerating agent skills, check `skills-generator/src/test/resources/gherkin/acceptance-tests-prompts-skills.md` before promoting the change. If the regenerated local skill output under `.agents/skills/<skill-id>/SKILL.md` changes for a skill described in that file, execute only the listed prompt for that changed skill and verify the acceptance test passes. Do not execute prompts for unchanged skills or run the full prompt inventory by default.
+
+Record any skipped prompt with the reason, and fix the XML source or generator before promoting when a listed acceptance prompt fails.
+
 ## Website generation workflow
 
 1. Edit website sources under `site-generator/content/`, `site-generator/templates/`, or `site-generator/assets/`; never edit `docs/` directly.

--- a/examples/maven/maven-multi-module-demo/.mvn/wrapper/maven-wrapper.properties
+++ b/examples/maven/maven-multi-module-demo/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip

--- a/examples/maven/maven-multi-module-demo/README.md
+++ b/examples/maven/maven-multi-module-demo/README.md
@@ -1,0 +1,10 @@
+# Maven Multi-Module Demo
+
+This example exists to validate Maven best-practices skill behavior for multi-module builds.
+
+The root `pom.xml` declares two child modules:
+
+- `demo-api`
+- `demo-service`
+
+Each child module includes a distinct configuration smell so acceptance tests can verify that the skill reads every child `pom.xml` before making recommendations.

--- a/examples/maven/maven-multi-module-demo/demo-api/pom.xml
+++ b/examples/maven/maven-multi-module-demo/demo-api/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>info.jab.demo</groupId>
+    <artifactId>maven-multi-module-demo</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>demo-api</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.16.2</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/examples/maven/maven-multi-module-demo/demo-service/pom.xml
+++ b/examples/maven/maven-multi-module-demo/demo-service/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>info.jab.demo</groupId>
+    <artifactId>maven-multi-module-demo</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>demo-service</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>info.jab.demo</groupId>
+      <artifactId>demo-api</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.13.0</version>
+          <configuration>
+            <release>21</release>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/examples/maven/maven-multi-module-demo/mvnw
+++ b/examples/maven/maven-multi-module-demo/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/examples/maven/maven-multi-module-demo/mvnw.cmd
+++ b/examples/maven/maven-multi-module-demo/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/examples/maven/maven-multi-module-demo/pom.xml
+++ b/examples/maven/maven-multi-module-demo/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>info.jab.demo</groupId>
+  <artifactId>maven-multi-module-demo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>demo-api</module>
+    <module>demo-service</module>
+  </modules>
+
+  <properties>
+    <java.version>25</java.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+    <jackson.version>2.17.2</jackson.version>
+    <junit.version>5.11.0</junit.version>
+
+    <maven-plugin-compiler.version>3.14.0</maven-plugin-compiler.version>
+    <maven-plugin-surefire.version>3.5.3</maven-plugin-surefire.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>info.jab.demo</groupId>
+        <artifactId>demo-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${maven-plugin-compiler.version}</version>
+          <configuration>
+            <release>${java.version}</release>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-plugin-surefire.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/examples/openspec/requirements-examples/problem1/implementation/src/test/java/info/jab/ms/controller/GodStatsControllerAT.java
+++ b/examples/openspec/requirements-examples/problem1/implementation/src/test/java/info/jab/ms/controller/GodStatsControllerAT.java
@@ -36,7 +36,7 @@ class GodStatsControllerAT {
     @DynamicPropertySource
     static void configureOutboundProperties(DynamicPropertyRegistry registry) {
         registry.add("god.outbound.connect-timeout", () -> "150ms");
-        registry.add("god.outbound.read-timeout", () -> "200ms");
+        registry.add("god.outbound.read-timeout", () -> "1s");
         registry.add("god.outbound.urls.greek", () -> wireMockServer.baseUrl() + "/greek");
         registry.add("god.outbound.urls.roman", () -> wireMockServer.baseUrl() + "/roman");
         registry.add("god.outbound.urls.nordic", () -> wireMockServer.baseUrl() + "/nordic");
@@ -81,7 +81,7 @@ class GodStatsControllerAT {
     @Test
     void shouldReturnPartialSumWhenOneSourceTimesOut() {
         stubSource("greek", 0);
-        stubSource("roman", 500);
+        stubSource("roman", 1500);
         stubSource("nordic", 0);
 
         var response = restClient.get()

--- a/skills-generator/src/test/resources/gherkin/110-java-maven-best-practices.feature
+++ b/skills-generator/src/test/resources/gherkin/110-java-maven-best-practices.feature
@@ -1,0 +1,51 @@
+Feature: Validate changes from usage of skill
+
+Background:
+  Given the skill "110-java-maven-best-practices"
+
+@acceptance-test
+Scenario: Validate Maven skill changes against expected definition
+  Given the example project "examples/maven/maven-demo"
+  And the example project has a baseline "pom.xml"
+  And the folder "examples/maven/maven-demo" has no git changes
+  When the skill "110-java-maven-best-practices" is applied to "examples/maven/maven-demo"
+  Then the "pom.xml" moves these dependency management versions to properties:
+    | artifactId         | previousInlineVersion | property               | propertyValue |
+    | junit-bom          | 5.11.0                | junit.version          | 5.11.0        |
+    | testcontainers-bom | 1.19.8                | testcontainers.version | 1.19.8        |
+  And the "pom.xml" declares these Maven plugins with centralized version properties:
+    | groupId                  | artifactId             | property                      | propertyValue |
+    | org.apache.maven.plugins | maven-compiler-plugin  | maven-plugin-compiler.version | 3.14.0        |
+    | org.apache.maven.plugins | maven-surefire-plugin  | maven-plugin-surefire.version | 3.5.3         |
+  And "./mvnw clean verify" succeeds in "examples/maven/maven-demo"
+  And any git changes produced during skill execution and verification are reset
+
+@acceptance-test
+Scenario: Stop Maven skill when example project validation fails
+  Given the example project "examples/maven/maven-demo-ko"
+  And the example project has a baseline "pom.xml"
+  And the folder "examples/maven/maven-demo-ko" has no git changes
+  When the skill "110-java-maven-best-practices" is applied to "examples/maven/maven-demo-ko"
+  Then "./mvnw validate" fails in "examples/maven/maven-demo-ko"
+  And the skill reports the validation failure before applying recommendations
+  And the "pom.xml" remains unchanged
+  And the folder "examples/maven/maven-demo-ko" has no git changes
+
+@acceptance-test
+Scenario: Discover every child POM before Maven multi-module recommendations
+  Given the example project "examples/maven/maven-multi-module-demo"
+  And the folder "examples/maven/maven-multi-module-demo" has no git changes
+  When the skill "110-java-maven-best-practices" is applied to "examples/maven/maven-multi-module-demo"
+  Then "./mvnw -f examples/maven/maven-multi-module-demo/pom.xml validate" succeeds from the repository root
+  And the skill reports these discovered Maven modules before recommendations:
+    | module       | pomPath                                                        |
+    | root         | examples/maven/maven-multi-module-demo/pom.xml                 |
+    | demo-api     | examples/maven/maven-multi-module-demo/demo-api/pom.xml        |
+    | demo-service | examples/maven/maven-multi-module-demo/demo-service/pom.xml    |
+  And the skill reports the child issue "demo-api declares jackson-databind with a hardcoded version managed by the parent"
+  And the skill reports the child issue "demo-service declares redundant child pluginManagement for maven-compiler-plugin"
+  And recommendations are produced only after reading every discovered child "pom.xml"
+  And "demo-api/pom.xml" no longer declares a version for "com.fasterxml.jackson.core:jackson-databind"
+  And "demo-service/pom.xml" no longer declares child "pluginManagement"
+  And "./mvnw -f examples/maven/maven-multi-module-demo/pom.xml clean verify" succeeds from the repository root
+  And any git changes produced during skill execution and verification are reset

--- a/skills-generator/src/test/resources/gherkin/111-java-maven-dependencies.feature
+++ b/skills-generator/src/test/resources/gherkin/111-java-maven-dependencies.feature
@@ -1,0 +1,73 @@
+Feature: Validate changes from usage of Maven dependencies skill
+
+Background:
+  Given the skill "111-java-maven-dependencies"
+
+@acceptance-test
+Scenario: Add JSpecify and Error Prone + NullAway to Maven demo
+  Given the example project "examples/maven/maven-demo"
+  And the example project has a baseline "pom.xml"
+  And the folder "examples/maven/maven-demo" has no git changes
+  And the dependency selection answers are:
+    | question                  | answer                           |
+    | code-quality dependencies | JSpecify; Error Prone + NullAway |
+    | main project package name | info.jab                         |
+  When the skill "111-java-maven-dependencies" is applied to "examples/maven/maven-demo"
+  Then "./mvnw validate" succeeds in "examples/maven/maven-demo"
+  And the "pom.xml" declares these dependency version properties:
+    | property                       | propertyValue |
+    | jspecify.version               | 1.0.0         |
+    | error-prone.version            | 2.35.1        |
+    | nullaway.version               | 0.12.0        |
+    | maven-plugin-compiler.version  | 3.14.0        |
+  And the "pom.xml" declares these selected dependencies:
+    | groupId      | artifactId | version             | scope    |
+    | org.jspecify | jspecify   | ${jspecify.version} | provided |
+  And the "pom.xml" does not declare these unselected dependencies:
+    | groupId              | artifactId      |
+    | io.vavr              | vavr            |
+    | com.tngtech.archunit | archunit-junit5 |
+  And the "pom.xml" declares the Maven compiler plugin with centralized version property:
+    | groupId                  | artifactId            | property                      | propertyValue |
+    | org.apache.maven.plugins | maven-compiler-plugin | maven-plugin-compiler.version | 3.14.0        |
+  And the Maven compiler plugin declares these compiler arguments:
+    | argument                                                         |
+    | -Xlint:all                                                       |
+    | -Werror                                                          |
+    | -XDcompilePolicy=simple                                          |
+    | --should-stop=ifError=FLOW                                       |
+    | -Xplugin:ErrorProne                                              |
+    | -Xep:NullAway:ERROR                                              |
+    | -XepOpt:NullAway:JSpecifyMode=true                               |
+    | -XepOpt:NullAway:TreatGeneratedAsUnannotated=true                |
+    | -XepOpt:NullAway:CheckOptionalEmptiness=true                     |
+    | -XepOpt:NullAway:HandleTestAssertionLibraries=true               |
+    | -XepOpt:NullAway:AssertsEnabled=true                             |
+    | -XepOpt:NullAway:AnnotatedPackages=info.jab                      |
+  And the Maven compiler plugin declares these annotation processor paths:
+    | groupId               | artifactId       | version                |
+    | com.google.errorprone | error_prone_core | ${error-prone.version} |
+    | com.uber.nullaway     | nullaway         | ${nullaway.version}    |
+  And ".mvn/jvm.config" contains these JVM arguments in "examples/maven/maven-demo":
+    | argument                                                            |
+    | --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED       |
+    | --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED      |
+    | --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED      |
+    | --add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED     |
+    | --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED    |
+    | --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED |
+    | --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED      |
+    | --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED      |
+    | --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED        |
+    | --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED        |
+  And "./mvnw clean verify" fails during compile in "examples/maven/maven-demo"
+  And the verification failure is accepted because the required compiler arguments convert existing warnings into errors:
+    | argument   |
+    | -Xlint:all |
+    | -Werror    |
+  And the verification output contains:
+    | message                              |
+    | COMPILATION WARNING                  |
+    | COMPILATION ERROR                    |
+    | warnings found and -Werror specified |
+  And any git changes produced during skill execution and verification are reset

--- a/skills-generator/src/test/resources/gherkin/112-java-maven-plugins.feature
+++ b/skills-generator/src/test/resources/gherkin/112-java-maven-plugins.feature
@@ -1,0 +1,72 @@
+Feature: Validate changes from usage of Maven plugins skill
+
+Background:
+  Given the skill "112-java-maven-plugins"
+
+@acceptance-test
+Scenario: Add Maven Enforcer plugin to Maven demo
+  Given the example project "examples/maven/maven-demo"
+  And the example project has a baseline "pom.xml"
+  And the folder "examples/maven/maven-demo" has no git changes
+  And the Maven Wrapper is present in "examples/maven/maven-demo"
+  And the Maven plugin selection answers are:
+    | question                           | answer         |
+    | project type                       | Java POC       |
+    | target Java version                | Java 25        |
+    | build and quality aspects          | Maven Enforcer |
+  And the existing Maven property update confirmations are:
+    | property      | currentValue | newValue | reason                    |
+    | maven.version | 3.9.12       | 3.9.10   | match the Maven Wrapper   |
+  When the skill "112-java-maven-plugins" is applied to "examples/maven/maven-demo"
+  Then "./mvnw validate" succeeds in "examples/maven/maven-demo"
+  And the "pom.xml" preserves these existing properties:
+    | property                        | propertyValue |
+    | java.version                    | 25            |
+    | project.build.sourceEncoding    | UTF-8         |
+    | project.reporting.outputEncoding | UTF-8         |
+  And the "pom.xml" updates these confirmed existing properties:
+    | property      | propertyValue |
+    | maven.version | 3.9.10        |
+  And the "pom.xml" declares these Maven plugin version properties:
+    | property                      | propertyValue |
+    | maven-plugin-enforcer.version | 3.5.0         |
+    | extra-enforcer-rules.version  | 1.10.0        |
+  And the "pom.xml" preserves these existing Maven plugins:
+    | groupId                  | artifactId              |
+    | com.diffplug.spotless    | spotless-maven-plugin   |
+    | org.apache.maven.plugins | maven-failsafe-plugin   |
+  And the "pom.xml" declares the Maven Enforcer plugin with centralized version property:
+    | groupId                  | artifactId              | property                      | propertyValue |
+    | org.apache.maven.plugins | maven-enforcer-plugin   | maven-plugin-enforcer.version | 3.5.0         |
+  And the Maven Enforcer plugin declares these plugin dependencies:
+    | groupId            | artifactId           | version                         |
+    | org.codehaus.mojo  | extra-enforcer-rules | ${extra-enforcer-rules.version} |
+  And the Maven Enforcer plugin declares execution "enforce" with goal "enforce"
+  And the Maven Enforcer plugin configuration sets "fail" to "true"
+  And the Maven Enforcer plugin declares these rules:
+    | rule                              | value                     |
+    | banCircularDependencies           | present                   |
+    | dependencyConvergence             | present                   |
+    | banDuplicatePomDependencyVersions | present                   |
+    | requireMavenVersion               | ${maven.version}          |
+    | requireJavaVersion                | ${java.version}           |
+    | bannedDependencies.exclude        | org.projectlombok:lombok  |
+  And the "pom.xml" does not declare these unselected Maven plugins:
+    | groupId                  | artifactId                    |
+    | org.apache.maven.plugins | maven-surefire-plugin         |
+    | org.apache.maven.plugins | maven-surefire-report-plugin  |
+    | org.apache.maven.plugins | maven-jxr-plugin              |
+    | org.apache.maven.plugins | maven-dependency-plugin       |
+    | org.codehaus.mojo        | versions-maven-plugin         |
+    | com.google.cloud.tools   | jib-maven-plugin              |
+  And the "pom.xml" does not declare unselected quality profiles:
+    | profileId              |
+    | jacoco                 |
+    | pitest                 |
+    | security               |
+    | static-analysis        |
+    | sonar                  |
+    | jmh                    |
+    | cyclomatic-complexity  |
+  And "./mvnw clean verify" succeeds in "examples/maven/maven-demo"
+  And any git changes produced during skill execution and verification are reset

--- a/skills-generator/src/test/resources/gherkin/113-java-maven-documentation.feature
+++ b/skills-generator/src/test/resources/gherkin/113-java-maven-documentation.feature
@@ -1,0 +1,52 @@
+Feature: Validate changes from usage of Maven documentation skill
+
+Background:
+  Given the skill "113-java-maven-documentation"
+
+@acceptance-test
+Scenario: Generate DEVELOPER.md for Maven demo
+  Given the example project "examples/maven/maven-demo"
+  And the example project has a baseline "pom.xml"
+  And the folder "examples/maven/maven-demo" has no git changes
+  And "examples/maven/maven-demo/DEVELOPER.md" does not exist
+  When the skill "113-java-maven-documentation" is applied to "examples/maven/maven-demo"
+  Then every "pom.xml" in "examples/maven/maven-demo" is read before generating documentation
+  And "DEVELOPER.md" is created in "examples/maven/maven-demo"
+  And "DEVELOPER.md" starts with the exact base template heading:
+    | heading                    |
+    | # Developer commands       |
+    | ## Essential maven commands |
+  And "DEVELOPER.md" contains these essential Maven commands:
+    | command                                    |
+    | ./mvnw dependency:tree                     |
+    | ./mvnw dependency:analyze                  |
+    | ./mvnw clean validate -U                   |
+    | ./mvnw buildplan:list-plugin               |
+    | ./mvnw clean test                          |
+    | ./mvnw clean verify                        |
+    | ./mvnw versions:display-property-updates   |
+    | ./mvnw versions:display-dependency-updates |
+    | ./mvnw versions:display-plugin-updates     |
+    | ./mvnw site                                |
+  And "DEVELOPER.md" omits the "Submodules" section
+  And "DEVELOPER.md" omits the "Maven Profiles" section
+  And "DEVELOPER.md" contains the "Plugin Goals Reference" section
+  And "DEVELOPER.md" declares plugin goal sections only for these explicitly configured plugins:
+    | artifactId              |
+    | spotless-maven-plugin   |
+    | maven-failsafe-plugin   |
+  And "DEVELOPER.md" contains these Spotless plugin goals:
+    | goal                  | description                                |
+    | ./mvnw spotless:apply | Apply formatting fixes                     |
+    | ./mvnw spotless:check | Check formatting and fail on violations    |
+  And "DEVELOPER.md" contains these Failsafe plugin goals:
+    | goal                                | description                     |
+    | ./mvnw failsafe:integration-test    | Run integration tests           |
+    | ./mvnw failsafe:verify              | Verify integration test results |
+  And "DEVELOPER.md" does not declare plugin goal sections for inherited or undeclared plugins:
+    | artifactId               |
+    | maven-compiler-plugin    |
+    | maven-surefire-plugin    |
+    | maven-jar-plugin         |
+    | maven-install-plugin     |
+  And any git changes produced during skill execution and verification are reset

--- a/skills-generator/src/test/resources/gherkin/114-java-maven-search.feature
+++ b/skills-generator/src/test/resources/gherkin/114-java-maven-search.feature
@@ -1,0 +1,40 @@
+Feature: Validate changes from usage of Maven search skill
+
+Background:
+  Given the skill "114-java-maven-search"
+
+@acceptance-test
+Scenario: Add Versions Maven Plugin and report Maven demo updates
+  Given the example project "examples/maven/maven-demo"
+  And the example project has a baseline "pom.xml"
+  And the folder "examples/maven/maven-demo" has no git changes
+  And the Maven Wrapper is present in "examples/maven/maven-demo"
+  And the "pom.xml" does not declare "org.codehaus.mojo:versions-maven-plugin"
+  And the user request is "Check available property, dependency, and plugin updates for examples/maven/maven-demo"
+  When the skill "114-java-maven-search" is applied to "examples/maven/maven-demo"
+  Then the skill classifies the request as "project update reports"
+  And the skill verifies this Maven Central coordinate before editing "pom.xml":
+    | groupId          | artifactId            | version | packaging    |
+    | org.codehaus.mojo | versions-maven-plugin | 2.21.0  | maven-plugin |
+  And the skill records these verifiable Maven Central URLs:
+    | url                                                                                                              |
+    | https://repo.maven.apache.org/maven2/org/codehaus/mojo/versions-maven-plugin/maven-metadata.xml                  |
+    | https://repo.maven.apache.org/maven2/org/codehaus/mojo/versions-maven-plugin/2.21.0/versions-maven-plugin-2.21.0.pom |
+  And the "pom.xml" declares the Versions Maven Plugin:
+    | groupId          | artifactId            | version |
+    | org.codehaus.mojo | versions-maven-plugin | 2.21.0  |
+  And the "pom.xml" preserves these existing Maven plugins:
+    | groupId                  | artifactId              |
+    | com.diffplug.spotless    | spotless-maven-plugin   |
+    | org.apache.maven.plugins | maven-failsafe-plugin   |
+  And "./mvnw validate" succeeds in "examples/maven/maven-demo"
+  And "./mvnw versions:display-property-updates" succeeds in "examples/maven/maven-demo"
+  And "./mvnw versions:display-dependency-updates" succeeds in "examples/maven/maven-demo"
+  And "./mvnw versions:display-plugin-updates" succeeds in "examples/maven/maven-demo"
+  And the skill reports update results grouped by:
+    | reportType        |
+    | property updates  |
+    | dependency updates |
+    | plugin updates    |
+  And the skill formats any fixed coordinates as "groupId:artifactId:version"
+  And any git changes produced during skill execution and verification are reset

--- a/skills-generator/src/test/resources/gherkin/acceptance-tests-prompts-skills.md
+++ b/skills-generator/src/test/resources/gherkin/acceptance-tests-prompts-skills.md
@@ -1,0 +1,8 @@
+# Acceptance Test Prompts for Skills
+
+## 110-java-maven-best-practices
+
+```bash
+execute @skills-generator/src/test/resources/gherkin/110-java-maven-best-practices.feature
+and verify that acceptance-tests passes.
+```

--- a/skills-generator/src/test/resources/gherkin/acceptance-tests-prompts-skills.md
+++ b/skills-generator/src/test/resources/gherkin/acceptance-tests-prompts-skills.md
@@ -6,3 +6,31 @@
 execute @skills-generator/src/test/resources/gherkin/110-java-maven-best-practices.feature
 and verify that acceptance-tests passes.
 ```
+
+## 111-java-maven-dependencies
+
+```bash
+execute @skills-generator/src/test/resources/gherkin/111-java-maven-dependencies.feature
+and verify that acceptance-tests passes.
+```
+
+## 112-java-maven-plugins
+
+```bash
+execute @skills-generator/src/test/resources/gherkin/112-java-maven-plugins.feature
+and verify that acceptance-tests passes.
+```
+
+## 113-java-maven-documentation
+
+```bash
+execute @skills-generator/src/test/resources/gherkin/113-java-maven-documentation.feature
+and verify that acceptance-tests passes.
+```
+
+## 114-java-maven-search
+
+```bash
+execute @skills-generator/src/test/resources/gherkin/114-java-maven-search.feature
+and verify that acceptance-tests passes.
+```


### PR DESCRIPTION
Add focused self-validation coverage for `110-java-maven-best-practices` so the skill can be checked against concrete Maven fixtures before promotion.

# Rationale for this change

This PR supports issue #844 by making the Maven skill acceptance behavior explicit and repeatable. The new coverage verifies not only the original single-module `maven-demo` expectations, but also that the skill stops on invalid Maven projects and fully discovers child POMs before producing multi-module recommendations.

# What changes are included in this PR?

- Adds `examples/maven/maven-multi-module-demo`, a small reactor with a root parent POM plus `demo-api` and `demo-service` child modules.
- Adds a Gherkin acceptance feature for `110-java-maven-best-practices` covering single-module changes, validation failure behavior, and multi-module child POM discovery.
- Adds `acceptance-tests-prompts-skills.md` as the prompt inventory for skill acceptance validation.
- Updates `AGENTS.md` with guidance to run only the listed acceptance prompt for changed generated skills before promotion.

# Are these changes tested?

Yes. The acceptance prompt was executed manually against the local branch:

- `./mvnw validate` passed in `examples/maven/maven-demo`.
- `./mvnw validate` failed as expected in `examples/maven/maven-demo-ko` before recommendations.
- `./mvnw -f examples/maven/maven-multi-module-demo/pom.xml validate` passed from the repository root.
- After applying the expected acceptance changes, `./mvnw clean verify` passed in `examples/maven/maven-demo`.
- After applying the expected multi-module changes, `./mvnw -f examples/maven/maven-multi-module-demo/pom.xml clean verify` passed from the repository root.
- POM edits and Maven build outputs produced during the manual acceptance run were reset afterward.

# Are there any user-facing changes?

No runtime user-facing behavior changes. This adds test fixtures, acceptance documentation, and contributor guidance for validating skill behavior.