### PR TITLE
feat(skills): add EU Digital Services Act regulation skill

### DIFF
--- a/documentation/openspec/changes/add-eu-digital-services-act-regulation-skill/tasks.md
+++ b/documentation/openspec/changes/add-eu-digital-services-act-regulation-skill/tasks.md
@@ -6,21 +6,21 @@
 - [x] 1.2 Confirm `801-regulations-eu-ai-act`, `802-regulations-dora`, and `803-regulations-gdpr` are already covered and the Digital Services Act remains pending.
 - [x] 1.3 Create a per-regulation OpenSpec change for the Digital Services Act.
 - [x] 1.4 Record source artifacts, derivation direction, scope boundary, and validation expectations.
-- [ ] 1.5 Add `skills-generator/src/main/resources/skill-indexes/807-skill.xml`.
-- [ ] 1.6 Add `skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-chapters-summary.xml` with direct official-source chapter links and article mapping in the same style as `804-regulations-eu-nis2-chapters-summary.xml`.
-- [ ] 1.7 Add `skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-engineering-examples.xml` with Java-focused examples and output guidance.
-- [ ] 1.8 Add `skills-generator/src/main/resources/skill-references/assets/reports/807-eu-digital-services-act-engineering-review-report-template.md` with a potential violation or non-compliance table that includes reference area and associated official-source link columns.
-- [ ] 1.9 Include engineering controls for content decision audit logs, moderation workflow state, notice intake and response tracking, recommender and ranking explanation evidence, ad transparency metadata, user controls, complaint and appeal workflows, risk assessment evidence, incident escalation, data access for auditors or researchers where applicable, and privacy-safe observability.
-- [ ] 1.10 Update `807-skill.xml` so the workflow reads chapter summary, engineering examples, and report template before implementation review.
-- [ ] 1.11 Register skill id `807` with explicit `skillId="807-regulations-eu-digital-services-act"`, references, and report template resource in `skills-generator/src/main/resources/skills.xml`.
-- [ ] 1.12 Add `skills-generator/src/test/resources/gherkin/807-regulations-eu-digital-services-act.feature` with pull-request and direct-to-main acceptance scenarios modeled after `801-804`.
-- [ ] 1.13 Ensure the Gherkin scenarios require reading the chapters summary, engineering examples, and report template, and require linked violation mapping in generated reports.
-- [ ] 1.14 Add Digital Services Act report examples under `examples/regulations/eu-digital-services-act`.
-- [ ] 1.15 Add `807-regulations-eu-digital-services-act` to `skills-generator/src/test/resources/gherkin/acceptance-tests-prompts-skills.md`.
-- [ ] 1.16 Validate changed XML files with `xmllint --noout`.
-- [ ] 1.17 Run `./mvnw clean install -pl skills-generator`.
-- [ ] 1.18 Inspect generated local `.agents/skills/807-regulations-eu-digital-services-act/SKILL.md`.
-- [ ] 1.19 Inspect generated local chapters summary, engineering examples, and report template outputs.
-- [ ] 1.20 Execute the listed `807-regulations-eu-digital-services-act` acceptance prompt and verify it passes.
-- [ ] 1.21 Run `./mvnw clean verify -pl skills-generator`.
-- [ ] 1.22 Run `openspec validate --all`.
+- [x] 1.5 Add `skills-generator/src/main/resources/skill-indexes/807-skill.xml`.
+- [x] 1.6 Add `skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-chapters-summary.xml` with direct official-source chapter links and article mapping in the same style as `804-regulations-eu-nis2-chapters-summary.xml`.
+- [x] 1.7 Add `skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-engineering-examples.xml` with Java-focused examples and output guidance.
+- [x] 1.8 Add `skills-generator/src/main/resources/skill-references/assets/reports/807-eu-digital-services-act-engineering-review-report-template.md` with a potential violation or non-compliance table that includes reference area and associated official-source link columns.
+- [x] 1.9 Include engineering controls for content decision audit logs, moderation workflow state, notice intake and response tracking, recommender and ranking explanation evidence, ad transparency metadata, user controls, complaint and appeal workflows, risk assessment evidence, incident escalation, data access for auditors or researchers where applicable, and privacy-safe observability.
+- [x] 1.10 Update `807-skill.xml` so the workflow reads chapter summary, engineering examples, and report template before implementation review.
+- [x] 1.11 Register skill id `807` with explicit `skillId="807-regulations-eu-digital-services-act"`, references, and report template resource in `skills-generator/src/main/resources/skills.xml`.
+- [x] 1.12 Add `skills-generator/src/test/resources/gherkin/807-regulations-eu-digital-services-act.feature` with pull-request and direct-to-main acceptance scenarios modeled after `801-804`.
+- [x] 1.13 Ensure the Gherkin scenarios require reading the chapters summary, engineering examples, and report template, and require linked violation mapping in generated reports.
+- [x] 1.14 Add Digital Services Act report examples under `examples/regulations/eu-digital-services-act`.
+- [x] 1.15 Add `807-regulations-eu-digital-services-act` to `skills-generator/src/test/resources/gherkin/acceptance-tests-prompts-skills.md`.
+- [x] 1.16 Validate changed XML files with `xmllint --noout`.
+- [x] 1.17 Run `./mvnw clean install -pl skills-generator`.
+- [x] 1.18 Inspect generated local `.agents/skills/807-regulations-eu-digital-services-act/SKILL.md`.
+- [x] 1.19 Inspect generated local chapters summary, engineering examples, and report template outputs.
+- [x] 1.20 Execute the listed `807-regulations-eu-digital-services-act` acceptance prompt and verify it passes. Manual coverage recorded through `examples/regulations/eu-digital-services-act/DSA-ENGINEERING-REVIEW-REPORT.md` and `examples/regulations/eu-digital-services-act/DSA-DIRECT-MAIN-ENGINEERING-REVIEW-REPORT.md`; no automated acceptance runner beyond the documented prompt was found.
+- [x] 1.21 Run `./mvnw clean verify -pl skills-generator`.
+- [x] 1.22 Run `openspec validate --all`.

--- a/examples/regulations/eu-digital-services-act/DSA-DIRECT-MAIN-ENGINEERING-REVIEW-REPORT.md
+++ b/examples/regulations/eu-digital-services-act/DSA-DIRECT-MAIN-ENGINEERING-REVIEW-REPORT.md
@@ -1,0 +1,206 @@
+# Digital Services Act Engineering Review Report
+
+Use this report as engineering evidence for legal, compliance, trust-and-safety, privacy, security, product, risk, audit, research-access, architecture, and business-owner review.
+
+This report is not legal advice. It identifies engineering controls and escalation points from the reviewed direct-to-main delivery evidence. Intermediary classification, platform classification, VLOP or VLOSE status, illegal-content determinations, advertising or recommender interpretation, audit or researcher access duties, systemic-risk conclusions, and regulatory interpretation require qualified owner review.
+
+## 1. Review Context
+
+- System or service name: CheckoutService delivery instructions change
+- Repository, product, platform, or business service: Fictional Java Quarkus ecommerce platform with direct commits to `main`
+- Review date: 2026-06-14
+- Reviewers: AI-assisted Digital Services Act engineering review
+- Business owner: Not identified in reviewed evidence
+- Technical owner: Software engineers, tech leads, and platform engineers are described, but no named CheckoutService owner is identified
+- Product owner: Not identified in reviewed evidence
+- Trust-and-safety owner: Not identified in reviewed evidence
+- Privacy owner: Not identified in reviewed evidence
+- Security owner: Not identified in reviewed evidence
+- Legal/compliance owner: Not identified in reviewed evidence
+- Risk or audit owner: Not identified in reviewed evidence
+- Research-access owner, where applicable: Not identified in reviewed evidence
+- Source materials reviewed:
+  - `examples/diagrams/deployment/system-example-cicd-model.md`
+  - `examples/diagrams/deployment/expected-system-deployment.puml`
+  - `examples/diagrams/deployment/checkout-service-feature-request.md`
+  - `.agents/skills/807-regulations-eu-digital-services-act/references/807-regulations-eu-digital-services-act-chapters-summary.md`
+  - `.agents/skills/807-regulations-eu-digital-services-act/references/807-regulations-eu-digital-services-act-engineering-examples.md`
+  - `.agents/skills/807-regulations-eu-digital-services-act/assets/reports/807-eu-digital-services-act-engineering-review-report-template.md`
+
+## 2. Service And Platform Context
+
+- Service description: CheckoutService coordinates checkout saga steps for price validation, inventory reservation, payment authorization, order creation, delivery slot booking, PostgreSQL order state, saga state, and Kafka events.
+- Possible intermediary-service signal: The reviewed evidence describes a customer-facing ecommerce platform and web storefront, but it does not confirm that CheckoutService or the platform offers an intermediary service under the Digital Services Act.
+- Possible hosting-service signal: The feature stores shopper-provided delivery instructions for order fulfillment, but the reviewed evidence does not show public dissemination of recipient-provided information.
+- Possible online-platform or marketplace signal: Ecommerce, catalog, search, checkout, payment, delivery, and shopper interactions are present. The reviewed evidence does not confirm third-party trader listings, user-generated public content, or marketplace platform classification.
+- Possible online-search-engine signal: A product Search Service exists, but the reviewed evidence does not show a general online search engine. Product ranking or search explanations may still be product governance evidence.
+- Possible advertising or recommender signal: No advertising, promoted listing, personalization, or recommender workflow is described in the reviewed files.
+- Possible VLOP or VLOSE signal: No active-recipient count, designation, or very-large-platform evidence is present.
+- Deployment geography: Azure production environment is described; EU recipient geography and Member State targeting are not specified.
+- Environments in scope: Development, test, staging, and production.
+- Active-recipient or user-scale evidence: Not present.
+- User, trader, or third-party content flows: Shopper-provided delivery instructions are persisted with orders. Product catalog ownership, trader listing source, user reviews, public posts, ads, and marketplace seller flows are not described.
+- Open applicability questions:
+  - Does the ecommerce platform qualify as an intermediary service, hosting service, online platform, or marketplace under the Digital Services Act?
+  - Does direct-to-main delivery provide enough review evidence for DSA-sensitive platform, search, ranking, support, privacy, or transparency changes?
+  - Are products listed by the platform itself, internal catalog owners, or third-party traders?
+  - Does the Search Service use ranking, recommender, personalization, or sponsored placement logic that needs user-facing explanation or ad transparency evidence?
+  - Are there notice-and-action, moderation, complaint, appeal, trader traceability, or transparency-reporting workflows outside the reviewed files?
+  - Could the platform meet VLOP or VLOSE thresholds, and who owns active-recipient measurement?
+
+## 3. DSA Engineering Scope
+
+- Applications, APIs, jobs, and batch workloads: Web storefront BFF, API gateway, identity, catalog, search, cart, pricing, CheckoutService, payment adapter, inventory, delivery slot, notification worker, analytics pipeline, checkout saga logic, and deployment workflows.
+- User-generated content, trader listings, product data, ads, or third-party information: Shopper delivery instructions are user-provided order data. Product data exists, but the reviewed evidence does not identify third-party trader listings, user reviews, public content, or ads.
+- Notice intake, authority orders, and response workflows: Not present in reviewed evidence.
+- Content decision audit logs and moderation workflow state: Not present; no content moderation workflow is described.
+- Complaint, appeal, out-of-court dispute, and reinstatement workflows: Not present in reviewed evidence.
+- Recommender, ranking, search, personalization, and user-control workflows: Product search exists; ranking parameters, sort controls, personalization, and user-facing explanation evidence are not present.
+- Advertising transparency metadata and repository evidence: Not present; no ads or promoted listings are described.
+- Marketplace trader traceability and compliance-by-design controls: Not present; no trader onboarding or seller listing evidence is described.
+- Risk assessment, audit, crisis response, and data access workflows where applicable: Not present; VLOP/VLOSE scope is not established.
+- Logs, metrics, traces, dashboards, and privacy-safe observability: Azure Monitor, App Insights, Log Analytics, structured logs, metrics, traces, correlation IDs, dashboards, alerts, health checks, and smoke tests are described. The feature explicitly requires free-text delivery notes to be excluded from operational logs.
+- Operational runbooks and support model: Support and operations teams are described, but DSA-specific notice, moderation, appeal, transparency, audit, or researcher-access runbooks are not present.
+
+## 4. Potential Violation Or Non-Compliance Mapping
+
+This section is not a legal finding. It lists concrete potential Digital Services Act violation or non-compliance signals from the reviewed direct-to-main delivery evidence and routes each item to qualified owner review. No violation is confirmed by this engineering review.
+
+| Potential violation or non-compliance signal | DSA reference area | Associated official-source link | Evidence from reviewed system | Current status | Required owner review | Engineering action |
+| -------------------------------------------- | ------------------ | ------------------------------- | ----------------------------- | -------------- | --------------------- | ------------------ |
+| Unclear intermediary, hosting, online-platform, marketplace, or online-search scope | Applicability and definitions | [Chapter I](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_I) | Ecommerce storefront, product search, checkout, and shopper delivery instructions are described, but DSA classification is not recorded | Potential gap | Legal / compliance / product owner | Record DSA scope decision, EU recipient geography, content flows, trader model, and accountable owners |
+| Direct-to-main commit path lacks explicit review evidence for a platform-facing change | Due diligence governance evidence | [Chapter III](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | Engineers inspect small direct commits to `main`; feature modifies order database structure and Kafka event data | Potential gap | Platform / security / product / risk owner | Require protected-main or equivalent approval control for DSA-sensitive, privacy-sensitive, search, ranking, moderation, ad, or transparency-affecting changes |
+| Missing DSA owner model | Due diligence governance evidence | [Chapter III](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | No legal, compliance, trust-and-safety, privacy, product, risk, audit, or research-access owners are named | Potential gap | Business / product / legal / compliance | Add DSA scope inventory with owner handoffs for platform, search, catalog, checkout, support, and observability |
+| Missing notice intake and response tracking if hosting duties apply | Notice-and-action controls | [Chapter III, Section 2](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | No notice-and-action, authority order, statement-of-reasons, or trusted flagger workflow is described | Potential gap if hosting or platform duties apply | Trust-and-safety / legal / security | Add notice intake, validation, triage, action, response, statement-of-reasons, and redress tracking where applicable |
+| Missing complaint and appeal workflow evidence if online platform duties apply | Online platform redress controls | [Chapter III, Section 3](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | Support and operations teams are described, but complaint, appeal, dispute, reinstatement, and moderation reversal evidence is not present | Potential gap if online platform duties apply | Trust-and-safety / product / legal | Define appeal state, deadlines, decisions, reinstatement actions, notifications, and evidence retention where applicable |
+| Missing product search or ranking explanation evidence | Recommender and ranking transparency | [Article 27](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | Product Search Service exists; ranking parameters, sort controls, personalization status, and user-facing explanations are not shown | Potential gap if recommender duties apply | Product / search-platform / legal / privacy | Record search and ranking parameters, user controls, personalization status, and explanation snapshots |
+| Missing ad transparency metadata if promoted listings or ads exist | Advertising transparency | [Article 26](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | No advertising or sponsored listing workflow is described | Open question | Product / ads owner / legal / privacy | Confirm whether ads or sponsored placements exist; if yes, attach ad labels, payer, beneficiary, targeting parameters, and guardrail evidence |
+| Missing trader traceability if marketplace duties apply | Marketplace trader controls | [Chapter III, Section 4](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | Product catalog is described, but trader onboarding, seller identity, and listing completeness evidence are not shown | Open question | Marketplace / legal / compliance | Confirm product source model; add trader traceability and compliance-by-design evidence if third-party traders can sell |
+| Missing VLOP/VLOSE evidence if platform scale applies | Systemic-risk obligations | [Chapter III, Section 5](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | No active-recipient count, designation, risk assessment, audit, ad repository, data access, or researcher-access evidence is present | Open question | Legal / risk / audit / research-access / executive accountability | Add active-recipient measurement and VLOP/VLOSE review; if applicable, create risk, audit, mitigation, crisis, transparency, and governed data-access evidence |
+| Privacy-safe observability gap for free-text delivery notes | Evidence and confidentiality controls | [Chapter IV](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_IV) | The feature requires `delivery_instruction_note` to be excluded from logs and Kafka; tests are requested but not shown in reviewed evidence | Potential gap | Security / privacy / platform owner | Add privacy-safe logging tests, redaction policy, and observability review for delivery instruction data |
+| Database migration and Kafka contract change may affect platform evidence | Engineering change control | [Chapter III](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | Feature adds order columns and changes Kafka event schema to version 3 for `delivery.slot.requested`, `order.created`, and `order.confirmed` | Potential gap | Architecture / platform / product owner | Require migration approval, Kafka compatibility evidence, and release records before production deployment |
+
+## 5. Engineering Controls
+
+- Pre-commit review and main-branch protection: Replace direct-to-main release eligibility for this change with branch protection, required review, signed approval, or an equivalent auditable control before production deployment.
+- Scope and service inventory: Add a DSA inventory entry for storefront, catalog, search, cart, checkout, delivery, notification, support, analytics, and any marketplace, moderation, ad, recommender, or trader workflows.
+- Authority order and information request tracking: If DSA hosting or intermediary duties apply, add order receipt, legal basis, content locator, territorial scope, response time, user notification, and redress evidence.
+- Notice intake and response tracking: If hosting or online platform duties apply, add notice validation, triage, deduplication, action, response, statement-of-reasons, trusted flagger, and misuse tracking.
+- Content decision audit logs: If product listings, user content, reviews, ads, or accounts can be restricted, record decision source, policy reference, evidence ID, action, user notification, appeal availability, and workflow state.
+- Moderation workflow state: Define queues, states, deadlines, ownership, reversals, reinstatement, and redacted evidence storage where moderation exists.
+- Statement-of-reasons records: Create structured records for removals, disabling, demotion, suspension, account restrictions, or marketplace listing restrictions where applicable.
+- User notification and redress: Add user-facing notifications, support escalation, appeal eligibility, and out-of-court dispute information where applicable.
+- Complaint, appeal, dispute, and reinstatement workflows: Preserve appeal state, reviewer group, outcome, reversal, reinstatement action, and notifications.
+- Trusted flagger routing and misuse protections: Add priority routing, abuse detection, repeated manifestly unfounded notice handling, and owner approval if trusted flagger workflows exist.
+- Recommender and ranking explanation evidence: Record search and ranking parameters for product discovery, personalization status, sort controls, explanation snapshots, and user controls.
+- User controls and profiling-related alternatives where applicable: Add controls for sort, personalization, profiling-free alternatives where applicable, and minor-protection review if minors can use the storefront.
+- Advertising transparency metadata: If ads or sponsored listings exist, record ad label, payer, beneficiary, main targeting parameters, sensitive-profiling guardrails, and repository readiness where applicable.
+- Marketplace trader traceability: If third-party traders sell through the platform, record trader identity, contact, payment, registration, verification, listing completeness, suspension, and consumer notification evidence.
+- Transparency reporting: Add jobs or records for moderation actions, notices, complaints, automated tools, active-recipient counts, and other required metrics where applicable.
+- Risk assessment and mitigation where applicable: If VLOP/VLOSE scope may apply, create risk assessment, mitigation tracker, crisis response, independent audit, compliance function, ad repository, and data access evidence.
+- Data access for auditors or vetted researchers where applicable: Use governed, scoped, logged, redacted, revocable access rather than ad hoc production database dumps.
+- Incident escalation and crisis-response evidence: Add DSA incident runbooks for notice workflow failure, moderation outage, ad metadata failure, ranking explanation defects, transparency reporting defects, or direct-to-main release control failures.
+- Privacy-safe observability: Exclude `delivery_instruction_note` from logs and Kafka payloads; preserve correlation IDs, order IDs, saga IDs, schema versions, and event names without logging free-text notes, access codes, secrets, tokens, or sensitive reports.
+
+## 6. Evidence Inventory
+
+- DSA scope inventory: Not present.
+- Terms, policies, and user-facing explanations: Not present.
+- Notice intake records: Not present.
+- Authority order records: Not present.
+- Content decision audit records: Not present.
+- Statement-of-reasons records: Not present.
+- Complaint and appeal records: Not present.
+- Recommender or ranking explanation records: Product Search Service exists; explanation evidence is not present.
+- User-control settings: Not present.
+- Advertising metadata and repository records: Not present.
+- Trader traceability evidence: Not present.
+- Transparency report jobs or outputs: Not present.
+- Risk assessment and mitigation records: Not present.
+- Audit reports or audit plans: Not present.
+- Researcher or authority data-access controls: Not present.
+- Incident runbooks and alert routing: General logs, metrics, traces, dashboards, and alerts are described; DSA-specific runbooks are not present.
+- Privacy-safe logging policy and tests: Feature requires delivery note log exclusion; tests are requested but not present.
+- Release decision: Not present.
+- Direct-to-main approval evidence: Not present beyond the described continuous delivery model.
+
+## 7. Residual Risks
+
+- Residual risk: Direct-to-main delivery may allow a DSA-sensitive platform, search, ranking, support, privacy, database, or Kafka contract change to reach production without independent review.
+- Impact: Missing DSA scope decision, weak transparency evidence, unapproved user-data propagation, incomplete rollback planning, and weak governance evidence.
+- Likelihood: Medium, because the reviewed delivery model commits every change directly to `main`.
+- Mitigation: Require protected-main rules or equivalent review controls, approval evidence, emergency exception process, and release gates for DSA-sensitive, privacy-sensitive, database, Kafka, search, ranking, ad, moderation, and transparency-affecting changes.
+- Owner: Platform owner, security owner, product owner, legal/compliance owner, architecture owner, and executive accountability owner.
+- Acceptance decision: Required before production release.
+- Review date: Before the direct-to-main commit is eligible for deployment.
+
+- Residual risk: DSA scope is unknown for the ecommerce platform and related product search, catalog, checkout, and support workflows.
+- Impact: Late discovery of notice, transparency, redress, trader traceability, recommender, ad, or VLOP/VLOSE evidence obligations.
+- Likelihood: Medium, because the reviewed system is customer-facing ecommerce but lacks classification evidence.
+- Mitigation: Record DSA scope decision, business model, EU geography, content flows, trader model, active-recipient count evidence, and accountable owners.
+- Owner: Legal/compliance, product owner, trust-and-safety owner, and business owner.
+- Acceptance decision: Required before treating the platform as DSA out of scope.
+- Review date: Before production reliance.
+
+- Residual risk: Product search or ranking may lack user-facing explanation and user-control evidence if recommender or platform transparency duties apply.
+- Impact: Incomplete transparency evidence and weak owner review for product discovery behavior.
+- Likelihood: Unknown, because ranking behavior is not described.
+- Mitigation: Record ranking parameters, sort controls, personalization status, explanation snapshots, and product owner approval.
+- Owner: Product owner, search-platform owner, legal/compliance owner, and privacy owner.
+- Acceptance decision: Required if online platform or recommender duties apply.
+- Review date: Before production deployment.
+
+- Residual risk: Delivery instruction free text may spread through logs, Kafka, support tools, or incident evidence.
+- Impact: Privacy exposure and unreliable governance evidence.
+- Likelihood: Medium, because the feature explicitly introduces free text and event changes.
+- Mitigation: Exclude notes from Kafka and logs, use field-level authorization for note lookup, add privacy-safe logging tests, and review retention rules.
+- Owner: CheckoutService owner, privacy owner, security owner, and legal/compliance owner.
+- Acceptance decision: Required before production release.
+- Review date: Before committing to `main` and before production deployment.
+
+## 8. Release Decision
+
+- Decision: Blocked for production until direct-to-main delivery is supplemented with DSA scope, owner handoff, and platform change-control evidence. If qualified owners confirm the change does not involve DSA-regulated platform, hosting, marketplace, advertising, recommender, or VLOP/VLOSE workflows, DSA-specific blockers can be closed with that evidence.
+- Conditions:
+  - Protected-main or equivalent pre-commit approval control is enforced for this change.
+  - DSA scope inventory confirms whether the ecommerce platform has intermediary, hosting, online platform, marketplace, search, advertising, recommender, or VLOP/VLOSE concerns.
+  - Product search and ranking behavior is reviewed for explanation and user-control evidence.
+  - Delivery instruction notes are excluded from Kafka and operational logs.
+  - Database migration tests and Kafka schema version 3 compatibility tests are linked to the release.
+  - Legal/compliance and product owners confirm whether notice, moderation, complaint, appeal, trader traceability, ad transparency, or transparency reporting controls are needed.
+- Blockers:
+  - Direct-to-main commit path lacks explicit pre-merge review, protected-main approval, or exception evidence.
+  - Missing DSA scope classification and owners.
+  - Missing evidence for product search/ranking explanation and user controls.
+  - Missing privacy-safe logging tests for free-text delivery notes.
+  - Missing release evidence for database migration approval and Kafka compatibility.
+- Required approvals: Service owner, tech lead, product owner, platform owner, privacy owner, security owner, legal/compliance owner, trust-and-safety owner when applicable, business owner, and executive accountability owner for direct-to-main exception or approval policy.
+- Expiry or review date: Before committing to `main` and again before production deployment.
+- Environments approved: Development and test only until blockers are resolved.
+- Emergency rollback path: Previous validated image plus compatible database state. Confirm whether the order table migration can be safely rolled forward or rolled back without losing delivery instruction data.
+
+## 9. Action Plan
+
+| Priority | Action | Owner | Due date | Evidence expected | Status |
+| -------- | ------ | ----- | -------- | ----------------- | ------ |
+| High | Add protected-main or equivalent auditable review control for the CheckoutService delivery-instructions change | Platform owner / security owner | Before production deployment | Branch protection, approval, or exception evidence | Open |
+| High | Require DSA and privacy pre-commit review for platform-scope, search, ranking, ad, moderation, transparency, database migration, Kafka contract, and production-side-effect changes | Product owner / legal-compliance owner / architecture owner | Before committing to `main` | Review checklist and approval record | Open |
+| High | Create DSA scope inventory covering intermediary, hosting, online platform, marketplace, search, recommender, advertising, trader, active-recipient, and VLOP/VLOSE signals | Product owner / legal-compliance owner | Before release approval | DSA scope record linked to release | Open |
+| High | Add privacy-safe logging and Kafka contract tests proving free-text delivery notes are not logged or broadcast | CheckoutService owner / security owner | Before release approval | Test report and logging policy evidence | Open |
+| High | Add migration approval and tests for nullable/default order columns and rollback or forward-fix behavior | CheckoutService owner / data owner | Before release approval | Migration test results and release note | Open |
+| High | Add Kafka schema version 3 compatibility evidence for `delivery.slot.requested`, `order.created`, and `order.confirmed` | CheckoutService owner / downstream service owners | Before release approval | Contract test report and schema evidence | Open |
+| Medium | Record product search and ranking explanation evidence, user controls, personalization status, and owner approval | Search-platform owner / product owner | Before production deployment | Ranking explanation snapshot and user-control record | Open |
+| Medium | Confirm whether ads, promoted listings, third-party traders, user reviews, notices, moderation, complaints, or appeals exist outside the reviewed files | Product owner / trust-and-safety owner | Before production deployment | Capability inventory and owner decisions | Open |
+| Medium | Define DSA incident escalation for notice, moderation, ranking, ad, transparency, direct-to-main control, or reporting workflow failures if those capabilities exist | Trust-and-safety / security operations | Before production deployment | Runbook and alert-routing evidence | Open |
+| Low | Schedule next DSA engineering review after any marketplace, ad, recommender, review, moderation, direct-to-main policy, or EU-scale change | Product owner / legal-compliance owner | After production validation | Review trigger record | Open |
+
+## 10. Final Notes
+
+- Items requiring legal interpretation: Intermediary, hosting, online platform, marketplace, online search engine, VLOP/VLOSE, illegal-content, advertising, recommender, audit, researcher-access, and regulatory interpretation.
+- Items requiring platform or intermediary classification: Ecommerce platform business model, product source model, EU recipient targeting, and active-recipient count.
+- Items requiring illegal-content or policy interpretation: None confirmed in reviewed files; required if product listings, user reviews, seller content, or delivery notes become subject to moderation.
+- Items requiring advertising or recommender interpretation: Product search/ranking, promoted listings, personalization, and sponsored placement status.
+- Items requiring VLOP/VLOSE, systemic-risk, audit, or researcher-access review: Active-recipient count and designation status are unknown.
+- Items requiring privacy or security review: Direct-to-main release path, delivery instruction note handling, logs, Kafka payloads, support tooling, retention, and field-level authorization.
+- Items requiring product or business acceptance: DSA scope decision, search/ranking transparency, direct-to-main residual risk, delivery note user experience, and release timing.
+- Next review trigger: Direct-to-main approval request, production deployment request, marketplace or trader capability, ad or promoted listing capability, recommender change, user-generated public content, moderation workflow, active-recipient threshold review, direct-to-main policy change, database schema change, Kafka event contract change, or privacy-safe observability failure.

--- a/examples/regulations/eu-digital-services-act/DSA-ENGINEERING-REVIEW-REPORT.md
+++ b/examples/regulations/eu-digital-services-act/DSA-ENGINEERING-REVIEW-REPORT.md
@@ -1,0 +1,191 @@
+# Digital Services Act Engineering Review Report
+
+Use this report as engineering evidence for legal, compliance, trust-and-safety, privacy, security, product, risk, audit, research-access, architecture, and business-owner review.
+
+This report is not legal advice. It identifies engineering controls and escalation points from the reviewed system evidence. Intermediary classification, platform classification, VLOP or VLOSE status, illegal-content determinations, advertising or recommender interpretation, audit or researcher access duties, systemic-risk conclusions, and regulatory interpretation require qualified owner review.
+
+## 1. Review Context
+
+- System or service name: CheckoutService delivery instructions change
+- Repository, product, platform, or business service: Fictional Java Quarkus ecommerce platform
+- Review date: 2026-06-14
+- Reviewers: AI-assisted Digital Services Act engineering review
+- Business owner: Not identified in reviewed evidence
+- Technical owner: Software engineers, tech leads, reviewers, and platform engineers are described, but no named CheckoutService owner is identified
+- Product owner: Not identified in reviewed evidence
+- Trust-and-safety owner: Not identified in reviewed evidence
+- Privacy owner: Not identified in reviewed evidence
+- Security owner: Not identified in reviewed evidence
+- Legal/compliance owner: Not identified in reviewed evidence
+- Risk or audit owner: Not identified in reviewed evidence
+- Research-access owner, where applicable: Not identified in reviewed evidence
+- Source materials reviewed:
+  - `examples/diagrams/deployment/system-example-cicd-pr-model.md`
+  - `examples/diagrams/deployment/expected-system-deployment.puml`
+  - `examples/diagrams/deployment/checkout-service-feature-request.md`
+  - `.agents/skills/807-regulations-eu-digital-services-act/references/807-regulations-eu-digital-services-act-chapters-summary.md`
+  - `.agents/skills/807-regulations-eu-digital-services-act/references/807-regulations-eu-digital-services-act-engineering-examples.md`
+  - `.agents/skills/807-regulations-eu-digital-services-act/assets/reports/807-eu-digital-services-act-engineering-review-report-template.md`
+
+## 2. Service And Platform Context
+
+- Service description: CheckoutService coordinates checkout saga steps for price validation, inventory reservation, payment authorization, order creation, delivery slot booking, PostgreSQL order state, saga state, and Kafka events.
+- Possible intermediary-service signal: The reviewed evidence describes a customer-facing ecommerce platform and web storefront, but it does not confirm that CheckoutService or the platform offers an intermediary service under the Digital Services Act.
+- Possible hosting-service signal: The feature stores shopper-provided delivery instructions for order fulfillment, but the reviewed evidence does not show public dissemination of recipient-provided information.
+- Possible online-platform or marketplace signal: Ecommerce, catalog, search, checkout, payment, delivery, and shopper interactions are present. The reviewed evidence does not confirm third-party trader listings, user-generated public content, or marketplace platform classification.
+- Possible online-search-engine signal: A product Search Service exists, but the reviewed evidence does not show a general online search engine. Product ranking or search explanations may still be product governance evidence.
+- Possible advertising or recommender signal: No advertising, promoted listing, personalization, or recommender workflow is described in the reviewed files.
+- Possible VLOP or VLOSE signal: No active-recipient count, designation, or very-large-platform evidence is present.
+- Deployment geography: Azure production environment is described; EU recipient geography and Member State targeting are not specified.
+- Environments in scope: Development, test, staging, and production.
+- Active-recipient or user-scale evidence: Not present.
+- User, trader, or third-party content flows: Shopper-provided delivery instructions are persisted with orders. Product catalog ownership, trader listing source, user reviews, public posts, ads, and marketplace seller flows are not described.
+- Open applicability questions:
+  - Does the ecommerce platform qualify as an intermediary service, hosting service, online platform, or marketplace under the Digital Services Act?
+  - Are products listed by the platform itself, internal catalog owners, or third-party traders?
+  - Does the Search Service use ranking, recommender, personalization, or sponsored placement logic that needs user-facing explanation or ad transparency evidence?
+  - Are there notice-and-action, moderation, complaint, appeal, trader traceability, or transparency-reporting workflows outside the reviewed files?
+  - Could the platform meet VLOP or VLOSE thresholds, and who owns active-recipient measurement?
+
+## 3. DSA Engineering Scope
+
+- Applications, APIs, jobs, and batch workloads: Web storefront BFF, API gateway, identity, catalog, search, cart, pricing, CheckoutService, payment adapter, inventory, delivery slot, notification worker, analytics pipeline, checkout saga logic, and deployment workflows.
+- User-generated content, trader listings, product data, ads, or third-party information: Shopper delivery instructions are user-provided order data. Product data exists, but the reviewed evidence does not identify third-party trader listings, user reviews, public content, or ads.
+- Notice intake, authority orders, and response workflows: Not present in reviewed evidence.
+- Content decision audit logs and moderation workflow state: Not present; no content moderation workflow is described.
+- Complaint, appeal, out-of-court dispute, and reinstatement workflows: Not present in reviewed evidence.
+- Recommender, ranking, search, personalization, and user-control workflows: Product search exists; ranking parameters, sort controls, personalization, and user-facing explanation evidence are not present.
+- Advertising transparency metadata and repository evidence: Not present; no ads or promoted listings are described.
+- Marketplace trader traceability and compliance-by-design controls: Not present; no trader onboarding or seller listing evidence is described.
+- Risk assessment, audit, crisis response, and data access workflows where applicable: Not present; VLOP/VLOSE scope is not established.
+- Logs, metrics, traces, dashboards, and privacy-safe observability: Azure Monitor, App Insights, Log Analytics, structured logs, metrics, traces, correlation IDs, dashboards, alerts, health checks, and smoke tests are described. The feature explicitly requires free-text delivery notes to be excluded from operational logs.
+- Operational runbooks and support model: Support and operations teams are described, but DSA-specific notice, moderation, appeal, transparency, audit, or researcher-access runbooks are not present.
+
+## 4. Potential Violation Or Non-Compliance Mapping
+
+This section is not a legal finding. It lists concrete potential Digital Services Act violation or non-compliance signals from the reviewed evidence and routes each item to qualified owner review. No violation is confirmed by this engineering review.
+
+| Potential violation or non-compliance signal | DSA reference area | Associated official-source link | Evidence from reviewed system | Current status | Required owner review | Engineering action |
+| -------------------------------------------- | ------------------ | ------------------------------- | ----------------------------- | -------------- | --------------------- | ------------------ |
+| Unclear intermediary, hosting, online-platform, marketplace, or online-search scope | Applicability and definitions | [Chapter I](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_I) | Ecommerce storefront, product search, checkout, and shopper delivery instructions are described, but DSA classification is not recorded | Potential gap | Legal / compliance / product owner | Record DSA scope decision, EU recipient geography, content flows, trader model, and accountable owners |
+| Missing DSA owner model | Due diligence governance evidence | [Chapter III](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | No legal, compliance, trust-and-safety, privacy, product, risk, audit, or research-access owners are named | Potential gap | Business / product / legal / compliance | Add DSA scope inventory with owner handoffs for platform, search, catalog, checkout, support, and observability |
+| Missing notice intake and response tracking if hosting duties apply | Notice-and-action controls | [Chapter III, Section 2](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | No notice-and-action, authority order, statement-of-reasons, or trusted flagger workflow is described | Potential gap if hosting or platform duties apply | Trust-and-safety / legal / security | Add notice intake, validation, triage, action, response, statement-of-reasons, and redress tracking where applicable |
+| Missing complaint and appeal workflow evidence if online platform duties apply | Online platform redress controls | [Chapter III, Section 3](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | Support and operations teams are described, but complaint, appeal, dispute, reinstatement, and moderation reversal evidence is not present | Potential gap if online platform duties apply | Trust-and-safety / product / legal | Define appeal state, deadlines, decisions, reinstatement actions, notifications, and evidence retention where applicable |
+| Missing product search or ranking explanation evidence | Recommender and ranking transparency | [Article 27](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | Product Search Service exists; ranking parameters, sort controls, personalization status, and user-facing explanations are not shown | Potential gap if recommender duties apply | Product / search-platform / legal / privacy | Record search and ranking parameters, user controls, personalization status, and explanation snapshots |
+| Missing ad transparency metadata if promoted listings or ads exist | Advertising transparency | [Article 26](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | No advertising or sponsored listing workflow is described | Open question | Product / ads owner / legal / privacy | Confirm whether ads or sponsored placements exist; if yes, attach ad labels, payer, beneficiary, targeting parameters, and guardrail evidence |
+| Missing trader traceability if marketplace duties apply | Marketplace trader controls | [Chapter III, Section 4](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | Product catalog is described, but trader onboarding, seller identity, and listing completeness evidence are not shown | Open question | Marketplace / legal / compliance | Confirm product source model; add trader traceability and compliance-by-design evidence if third-party traders can sell |
+| Missing VLOP/VLOSE evidence if platform scale applies | Systemic-risk obligations | [Chapter III, Section 5](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | No active-recipient count, designation, risk assessment, audit, ad repository, data access, or researcher-access evidence is present | Open question | Legal / risk / audit / research-access / executive accountability | Add active-recipient measurement and VLOP/VLOSE review; if applicable, create risk, audit, mitigation, crisis, transparency, and governed data-access evidence |
+| Privacy-safe observability gap for free-text delivery notes | Evidence and confidentiality controls | [Chapter IV](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_IV) | The feature requires `delivery_instruction_note` to be excluded from logs and Kafka; tests are requested but not shown in reviewed evidence | Potential gap | Security / privacy / platform owner | Add privacy-safe logging tests, redaction policy, and observability review for delivery instruction data |
+| Database migration and Kafka contract change may affect platform evidence | Engineering change control | [Chapter III](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | Feature adds order columns and changes Kafka event schema to version 3 for `delivery.slot.requested`, `order.created`, and `order.confirmed` | Potential gap | Architecture / platform / product owner | Require migration approval, Kafka compatibility evidence, and release records before production deployment |
+
+## 5. Engineering Controls
+
+- Scope and service inventory: Add a DSA inventory entry for storefront, catalog, search, cart, checkout, delivery, notification, support, analytics, and any marketplace, moderation, ad, recommender, or trader workflows.
+- Authority order and information request tracking: If DSA hosting or intermediary duties apply, add order receipt, legal basis, content locator, territorial scope, response time, user notification, and redress evidence.
+- Notice intake and response tracking: If hosting or online platform duties apply, add notice validation, triage, deduplication, action, response, statement-of-reasons, trusted flagger, and misuse tracking.
+- Content decision audit logs: If product listings, user content, reviews, ads, or accounts can be restricted, record decision source, policy reference, evidence ID, action, user notification, appeal availability, and workflow state.
+- Moderation workflow state: Define queues, states, deadlines, ownership, reversals, reinstatement, and redacted evidence storage where moderation exists.
+- Statement-of-reasons records: Create structured records for removals, disabling, demotion, suspension, account restrictions, or marketplace listing restrictions where applicable.
+- User notification and redress: Add user-facing notifications, support escalation, appeal eligibility, and out-of-court dispute information where applicable.
+- Complaint, appeal, dispute, and reinstatement workflows: Preserve appeal state, reviewer group, outcome, reversal, reinstatement action, and notifications.
+- Trusted flagger routing and misuse protections: Add priority routing, abuse detection, repeated manifestly unfounded notice handling, and owner approval if trusted flagger workflows exist.
+- Recommender and ranking explanation evidence: Record search and ranking parameters for product discovery, personalization status, sort controls, explanation snapshots, and user controls.
+- User controls and profiling-related alternatives where applicable: Add controls for sort, personalization, profiling-free alternatives where applicable, and minor-protection review if minors can use the storefront.
+- Advertising transparency metadata: If ads or sponsored listings exist, record ad label, payer, beneficiary, main targeting parameters, sensitive-profiling guardrails, and repository readiness where applicable.
+- Marketplace trader traceability: If third-party traders sell through the platform, record trader identity, contact, payment, registration, verification, listing completeness, suspension, and consumer notification evidence.
+- Transparency reporting: Add jobs or records for moderation actions, notices, complaints, automated tools, active-recipient counts, and other required metrics where applicable.
+- Minor-protection and online interface controls: Review dark-pattern, interface design, default privacy, safety, and security controls if minors or vulnerable users may use the platform.
+- Risk assessment and mitigation where applicable: If VLOP/VLOSE scope may apply, create risk assessment, mitigation tracker, crisis response, independent audit, compliance function, ad repository, and data access evidence.
+- Data access for auditors or vetted researchers where applicable: Use governed, scoped, logged, redacted, revocable access rather than ad hoc production database dumps.
+- Incident escalation and crisis-response evidence: Add DSA incident runbooks for notice workflow failure, moderation outage, ad metadata failure, ranking explanation defects, or transparency reporting defects.
+- Privacy-safe observability: Exclude `delivery_instruction_note` from logs and Kafka payloads; preserve correlation IDs, order IDs, saga IDs, schema versions, and event names without logging free-text notes, access codes, secrets, tokens, or sensitive reports.
+
+## 6. Evidence Inventory
+
+- DSA scope inventory: Not present.
+- Terms, policies, and user-facing explanations: Not present.
+- Notice intake records: Not present.
+- Authority order records: Not present.
+- Content decision audit records: Not present.
+- Statement-of-reasons records: Not present.
+- Complaint and appeal records: Not present.
+- Recommender or ranking explanation records: Product Search Service exists; explanation evidence is not present.
+- User-control settings: Not present.
+- Advertising metadata and repository records: Not present.
+- Trader traceability evidence: Not present.
+- Transparency report jobs or outputs: Not present.
+- Risk assessment and mitigation records: Not present.
+- Audit reports or audit plans: Not present.
+- Researcher or authority data-access controls: Not present.
+- Incident runbooks and alert routing: General logs, metrics, traces, dashboards, and alerts are described; DSA-specific runbooks are not present.
+- Privacy-safe logging policy and tests: Feature requires delivery note log exclusion; tests are requested but not present.
+- Release decision: Not present.
+
+## 7. Residual Risks
+
+- Residual risk: DSA scope is unknown for the ecommerce platform and related product search, catalog, checkout, and support workflows.
+- Impact: Late discovery of notice, transparency, redress, trader traceability, recommender, ad, or VLOP/VLOSE evidence obligations.
+- Likelihood: Medium, because the reviewed system is customer-facing ecommerce but lacks classification evidence.
+- Mitigation: Record DSA scope decision, business model, EU geography, content flows, trader model, active-recipient count evidence, and accountable owners.
+- Owner: Legal/compliance, product owner, trust-and-safety owner, and business owner.
+- Acceptance decision: Required before treating the platform as DSA out of scope.
+- Review date: Before production reliance on the delivery-instructions change.
+
+- Residual risk: Product search or ranking may lack user-facing explanation and user-control evidence if recommender or platform transparency duties apply.
+- Impact: Incomplete transparency evidence and weak owner review for product discovery behavior.
+- Likelihood: Unknown, because ranking behavior is not described.
+- Mitigation: Record ranking parameters, sort controls, personalization status, explanation snapshots, and product owner approval.
+- Owner: Product owner, search-platform owner, legal/compliance owner, and privacy owner.
+- Acceptance decision: Required if online platform or recommender duties apply.
+- Review date: Before production deployment.
+
+- Residual risk: Delivery instruction free text may spread through logs, Kafka, support tools, or incident evidence.
+- Impact: Privacy exposure and unreliable governance evidence.
+- Likelihood: Medium, because the feature explicitly introduces free text and event changes.
+- Mitigation: Exclude notes from Kafka and logs, use field-level authorization for note lookup, add privacy-safe logging tests, and review retention rules.
+- Owner: CheckoutService owner, privacy owner, security owner, and legal/compliance owner.
+- Acceptance decision: Required before production release.
+- Review date: Before merge and before production deployment.
+
+## 8. Release Decision
+
+- Decision: Conditionally blocked for DSA production reliance until DSA scope and owner handoffs are recorded. If qualified owners confirm the change does not involve DSA-regulated platform, hosting, marketplace, advertising, recommender, or VLOP/VLOSE workflows, DSA-specific blockers can be closed with that evidence.
+- Conditions:
+  - DSA scope inventory confirms whether the ecommerce platform has intermediary, hosting, online platform, marketplace, search, advertising, recommender, or VLOP/VLOSE concerns.
+  - Product search and ranking behavior is reviewed for explanation and user-control evidence.
+  - Delivery instruction notes are excluded from Kafka and operational logs.
+  - Database migration tests and Kafka schema version 3 compatibility tests are linked to the release.
+  - Legal/compliance and product owners confirm whether notice, moderation, complaint, appeal, trader traceability, ad transparency, or transparency reporting controls are needed.
+- Blockers:
+  - Missing DSA scope classification and owners.
+  - Missing evidence for product search/ranking explanation and user controls.
+  - Missing privacy-safe logging tests for free-text delivery notes.
+  - Missing release evidence for database migration approval and Kafka compatibility.
+- Required approvals: Service owner, tech lead, product owner, platform owner, privacy owner, security owner, legal/compliance owner, trust-and-safety owner when applicable, and business owner.
+- Expiry or review date: Before merge and again before production deployment.
+- Environments approved: Development and test only until blockers are resolved.
+- Emergency rollback path: Previous validated image plus compatible database state. Confirm whether the order table migration can be safely rolled forward or rolled back without losing delivery instruction data.
+
+## 9. Action Plan
+
+| Priority | Action | Owner | Due date | Evidence expected | Status |
+| -------- | ------ | ----- | -------- | ----------------- | ------ |
+| High | Create DSA scope inventory covering intermediary, hosting, online platform, marketplace, search, recommender, advertising, trader, active-recipient, and VLOP/VLOSE signals | Product owner / legal-compliance owner | Before PR approval | DSA scope record linked to release | Open |
+| High | Add privacy-safe logging and Kafka contract tests proving free-text delivery notes are not logged or broadcast | CheckoutService owner / security owner | Before merge | Test report and logging policy evidence | Open |
+| High | Add migration approval and tests for nullable/default order columns and rollback or forward-fix behavior | CheckoutService owner / data owner | Before merge | Migration test results and release note | Open |
+| High | Add Kafka schema version 3 compatibility evidence for `delivery.slot.requested`, `order.created`, and `order.confirmed` | CheckoutService owner / downstream service owners | Before merge | Contract test report and schema evidence | Open |
+| Medium | Record product search and ranking explanation evidence, user controls, personalization status, and owner approval | Search-platform owner / product owner | Before production deployment | Ranking explanation snapshot and user-control record | Open |
+| Medium | Confirm whether ads, promoted listings, third-party traders, user reviews, notices, moderation, complaints, or appeals exist outside the reviewed files | Product owner / trust-and-safety owner | Before production deployment | Capability inventory and owner decisions | Open |
+| Medium | Define DSA incident escalation for notice, moderation, ranking, ad, transparency, or reporting workflow failures if those capabilities exist | Trust-and-safety / security operations | Before production deployment | Runbook and alert-routing evidence | Open |
+| Low | Schedule next DSA engineering review after any marketplace, ad, recommender, review, moderation, or EU-scale change | Product owner / legal-compliance owner | After production validation | Review trigger record | Open |
+
+## 10. Final Notes
+
+- Items requiring legal interpretation: Intermediary, hosting, online platform, marketplace, online search engine, VLOP/VLOSE, illegal-content, advertising, recommender, audit, researcher-access, and regulatory interpretation.
+- Items requiring platform or intermediary classification: Ecommerce platform business model, product source model, EU recipient targeting, and active-recipient count.
+- Items requiring illegal-content or policy interpretation: None confirmed in reviewed files; required if product listings, user reviews, seller content, or delivery notes become subject to moderation.
+- Items requiring advertising or recommender interpretation: Product search/ranking, promoted listings, personalization, and sponsored placement status.
+- Items requiring VLOP/VLOSE, systemic-risk, audit, or researcher-access review: Active-recipient count and designation status are unknown.
+- Items requiring privacy or security review: Delivery instruction note handling, logs, Kafka payloads, support tooling, retention, and field-level authorization.
+- Items requiring product or business acceptance: DSA scope decision, search/ranking transparency, delivery note user experience, and release timing.
+- Next review trigger: PR approval request, production deployment request, marketplace or trader capability, ad or promoted listing capability, recommender change, user-generated public content, moderation workflow, active-recipient threshold review, database schema change, Kafka event contract change, or privacy-safe observability failure.

--- a/skills-generator/src/main/resources/skill-indexes/807-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/807-skill.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="https://jabrena.github.io/pml/schemas/0.7.0/pml.xsd"
+      id="807-regulations-eu-digital-services-act">
+  <metadata>
+    <author>Juan Antonio Breña Moral</author>
+    <version>0.16.0-SNAPSHOT</version>
+    <license>Apache-2.0</license>
+    <description>Use when reviewing, designing, or modifying Java enterprise systems that may support intermediary services, hosting services, online platforms, marketplaces, content moderation, recommender systems, advertising delivery, complaint workflows, transparency reporting, or systemic-risk evidence under the EU Digital Services Act. This should trigger for requests such as Review a Java online platform for DSA controls; Design notice-and-action or appeal workflows; Add recommender, ad transparency, moderation, audit, researcher access, or privacy-safe observability evidence; Assess online-platform transparency controls before production release.</description>
+  </metadata>
+
+  <title>EU Digital Services Act Regulation for Java Online Platform Engineering</title>
+  <goal><![CDATA[
+Use this Skill to review Java enterprise applications, online platforms, marketplaces, hosting services, content moderation tools, recommender systems, advertising systems, complaint workflows, transparency reporting pipelines, operational dashboards, or audit evidence that may require Digital Services Act-aware engineering controls.
+
+Apply this Skill to determine what engineering controls, operational evidence, and escalation paths are needed before a Java system is released, connected to production traffic, used for online platform operations, or relied on for content moderation, recommender, advertising, complaint, or systemic-risk workflows.
+
+This Skill is not legal advice. It helps Java engineers, architects, tech leads, platform teams, trust-and-safety teams, and reviewers identify when Digital Services Act concerns may apply and how to translate online platform expectations into enterprise architecture controls such as content decision audit logs, moderation workflow state, notice intake and response tracking, recommender and ranking explanation evidence, advertising transparency metadata, user controls, complaint and appeal workflows, risk assessment evidence, incident escalation, data access for auditors or researchers where applicable, and privacy-safe observability.
+
+The purpose of this Skill is to increase awareness of potential gaps in the system and create engineering evidence for qualified review. The response produced by this Skill does not represent legal advice, a legal opinion, or a final regulatory determination.
+
+The main question is:
+
+> When does a Java enterprise system require Digital Services Act-aware online platform controls, and what should developers build differently?
+
+External reference: [Regulation (EU) 2022/2065 Digital Services Act](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065).
+
+Digital Services Act chapters summary reference: [Digital Services Act chapters summary](references/807-regulations-eu-digital-services-act-chapters-summary.md).
+
+Java engineering examples reference: [Digital Services Act engineering examples](references/807-regulations-eu-digital-services-act-engineering-examples.md).
+
+Report template asset: [Digital Services Act engineering review report template](assets/reports/807-eu-digital-services-act-engineering-review-report-template.md).
+
+## Scope
+
+This Skill applies to:
+
+- Java systems that may provide intermediary services, hosting services, online platforms, online marketplaces, or online interfaces where users, traders, or third parties provide content, products, services, or information
+- Spring Boot, Quarkus, Micronaut, and framework-agnostic Java services with notice-and-action, content moderation, statement-of-reasons, trusted flagger, complaint, appeal, or out-of-court dispute evidence requirements
+- Search, ranking, recommendation, feed, catalog ordering, personalization, advertising, ad repository, trader traceability, transparency reporting, user controls, and minor-protection workflows
+- Very large online platform or very large online search engine evidence where applicable, including systemic risk assessment, mitigation, crisis response, independent audit, compliance function, data access, vetted researcher access, and transparency reporting
+- Privacy-safe observability, incident escalation, moderation audit logging, user notification, workflow state, data access control, retention, and evidence reconstruction for platform governance
+
+## Digital Services Act Engineering Review
+
+Treat intermediary classification, hosting or online-platform classification, very-large-online-platform or very-large-online-search-engine scope, illegal-content policy, advertising or recommender interpretation, audit or researcher access duties, systemic-risk conclusions, and regulatory interpretation as governance decisions for legal, compliance, trust-and-safety, privacy, security, product, risk, and executive accountability owners.
+
+Engineering teams should still create evidence that makes those decisions reviewable:
+
+- Which user, trader, platform, marketplace, hosting, recommendation, advertising, complaint, or moderation workflows are in scope
+- Which content or product decisions are made, why they are made, which policy or order drove them, who can appeal them, and how decisions are audited
+- Which notices, orders, complaints, appeals, trusted flagger reports, and out-of-court dispute outcomes can be tracked end to end
+- Which recommender, ranking, advertising, user-control, minor-protection, trader-traceability, and transparency-reporting evidence exists
+- Which risk assessment, mitigation, audit, data access, researcher access, incident escalation, and privacy-safe observability evidence is available where VLOP or VLOSE concerns may apply
+]]></goal>
+
+  <constraints>
+    <constraints-description>Translate Digital Services Act concerns into engineering controls for Java enterprise systems. Do not provide legal advice or replace review by legal, compliance, trust-and-safety, privacy, security, product, risk, audit, research-access, or executive accountability owners.</constraints-description>
+    <constraint-list>
+      <constraint>**NOT LEGAL ADVICE**: Frame findings as online platform engineering controls and escalation points; recommend qualified review for intermediary classification, platform classification, VLOP or VLOSE status, illegal-content determinations, advertising or recommender interpretation, audit or researcher access duties, systemic-risk conclusions, and regulatory interpretation</constraint>
+      <constraint>**SCOPE FIRST**: Identify whether the Java system supports an intermediary service, hosting service, online platform, online marketplace, online search engine, recommender system, advertising workflow, or VLOP/VLOSE evidence flow before recommending controls</constraint>
+      <constraint>**MODERATION EVIDENCE**: Require traceable content decision audit logs, statement-of-reasons data, moderation workflow state, affected user notification, policy references, authority order references, and appeal eligibility where applicable</constraint>
+      <constraint>**NOTICE AND RESPONSE TRACKING**: Verify notice intake, validation, deduplication, triage, action, response, redress, trusted flagger handling, and misuse protections are auditable end to end</constraint>
+      <constraint>**TRANSPARENCY CONTROLS**: Review transparency reporting, recommender and ranking explanation evidence, ad transparency metadata, user-facing controls, trader traceability, and online interface design evidence</constraint>
+      <constraint>**USER REDRESS**: Verify complaint, appeal, out-of-court dispute, reinstatement, and support workflows preserve state, deadlines, reasons, evidence, and owner handoffs</constraint>
+      <constraint>**SYSTEMIC RISK WHERE APPLICABLE**: For potential VLOP or VLOSE scope, require risk assessment, mitigation, crisis response, independent audit, compliance function, data access, vetted researcher access, and transparency evidence</constraint>
+      <constraint>**PRIVACY-SAFE OBSERVABILITY**: Preserve platform governance evidence without exposing secrets, credentials, personal data, illegal-content details, sensitive user reports, researcher data, or moderation training data unnecessarily</constraint>
+      <constraint>**RELATIONSHIP TO OTHER RULES**: Use GDPR, AI Act, DORA, NIS2, Data Act, or sector guidance together with this Skill when the same system crosses privacy, AI, cybersecurity, resilience, data access, or platform governance boundaries</constraint>
+    </constraint-list>
+  </constraints>
+
+  <triggers>
+    <trigger-list>
+        <trigger>Review a Java online platform for Digital Services Act controls</trigger>
+        <trigger>Design notice-and-action, content moderation, complaint, appeal, or transparency reporting workflows</trigger>
+        <trigger>Add recommender explanation, ranking controls, advertising transparency metadata, trader traceability, or user controls</trigger>
+        <trigger>Assess VLOP, VLOSE, audit, researcher access, systemic risk, or crisis-response evidence before production release</trigger>
+        <trigger>Check whether Java platform logs, metrics, traces, and dashboards preserve DSA evidence without exposing sensitive data</trigger>
+    </trigger-list>
+  </triggers>
+  <steps>
+    <step number="1"><step-title>Read regulation summary, engineering examples, and report template</step-title><step-content>Read `references/807-regulations-eu-digital-services-act-chapters-summary.md`, `references/807-regulations-eu-digital-services-act-engineering-examples.md`, and `assets/reports/807-eu-digital-services-act-engineering-review-report-template.md` in that order. Use the chapters summary for Digital Services Act chapter, article, scope, liability, due diligence, transparency, online platform, marketplace, VLOP/VLOSE, supervision, enforcement, and owner-handoff context. Use the engineering examples for Java control patterns such as content decision audit logs, moderation workflow state, notice intake and response tracking, recommender and ranking explanation evidence, ad transparency metadata, user controls, complaint and appeal workflows, risk assessment evidence, incident escalation, data access for auditors or researchers where applicable, and privacy-safe observability. Do not start implementation review until the chapters summary, examples reference, and report template are understood.</step-content></step>
+    <step number="2"><step-title>Classify the platform scope</step-title><step-content>Identify service context, possible intermediary-service signals, hosting signals, online-platform or marketplace signals, online search or recommender signals, advertising workflows, trader interactions, user-generated content, terms and policy owners, content moderation decisions, user-redress paths, active-recipient evidence, VLOP/VLOSE indicators, deployment geography, data stores, observability systems, and governance owners. Escalate unclear intermediary or platform classification, VLOP/VLOSE status, illegal-content interpretation, advertising or recommender interpretation, audit or researcher access duties, systemic-risk conclusions, and regulatory interpretation to legal, compliance, trust-and-safety, privacy, security, product, risk, audit, research-access, or executive accountability owners.</step-content></step>
+    <step number="3"><step-title>Review implementation and platform evidence</step-title><step-content>Review Java code, configuration, controllers, DTOs, moderation services, policy engines, workflow state machines, persistence models, message schemas, search or ranking code, recommender configuration, ad delivery metadata, user-control settings, complaint and appeal records, transparency reporting jobs, logs, metrics, traces, audit exports, runbooks, tests, deployment workflows, and provider documentation. Check for gaps between claimed DSA controls and reviewable evidence.</step-content></step>
+    <step number="4"><step-title>Recommend engineering controls</step-title><step-content>Map Digital Services Act concerns to engineering actions: scope inventory, content decision audit logs, notice-and-action tracking, statement-of-reasons records, moderation workflow state, trusted flagger routing, misuse protections, complaint and appeal workflows, recommender explanation evidence, ranking controls, user controls, ad transparency metadata, trader traceability, transparency reporting, minor-protection controls, privacy-safe observability, incident escalation, and VLOP/VLOSE risk, audit, and researcher-access evidence where applicable.</step-content></step>
+    <step number="5"><step-title>Generate review report and owner handoffs</step-title><step-content>Use `assets/reports/807-eu-digital-services-act-engineering-review-report-template.md` to produce a concise engineering review with scope, evidence reviewed, Digital Services Act risk signals, potential violation or non-compliance signals, engineering gaps, recommended controls, owner handoffs, residual risks, release decision, and validation steps. State explicitly that intermediary classification, platform classification, VLOP/VLOSE status, illegal-content determinations, advertising or recommender interpretation, audit or researcher access duties, systemic-risk conclusions, and regulatory interpretation require qualified owner review.</step-content></step>
+  </steps>
+</prompt>

--- a/skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-chapters-summary.xml
+++ b/skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-chapters-summary.xml
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <metadata>
+        <author>Juan Antonio Breña Moral</author>
+        <version>0.16.0-SNAPSHOT</version>
+        <license>Apache-2.0</license>
+        <title>EU Digital Services Act Regulation for Java Online Platform Engineering</title>
+        <description>Use as a chapter-by-chapter and article-by-article summary of Regulation (EU) 2022/2065 to enrich Java online platform, moderation, transparency, recommender, advertising, and systemic-risk engineering reviews with Digital Services Act context.</description>
+    </metadata>
+
+    <role>You are a senior Java enterprise architect and online platform governance reviewer using the Digital Services Act article structure to map regulatory themes to engineering controls and owner handoffs</role>
+
+    <goal><![CDATA[
+Summarize the official chapter, article, and section structure of Regulation (EU) 2022/2065, the Digital Services Act, for engineering review of Java enterprise systems, online platforms, marketplaces, content moderation tools, recommender systems, advertising delivery systems, complaint workflows, transparency reporting pipelines, and audit evidence.
+
+Source reviewed: [EUR-Lex Regulation (EU) 2022/2065 HTML text](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065).
+
+This reference is not legal advice. Use it to orient engineering discovery, architecture review, platform governance evidence collection, release gates, and escalation conversations with legal, compliance, trust-and-safety, privacy, security, product, risk, audit, research-access, executive accountability, and business owners.
+
+Use `references/807-regulations-eu-digital-services-act-engineering-examples.md` for Java examples and implementation control patterns. Keep this chapters summary focused on Digital Services Act structure and article-level engineering implications.
+
+Report template asset: [Digital Services Act engineering review report template](../assets/reports/807-eu-digital-services-act-engineering-review-report-template.md).
+
+## [Chapter I: General provisions (Articles 1-3)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_I)
+
+Sets the objective, scope, and definitions for intermediary services, hosting services, online platforms, online search engines, advertisements, recommender systems, and content moderation. For Java teams, this chapter is the starting point for deciding whether a service, marketplace, user-generated-content flow, search/ranking workflow, ad workflow, or moderation tool needs DSA-aware evidence.
+
+Article map:
+- Article 1, Subject matter: establishes harmonised rules for intermediary services, liability exemptions, due diligence obligations, implementation, enforcement, and authority cooperation.
+- Article 2, Scope: applies to intermediary services offered to recipients in the Union and clarifies interaction with other Union acts, including data protection, consumer protection, audiovisual media, copyright, and criminal/civil judicial cooperation.
+- Article 3, Definitions: defines information society service, recipient, consumer, trader, intermediary service, hosting service, illegal content, online platform, online search engine, dissemination to the public, online interface, active recipient, advertisement, recommender system, content moderation, terms and conditions, and commercial communication.
+
+Engineering impact:
+- Record whether the Java system stores, transmits, ranks, recommends, moderates, advertises, or disseminates information provided by recipients, traders, or third parties.
+- Record online platform, marketplace, hosting, search, recommender, advertising, and content moderation signals separately; do not collapse them into a generic "website" label.
+- Treat intermediary classification, platform classification, active-recipient counts, VLOP/VLOSE scope, illegal-content interpretation, and regulatory applicability as qualified owner decisions.
+
+## [Chapter II: Liability of providers of intermediary services (Articles 4-10)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_II)
+
+Defines liability exemptions for mere conduit, caching, and hosting services; permits good-faith voluntary own-initiative investigations; prohibits general monitoring obligations; and defines orders to act against illegal content and orders to provide information.
+
+Article map:
+- Article 4, Mere conduit: covers transmission and access services under defined conditions.
+- Article 5, Caching: covers automatic, intermediate, and temporary storage under defined conditions.
+- Article 6, Hosting: covers storage of recipient-provided information and action after actual knowledge or awareness of illegal content.
+- Article 7, Voluntary own-initiative investigations and legal compliance: protects good-faith voluntary measures from causing loss of liability exemptions solely because those measures were taken.
+- Article 8, No general monitoring or active fact-finding obligations: prohibits general monitoring or active fact-finding obligations.
+- Article 9, Orders to act against illegal content: defines order content, territorial scope, language, notification, redress, and authority communication expectations.
+- Article 10, Orders to provide information: defines order content and provider response expectations for information about specific recipients.
+
+Engineering impact:
+- Keep authority orders, legal basis references, content identifiers, territorial scope, response timestamps, user notifications, redress information, and execution outcomes traceable.
+- Design moderation workflows around specific items, reasons, actions, evidence, and owner handoffs rather than broad uncontrolled monitoring assumptions.
+- Preserve order evidence and user notifications without exposing sensitive reports, personal data, secrets, or illegal-content details beyond need-to-know controls.
+
+## [Chapter III: Due diligence obligations for a transparent and safe online environment (Articles 11-48)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III)
+
+Defines layered obligations for all intermediary providers, hosting providers, online platforms, marketplaces, VLOPs, VLOSEs, and cross-cutting standards and codes of conduct. This chapter contains most DSA engineering controls for Java systems.
+
+Section 1, provisions applicable to all providers of intermediary services:
+- Article 11, Points of contact for Member State authorities, the Commission and the Board
+- Article 12, Points of contact for recipients of the service
+- Article 13, Legal representatives
+- Article 14, Terms and conditions
+- Article 15, Transparency reporting obligations for providers of intermediary services
+
+Engineering impact:
+- Maintain contact channels, terms and policy versions, machine-readable transparency records, moderation counts, automated-tool usage, and governance owners.
+- Link terms and conditions to moderation rules, recommender rules, ad policies, and user-facing explanation records.
+
+Section 2, additional provisions for hosting services, including online platforms:
+- Article 16, Notice and action mechanisms
+- Article 17, Statement of reasons
+- Article 18, Notification of suspicions of criminal offences
+
+Engineering impact:
+- Build notice intake with validation, evidence, content locator, submitter contact, legal or policy basis, triage, decision, response, deduplication, and misuse tracking.
+- Persist statement-of-reasons data for restrictions, removals, account suspensions, demotion, demonetisation, visibility limits, and appeal eligibility.
+- Escalate suspected criminal offences, threats to life or safety, illegal-content determinations, and reporting duties to qualified legal, trust-and-safety, security, and law-enforcement liaison owners.
+
+Section 3, additional provisions for online platforms:
+- Article 19, Exclusion for micro and small enterprises
+- Article 20, Internal complaint-handling system
+- Article 21, Out-of-court dispute settlement
+- Article 22, Trusted flaggers
+- Article 23, Measures and protection against misuse
+- Article 24, Transparency reporting obligations for providers of online platforms
+- Article 25, Online interface design and organisation
+- Article 26, Advertising on online platforms
+- Article 27, Recommender system transparency
+- Article 28, Online protection of minors
+
+Engineering impact:
+- Track complaint and appeal state, deadlines, decisions, reversals, reinstatement actions, trusted flagger priority handling, misuse warnings, and suspension evidence.
+- Provide user-facing ad labels, advertiser or payer information, main targeting parameters, and ad metadata while avoiding prohibited sensitive profiling patterns.
+- Provide recommender system parameters, ranking explanation evidence, and user controls for at least the main parameters that determine relative prominence.
+- Review dark-pattern, minor-protection, and user-choice interface risks with product, design, legal, privacy, and trust-and-safety owners.
+
+Section 4, additional provisions for online platforms allowing consumers to conclude distance contracts with traders:
+- Article 29, Exclusion for micro and small enterprises
+- Article 30, Traceability of traders
+- Article 31, Compliance by design
+- Article 32, Right to information
+
+Engineering impact:
+- Track trader identity, contact, payment, registration, self-certification, product or service listing completeness, suspension decisions, and consumer notification evidence.
+- Design marketplace onboarding, listing, and checkout interfaces so traders can provide required information before products or services are offered.
+- Preserve consumer-facing information and post-facto information duties after illegal product or service findings while coordinating privacy, fraud, and legal owners.
+
+Section 5, additional obligations for providers of very large online platforms and very large online search engines to manage systemic risks:
+- Article 33, Very large online platforms and very large online search engines
+- Article 34, Risk assessment
+- Article 35, Mitigation of risks
+- Article 36, Crisis response mechanism
+- Article 37, Independent audit
+- Article 38, Recommender systems
+- Article 39, Additional online advertising transparency
+- Article 40, Data access and scrutiny
+- Article 41, Compliance function
+- Article 42, Transparency reporting obligations
+- Article 43, Supervisory fee
+
+Engineering impact:
+- Treat active-recipient measurement, VLOP/VLOSE designation, systemic-risk conclusions, and risk acceptance as qualified governance decisions.
+- Preserve risk assessment inputs, model or ranking changes, recommender alternatives not based on profiling where applicable, mitigation decisions, crisis-response evidence, independent audit evidence, compliance-function handoffs, public transparency reporting, ad repository metadata, and data access controls for authorities and vetted researchers.
+- Implement researcher and auditor data access through scoped, logged, privacy-preserving, confidential, rate-limited, and revocable access paths.
+
+Section 6, other provisions concerning due diligence obligations:
+- Article 44, Standards
+- Article 45, Codes of conduct
+- Article 46, Codes of conduct for online advertising
+- Article 47, Codes of conduct for accessibility
+- Article 48, Crisis protocols
+
+Engineering impact:
+- Track standards, codes of conduct, advertising commitments, accessibility commitments, crisis protocols, and technical controls as architecture and release evidence.
+
+## [Chapter IV: Implementation, cooperation, penalties and enforcement (Articles 49-88)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_IV)
+
+Defines Digital Services Coordinators, enforcement powers, complaints, compensation, authority cooperation, the European Board for Digital Services, Commission supervision for VLOP/VLOSE obligations, investigatory powers, fines, penalty payments, professional secrecy, information sharing, representation, delegated acts, and committee procedure.
+
+Article groups:
+- Articles 49-55: competent authorities, Digital Services Coordinators, powers, penalties, complaint rights, compensation, and activity reports.
+- Articles 56-60: competences, mutual assistance, cross-border cooperation, referral to the Commission, and joint investigations.
+- Articles 61-63: European Board for Digital Services structure and tasks.
+- Articles 64-83: Commission expertise, VLOP/VLOSE enforcement, information requests, interviews, inspections, interim measures, commitments, monitoring, non-compliance, fines, enhanced supervision, penalty payments, limitation periods, right to be heard, publication, Court of Justice review, access restrictions, and implementing acts.
+- Articles 84-86: professional secrecy, information sharing system, and representation.
+- Articles 87-88: delegated acts and committee procedure.
+
+Engineering impact:
+- Keep DSA evidence structured enough for complaints, authority requests, audits, investigations, inspections, cross-border cooperation, Commission requests, and remedial action plans.
+- Treat missing, false, incomplete, or obstructed evidence as an engineering risk, not only a legal risk.
+- Coordinate confidentiality, personal-data protection, professional secrecy, and trade-secret safeguards when sharing logs, datasets, models, ranking evidence, ad data, and moderation records.
+
+## [Chapter V: Final provisions (Articles 89-93)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_V)
+
+Covers amendments, review, anticipated application for VLOP/VLOSE providers, entry into force, and application.
+
+Article map:
+- Article 89, Amendments to Directive 2000/31/EC
+- Article 90, Amendment to Directive (EU) 2020/1828
+- Article 91, Review
+- Article 92, Anticipated application to providers of very large online platforms and of very large online search engines
+- Article 93, Entry into force and application
+
+Engineering impact:
+- Track future review cycles, implementing acts, delegated acts, reporting templates, audit templates, standards, and guidance.
+- Review long-lived Java systems when service scope, active-recipient counts, advertising models, recommender designs, marketplace functions, or moderation policies change.
+
+## Engineering review focus
+
+When reviewing a Java enterprise system for Digital Services Act-aware controls, connect article themes to evidence:
+- Applicability and definitions: Articles 1-3
+- Liability and authority orders: Articles 4-10
+- Provider contact, terms, and transparency: Articles 11-15
+- Notice-and-action, statement of reasons, and criminal-offence escalation: Articles 16-18
+- Complaint, appeal, trusted flagger, misuse, platform transparency, interface, advertising, recommender, and minor-protection controls: Articles 20-28
+- Marketplace and trader traceability controls: Articles 30-32
+- VLOP/VLOSE designation, systemic risk, mitigation, crisis response, independent audit, recommender alternatives, ad repository, data access, compliance function, and transparency reports: Articles 33-43
+- Standards, codes, accessibility, and crisis protocols: Articles 44-48
+- Supervision, complaints, cooperation, enforcement, fines, access restrictions, professional secrecy, and information sharing: Articles 49-88
+
+]]></goal>
+
+    <constraints>
+        <constraints-description>
+            Use this reference as Digital Services Act context for Java engineering review. Do not provide legal advice or replace review by legal, compliance, trust-and-safety, privacy, security, product, risk, audit, research-access, executive accountability, or business owners.
+        </constraints-description>
+        <constraint-list>
+            <constraint>**NOT LEGAL ADVICE**: State when an article mapping requires qualified owner review instead of giving legal conclusions</constraint>
+            <constraint>**SUMMARY ONLY**: Keep this reference focused on Digital Services Act chapters, sections, articles, and engineering implications; use the engineering examples reference for Java patterns</constraint>
+            <constraint>**ARTICLE MAPPING**: Map findings to Digital Services Act topic areas such as applicability, liability, due diligence, notice-and-action, transparency, advertising, recommender systems, marketplace controls, systemic risk, audit, data access, supervision, or enforcement</constraint>
+            <constraint>**OWNER ESCALATION**: Escalate intermediary classification, platform classification, VLOP/VLOSE status, illegal-content determinations, advertising or recommender interpretation, audit or researcher access duties, systemic-risk conclusions, and regulatory interpretation to qualified owners</constraint>
+            <constraint>**EVIDENCE ORIENTATION**: Use article summaries to identify what engineering evidence is missing or weak, not to certify compliance</constraint>
+        </constraint-list>
+    </constraints>
+
+    <output-format>
+        <output-format-list>
+            <output-format-item>**READ** this Digital Services Act chapters summary before applying Java examples or generating the review report</output-format-item>
+            <output-format-item>**MAP** reviewed findings to Digital Services Act topic areas and article groups using only reviewed evidence</output-format-item>
+            <output-format-item>**ESCALATE** legal applicability, platform classification, VLOP/VLOSE scope, illegal-content determinations, advertising or recommender interpretation, audit or researcher access duties, systemic-risk conclusions, and regulatory interpretation to qualified owners</output-format-item>
+            <output-format-item>**HAND OFF** implementation control patterns to `references/807-regulations-eu-digital-services-act-engineering-examples.md`</output-format-item>
+        </output-format-list>
+    </output-format>
+
+    <safeguards>
+        <safeguards-list>
+            <safeguards-item>**DO NOT CERTIFY COMPLIANCE**: This reference supports engineering review and owner handoff only</safeguards-item>
+            <safeguards-item>**CHECK QUALIFIED INTERPRETATION**: Platform status, illegal-content meaning, VLOP/VLOSE designation, systemic-risk conclusions, and research-access duties require qualified owners</safeguards-item>
+            <safeguards-item>**KEEP FACTS GROUNDED**: Do not infer intermediary service scope, online platform scope, active-recipient counts, ad targeting, recommender behavior, or moderation duties without reviewed evidence and qualified owner input</safeguards-item>
+        </safeguards-list>
+    </safeguards>
+</prompt>

--- a/skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-engineering-examples.xml
+++ b/skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-engineering-examples.xml
@@ -1,0 +1,352 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <metadata>
+        <author>Juan Antonio Breña Moral</author>
+        <version>0.16.0-SNAPSHOT</version>
+        <license>Apache-2.0</license>
+        <title>EU Digital Services Act Regulation for Java Online Platform Engineering</title>
+        <description>Use as Java-focused Digital Services Act engineering examples for content decision audit logs, moderation workflow state, notice tracking, recommender explanation, ad transparency, user controls, appeals, systemic-risk evidence, auditor and researcher access, incident escalation, and privacy-safe observability.</description>
+    </metadata>
+
+    <role>You are a senior Java enterprise architect and online platform governance reviewer who translates Digital Services Act themes into concrete Java engineering examples and reviewable evidence patterns</role>
+
+    <goal>
+        Apply these Digital Services Act-aware examples after the regulation summary has been read and the target system scope is understood.
+
+        These examples are not legal advice. They show engineering patterns that help Java teams create reviewable evidence for legal, compliance, trust-and-safety, privacy, security, product, risk, audit, research-access, and executive accountability owners.
+
+        Use this examples reference together with `references/807-regulations-eu-digital-services-act-chapters-summary.md` and the [Digital Services Act engineering review report template](../assets/reports/807-eu-digital-services-act-engineering-review-report-template.md).
+    </goal>
+
+    <constraints>
+        <constraints-description>
+            Translate Digital Services Act concerns into engineering controls for Java enterprise systems without replacing qualified legal, compliance, trust-and-safety, privacy, security, product, risk, audit, research-access, or executive accountability review.
+        </constraints-description>
+        <constraint-list>
+            <constraint>**NOT LEGAL ADVICE**: Treat the examples as engineering control patterns and escalation aids, not legal findings</constraint>
+            <constraint>**EVIDENCE FIRST**: Prefer reviewable evidence over claims that platform controls exist</constraint>
+            <constraint>**OWNER HANDOFFS**: Include platform, product, legal, compliance, trust-and-safety, privacy, security, audit, research-access, and risk owners in control records</constraint>
+            <constraint>**PRIVACY-SAFE LOGGING**: Preserve moderation, ranking, advertising, complaint, audit, and incident evidence without exposing secrets, credentials, personal data, illegal-content details, sensitive reports, researcher datasets, trade secrets, or confidential model details unnecessarily</constraint>
+            <constraint>**RELEASE READINESS**: Do not mark a system ready when critical DSA scope, moderation, notice, transparency, recommender, advertising, complaint, appeal, risk, audit, researcher access, or owner handoff controls are undocumented, untested, ownerless, or dependent on unknown providers</constraint>
+        </constraint-list>
+    </constraints>
+
+    <examples>
+        <toc auto-generate="true" />
+
+        <example number="1" id="dsa-scope-and-service-inventory">
+            <example-header>
+                <example-title>Document DSA service scope and owners</example-title>
+                <example-subtitle>intermediary, hosting, platform, marketplace, recommender, ad, and VLOP/VLOSE signals</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Use this pattern when a Java system stores or disseminates recipient-provided information, ranks platform content, supports marketplace transactions, delivers ads, handles complaints, or produces transparency evidence. The inventory does not decide legal classification; it creates evidence for qualified owner review.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="yaml"><![CDATA[dsaServiceInventory:
+  service: marketplace-content-api
+  businessCapability: user listings, product search, checkout, and seller support
+  possibleScopeSignals:
+    intermediaryService: true
+    hostingService: true
+    onlinePlatform: owner-review-required
+    onlineMarketplace: owner-review-required
+    onlineSearchEngine: false
+    recommenderSystem: product-ranking-v2
+    advertisingWorkflow: promoted-listings
+    vlopOrVlose: active-recipient-count-review-required
+  owners:
+    productOwner: marketplace-product
+    technicalOwner: marketplace-platform
+    legalOwner: legal-platform-governance
+    trustSafetyOwner: trust-and-safety
+    privacyOwner: privacy-engineering
+    securityOwner: security-operations
+  evidence:
+    termsVersion: terms-2026-06
+    moderationPolicy: policy/content-v7
+    transparencyReportJob: jobs/dsa-transparency-report
+    recommenderExplanation: docs/ranking-explanation-v2
+    adMetadataSchema: schemas/ad-transparency-v1]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="yaml"><![CDATA[dsaServiceInventory:
+  service: marketplace-content-api
+  scope: probably just ecommerce
+  owner: platform
+  evidence: none]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="2" id="content-decision-audit-log">
+            <example-header>
+                <example-title>Record content decisions with moderation workflow state</example-title>
+                <example-subtitle>policy, authority order, statement of reasons, user notice, appeal, and retention</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Use this pattern when a Java service removes, disables, demotes, demonetises, suspends, or otherwise restricts content, listings, accounts, ads, or marketplace offers. The audit record should be reconstructable without storing unnecessary illegal-content details.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="java"><![CDATA[ContentDecision decision = contentDecisionRecorder.record(ContentDecisionRequest.builder()
+    .contentId(content.id())
+    .recipientId(content.ownerId())
+    .decisionType(DecisionType.VISIBILITY_RESTRICTED)
+    .source(DecisionSource.NOTICE_AND_ACTION)
+    .policyReference("marketplace-terms-v7:counterfeit-goods")
+    .officialOrderReference(orderReference.orElse(null))
+    .statementOfReasonsId(statementOfReasons.id())
+    .moderationWorkflowState("AWAITING_USER_APPEAL_WINDOW")
+    .appealAvailable(true)
+    .notifiedRecipientAt(clock.instant())
+    .evidenceReference(evidenceVault.storeRedacted(content, notice))
+    .owner("trust-and-safety")
+    .build());]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="java"><![CDATA[moderationRepository.save(new ModerationEvent(contentId, "removed"));]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="3" id="notice-intake-and-response-tracking">
+            <example-header>
+                <example-title>Track notice intake and response end to end</example-title>
+                <example-subtitle>validation, triage, trusted flagger handling, response, misuse protection, and deadlines</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Use this pattern for hosting or platform services with user or authority notices. The workflow should show who submitted the notice, what was actionable, how it was assessed, what decision was taken, and how the notifier and affected recipient were informed.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="java"><![CDATA[NoticeCase noticeCase = noticeWorkflow.open(NoticeIntake.builder()
+    .noticeId(command.noticeId())
+    .submitterType(command.trustedFlagger() ? SubmitterType.TRUSTED_FLAGGER : SubmitterType.USER)
+    .contentLocator(command.contentUrl())
+    .legalOrPolicyBasis(command.claimedBasis())
+    .contactChannel(command.contactEmail())
+    .receivedAt(clock.instant())
+    .build());
+
+noticeWorkflow.route(noticeCase.id(), Route.builder()
+    .priority(command.trustedFlagger() ? Priority.HIGH : Priority.NORMAL)
+    .reviewQueue("trust-safety-marketplace")
+    .deduplicationKey(noticeCase.deduplicationKey())
+    .misuseCheckRequired(true)
+    .build());]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="java"><![CDATA[emailSender.forward("support@example.com", request.body());]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="4" id="recommender-ranking-user-controls">
+            <example-header>
+                <example-title>Explain recommender and ranking behavior with user controls</example-title>
+                <example-subtitle>main parameters, prominence factors, alternatives, and evidence snapshots</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Use this pattern when Java services rank feeds, search results, marketplace listings, offers, content, or ads. The evidence should help product and legal owners review user-facing explanations and control behavior without exposing confidential implementation details.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="yaml"><![CDATA[rankingExplanation:
+  recommenderId: product-ranking-v2
+  surface: storefront-search-results
+  termsReference: terms-2026-06#ranking
+  mainParameters:
+    - text relevance
+    - product availability
+    - delivery promise
+    - price and promotion fit
+    - shopper-selected sort option
+  userControls:
+    sortOptions: [relevance, price_low_to_high, newest]
+    personalizationToggle: available
+    profilingFreeAlternative: owner-review-required-if-vlop-or-vlose
+  evidence:
+    explanationSnapshot: evidence:ranking-explanation-2026-06-14
+    experimentId: ranker-exp-421
+    owner: search-platform]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="yaml"><![CDATA[rankingExplanation:
+  recommenderId: product-ranking-v2
+  explanation: algorithm chooses best products]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="5" id="advertising-transparency-metadata">
+            <example-header>
+                <example-title>Attach advertising transparency metadata</example-title>
+                <example-subtitle>ad labels, payer, beneficiary, targeting parameters, repository evidence, and sensitive-profiling guardrails</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Use this pattern for promoted listings, sponsored search results, display ads, or commercial communications on online platforms. The metadata should be available to render user-facing labels and support transparency reporting.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="yaml"><![CDATA[adTransparency:
+  adId: ad-2026-0614-8821
+  surface: product-search-results
+  label: Sponsored
+  advertiser: Example Seller Ltd
+  payer: Example Seller Ltd
+  beneficiary: Example Seller Ltd
+  mainTargetingParameters:
+    - search query category
+    - delivery region
+    - product category
+  prohibitedProfilingCheck:
+    specialCategoryProfiling: not-used
+    minorProfiling: not-used
+    evidence: evidence:ad-policy-check-2026-06-14
+  repositoryRecord: owner-review-required-if-vlop-or-vlose
+  retentionPolicy: dsa-ad-transparency-retention-v1]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="yaml"><![CDATA[adTransparency:
+  adId: ad-2026-0614-8821
+  label: paid placement
+  targeting: optimized]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="6" id="complaint-appeal-workflow">
+            <example-header>
+                <example-title>Preserve complaint and appeal workflow state</example-title>
+                <example-subtitle>redress, reversals, reinstatement, dispute settlement, and notifications</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Use this pattern when recipients can challenge moderation decisions or marketplace restrictions. The workflow should record each decision, user submission, reviewer action, outcome, and restoration step.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="java"><![CDATA[AppealDecision appealDecision = appealWorkflow.decide(AppealReview.builder()
+    .appealId(appeal.id())
+    .contentDecisionId(appeal.contentDecisionId())
+    .reviewerGroup("trust-and-safety-appeals")
+    .outcome(AppealOutcome.RESTRICTION_REVERSED)
+    .reasonCode("POLICY_EXCEPTION_CONFIRMED")
+    .restorationAction(RestorationAction.RESTORE_VISIBILITY)
+    .recipientNotificationTemplate("appeal-reversed-v2")
+    .outOfCourtDisputeInfoIncluded(true)
+    .decidedAt(clock.instant())
+    .build());]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="java"><![CDATA[appeal.status = "done";
+appealRepository.save(appeal);]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="7" id="systemic-risk-audit-researcher-access">
+            <example-header>
+                <example-title>Prepare VLOP or VLOSE systemic-risk, audit, and researcher-access evidence</example-title>
+                <example-subtitle>risk assessment, mitigation, independent audit, data access, and confidentiality controls</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Use this pattern only where VLOP or VLOSE scope may apply or qualified owners request readiness evidence. The system should make risk, audit, and researcher-access data available through governed interfaces, not ad hoc production database access.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="yaml"><![CDATA[systemicRiskEvidence:
+  service: marketplace-platform
+  activeRecipientMeasurement: evidence:monthly-active-recipients-2026-06
+  vlopOrVloseStatus: owner-review-required
+  riskAssessment:
+    assessmentId: dsa-risk-2026-h1
+    assessedRisks:
+      - dissemination of illegal products
+      - recommender amplification of harmful listings
+      - consumer protection and minor protection impacts
+    mitigations:
+      - trusted flagger priority workflow
+      - ranking safety demotion rules
+      - ad sensitive-profiling guardrail
+  audit:
+    independentAuditPlan: evidence:audit-plan-2026
+    implementationEvidence: evidence:mitigation-tracker
+  dataAccess:
+    authorityExportApi: governed-readonly-api
+    vettedResearcherAccess: privacy-preserving-dataset-workspace
+    controls: [approval, minimization, pseudonymization, rate-limit, access-log, revocation]]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="yaml"><![CDATA[systemicRiskEvidence:
+  status: big platform maybe
+  dataAccess: ask DBA for a database dump]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="8" id="privacy-safe-observability-and-incident-escalation">
+            <example-header>
+                <example-title>Keep observability useful and privacy-safe</example-title>
+                <example-subtitle>moderation evidence, incident escalation, redaction, owner routing, and reconstructable traces</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Use this pattern when moderation, advertising, ranking, complaints, or transparency pipelines need operational monitoring. Evidence should support incident response and governance review without spreading sensitive content or personal data through logs.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="java"><![CDATA[PlatformIncident incident = incidentEscalation.raise(PlatformIncidentRequest.builder()
+    .incidentType(PlatformIncidentType.MODERATION_PIPELINE_FAILURE)
+    .severity(severityPolicy.classify(alert))
+    .affectedWorkflow("notice-and-action")
+    .evidenceIds(List.of(alert.evidenceId(), workflowMetrics.snapshotId()))
+    .redactionPolicy("dsa-observability-redaction-v1")
+    .ownerGroups(List.of("trust-and-safety", "security-operations", "legal-platform-governance"))
+    .build());
+
+logger.info("DSA workflow incident escalated incidentId={} workflow={} severity={}",
+    incident.id(),
+    incident.affectedWorkflow(),
+    incident.severity());]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="java"><![CDATA[logger.error("Moderation failed for content {}", fullUserContent);]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+    </examples>
+
+    <output-format>
+        <output-format-list>
+            <output-format-item>**MATCH** the relevant example patterns: DSA scope inventory, content decision audit log, notice tracking, recommender explanation, ad transparency, complaint and appeal workflow, systemic-risk evidence, auditor or researcher access, incident escalation, or privacy-safe observability</output-format-item>
+            <output-format-item>**RECOMMEND** engineering controls: scope inventory, moderation workflow state, statement-of-reasons records, notice intake and response tracking, trusted flagger routing, misuse protection, recommender and ranking explanation evidence, user controls, ad transparency metadata, complaint and appeal workflows, trader traceability, transparency reporting, minor-protection controls, privacy-safe observability, incident escalation, risk assessment, independent audit, and governed data access for auditors or researchers where applicable</output-format-item>
+            <output-format-item>**REPORT** conclusions and actions using `assets/reports/807-eu-digital-services-act-engineering-review-report-template.md`, including review context, platform scope, evidence reviewed, Digital Services Act risk signals, potential violation or non-compliance signals with official-source links, engineering controls, residual risks, release decision, and prioritized action plan with owners and due dates</output-format-item>
+        </output-format-list>
+    </output-format>
+
+    <safeguards>
+        <safeguards-list>
+            <safeguards-item>**PLATFORM EVIDENCE**: Do not accept undocumented claims that moderation, notice handling, recommender explanations, advertising transparency, complaint handling, transparency reporting, audit, researcher access, or systemic-risk controls exist; ask for reviewable evidence</safeguards-item>
+            <safeguards-item>**CLASSIFICATION HANDOFF**: Do not decide intermediary service, online platform, marketplace, online search engine, VLOP, VLOSE, illegal-content, systemic-risk, advertising, or recommender legal interpretation; route those decisions to qualified owners</safeguards-item>
+            <safeguards-item>**SENSITIVE CONTENT**: Do not copy illegal content, personal data, secrets, credentials, private reports, confidential datasets, or trade-secret model details into findings; reference redacted evidence IDs instead</safeguards-item>
+        </safeguards-list>
+    </safeguards>
+</prompt>

--- a/skills-generator/src/main/resources/skill-references/assets/reports/807-eu-digital-services-act-engineering-review-report-template.md
+++ b/skills-generator/src/main/resources/skill-references/assets/reports/807-eu-digital-services-act-engineering-review-report-template.md
@@ -1,0 +1,152 @@
+# Digital Services Act Engineering Review Report
+
+Use this template after reviewing `references/807-regulations-eu-digital-services-act-chapters-summary.md` and matching the relevant examples from `references/807-regulations-eu-digital-services-act-engineering-examples.md` for DSA scope inventory, content decision audit logs, notice tracking, recommender explanation, ad transparency, user controls, complaint and appeal workflows, systemic-risk evidence, auditor or researcher access, incident escalation, and privacy-safe observability.
+
+This report is not legal advice. Use it as engineering evidence for legal, compliance, trust-and-safety, privacy, security, product, risk, audit, research-access, executive accountability, architecture, and business-owner review.
+
+The purpose of this report is to increase awareness of potential gaps in the system and create engineering evidence for qualified review. The response produced from this template does not represent legal advice, a legal opinion, or a final regulatory determination.
+
+## 1. Review Context
+
+- System or service name:
+- Repository, product, platform, or business service:
+- Review date:
+- Reviewers:
+- Business owner:
+- Technical owner:
+- Product owner:
+- Trust-and-safety owner:
+- Privacy owner:
+- Security owner:
+- Legal/compliance owner:
+- Risk or audit owner:
+- Research-access owner, where applicable:
+- Source materials reviewed:
+
+## 2. Service And Platform Context
+
+- Service description:
+- Possible intermediary-service signal:
+- Possible hosting-service signal:
+- Possible online-platform or marketplace signal:
+- Possible online-search-engine signal:
+- Possible advertising or recommender signal:
+- Possible VLOP or VLOSE signal:
+- Deployment geography:
+- Environments in scope:
+- Active-recipient or user-scale evidence:
+- User, trader, or third-party content flows:
+- Open applicability questions:
+
+## 3. DSA Engineering Scope
+
+- Applications, APIs, jobs, and batch workloads:
+- User-generated content, trader listings, product data, ads, or third-party information:
+- Notice intake, authority orders, and response workflows:
+- Content decision audit logs and moderation workflow state:
+- Complaint, appeal, out-of-court dispute, and reinstatement workflows:
+- Recommender, ranking, search, personalization, and user-control workflows:
+- Advertising transparency metadata and repository evidence:
+- Marketplace trader traceability and compliance-by-design controls:
+- Risk assessment, audit, crisis response, and data access workflows where applicable:
+- Logs, metrics, traces, dashboards, and privacy-safe observability:
+- Operational runbooks and support model:
+
+## 4. Potential Violation Or Non-Compliance Mapping
+
+This section is not a legal finding. Use it to list concrete potential Digital Services Act violation or non-compliance signals from the reviewed evidence and route each item to qualified legal, compliance, trust-and-safety, privacy, security, product, risk, audit, research-access, or executive accountability review. When no violation is confirmed, say so explicitly and keep open items as potential gaps. Use the chapter and article links from `references/807-regulations-eu-digital-services-act-chapters-summary.md`; add more official-source links when one finding spans multiple DSA areas.
+
+| Potential violation or non-compliance signal | DSA reference area | Associated official-source link | Evidence from reviewed system | Current status | Required owner review | Engineering action |
+| -------------------------------------------- | ------------------ | ------------------------------- | ----------------------------- | -------------- | --------------------- | ------------------ |
+| Unclear intermediary, hosting, platform, marketplace, or search scope | Applicability and definitions | [Chapter I](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_I) | TBD | None identified / Potential gap / Confirmed concern | Legal / compliance / product owner | TBD |
+| Missing authority order tracking or user notification evidence | Orders to act or provide information | [Chapter II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_II) | TBD | None identified / Potential gap / Confirmed concern | Legal / trust-and-safety / security | TBD |
+| Missing notice intake, action response, or statement-of-reasons records | Hosting service notice-and-action controls | [Chapter III, Section 2](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | TBD | None identified / Potential gap / Confirmed concern | Trust-and-safety / legal / product | TBD |
+| Missing complaint, appeal, or dispute workflow state | Online platform redress controls | [Chapter III, Section 3](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | TBD | None identified / Potential gap / Confirmed concern | Trust-and-safety / legal / product | TBD |
+| Missing recommender explanation or user-control evidence | Recommender transparency | [Article 27](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | TBD | None identified / Potential gap / Confirmed concern | Product / legal / privacy / architecture | TBD |
+| Missing advertising transparency metadata | Online advertising transparency | [Article 26](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | TBD | None identified / Potential gap / Confirmed concern | Product / legal / privacy / ads owner | TBD |
+| Missing trader traceability or compliance-by-design evidence | Marketplace trader controls | [Chapter III, Section 4](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | TBD | None identified / Potential gap / Confirmed concern | Marketplace / legal / compliance | TBD |
+| Missing VLOP/VLOSE risk, audit, transparency, or data-access evidence where applicable | Systemic-risk obligations | [Chapter III, Section 5](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_III) | TBD | None identified / Potential gap / Confirmed concern | Legal / risk / audit / research-access / executive accountability | TBD |
+| Missing privacy-safe observability for platform governance evidence | Supervision, evidence, and confidentiality | [Chapter IV](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065#cpt_IV) | TBD | None identified / Potential gap / Confirmed concern | Security / privacy / trust-and-safety | TBD |
+
+## 5. Engineering Controls
+
+- Scope and service inventory:
+- Authority order and information request tracking:
+- Notice intake and response tracking:
+- Content decision audit logs:
+- Moderation workflow state:
+- Statement-of-reasons records:
+- User notification and redress:
+- Complaint, appeal, dispute, and reinstatement workflows:
+- Trusted flagger routing and misuse protections:
+- Recommender and ranking explanation evidence:
+- User controls and profiling-related alternatives where applicable:
+- Advertising transparency metadata:
+- Marketplace trader traceability:
+- Transparency reporting:
+- Minor-protection and online interface controls:
+- Risk assessment and mitigation where applicable:
+- Independent audit and compliance-function evidence where applicable:
+- Data access for auditors or vetted researchers where applicable:
+- Incident escalation and crisis-response evidence:
+- Privacy-safe observability:
+
+## 6. Evidence Inventory
+
+- DSA scope inventory:
+- Terms, policies, and user-facing explanations:
+- Notice intake records:
+- Authority order records:
+- Content decision audit records:
+- Statement-of-reasons records:
+- Complaint and appeal records:
+- Recommender or ranking explanation records:
+- User-control settings:
+- Advertising metadata and repository records:
+- Trader traceability evidence:
+- Transparency report jobs or outputs:
+- Risk assessment and mitigation records:
+- Audit reports or audit plans:
+- Researcher or authority data-access controls:
+- Incident runbooks and alert routing:
+- Privacy-safe logging policy and tests:
+- Release decision:
+
+## 7. Residual Risks
+
+- Residual risk:
+- Impact:
+- Likelihood:
+- Mitigation:
+- Owner:
+- Acceptance decision:
+- Review date:
+
+## 8. Release Decision
+
+- Decision:
+- Conditions:
+- Blockers:
+- Required approvals:
+- Expiry or review date:
+- Environments approved:
+- Emergency rollback path:
+
+## 9. Action Plan
+
+| Priority | Action | Owner | Due date | Evidence expected | Status |
+| -------- | ------ | ----- | -------- | ----------------- | ------ |
+| High     |        |       |          |                   | Open   |
+| Medium   |        |       |          |                   | Open   |
+| Low      |        |       |          |                   | Open   |
+
+## 10. Final Notes
+
+- Items requiring legal interpretation:
+- Items requiring platform or intermediary classification:
+- Items requiring illegal-content or policy interpretation:
+- Items requiring advertising or recommender interpretation:
+- Items requiring VLOP/VLOSE, systemic-risk, audit, or researcher-access review:
+- Items requiring privacy or security review:
+- Items requiring product or business acceptance:
+- Next review trigger:

--- a/skills-generator/src/main/resources/skills.xml
+++ b/skills-generator/src/main/resources/skills.xml
@@ -590,4 +590,14 @@
                 target="assets/reports/804-nis2-engineering-review-report-template.md" />
         </resource-list>
     </skill>
+    <skill id="807" skillId="807-regulations-eu-digital-services-act">
+        <reference-list>
+            <reference>807-regulations-eu-digital-services-act-chapters-summary</reference>
+            <reference>807-regulations-eu-digital-services-act-engineering-examples</reference>
+        </reference-list>
+        <resource-list>
+            <resource source="skill-references/assets/reports/807-eu-digital-services-act-engineering-review-report-template.md"
+                target="assets/reports/807-eu-digital-services-act-engineering-review-report-template.md" />
+        </resource-list>
+    </skill>
 </skill-inventory>

--- a/skills-generator/src/test/resources/gherkin/807-regulations-eu-digital-services-act.feature
+++ b/skills-generator/src/test/resources/gherkin/807-regulations-eu-digital-services-act.feature
@@ -1,0 +1,62 @@
+Feature: Validate changes from usage of EU Digital Services Act regulation skill
+
+Background:
+  Given the skill "807-regulations-eu-digital-services-act"
+
+@acceptance-test
+Scenario: Review a Java ecommerce platform change with Digital Services Act controls
+  Given the system description file "examples/diagrams/deployment/system-example-cicd-pr-model.md"
+  And the deployment and delivery pipeline diagram file "examples/diagrams/deployment/expected-system-deployment.puml"
+  And the simulated feature request file "examples/diagrams/deployment/checkout-service-feature-request.md"
+  And the local generated skill path ".agents/skills/807-regulations-eu-digital-services-act"
+  And the requested report output path is "examples/regulations/eu-digital-services-act/DSA-ENGINEERING-REVIEW-REPORT.md"
+  And any existing report at the requested output path must be overwritten
+  And the folder "examples/regulations/eu-digital-services-act" has no git changes
+  And the feature request is expected to be developed and released through the described CI/CD pipeline
+  And the Digital Services Act review facts are based only on information present in "examples/diagrams/deployment/system-example-cicd-pr-model.md" and "examples/diagrams/deployment/checkout-service-feature-request.md"
+  When the skill ".agents/skills/807-regulations-eu-digital-services-act" is applied to the system description, diagram, and feature request files
+  Then the skill reads "references/807-regulations-eu-digital-services-act-chapters-summary.md"
+  And the skill reads "references/807-regulations-eu-digital-services-act-engineering-examples.md"
+  And the skill reads "assets/reports/807-eu-digital-services-act-engineering-review-report-template.md"
+  And the skill frames Digital Services Act findings as engineering controls rather than legal advice
+  And review findings do not use facts outside "examples/diagrams/deployment/system-example-cicd-pr-model.md" and "examples/diagrams/deployment/checkout-service-feature-request.md"
+  And the skill scopes intermediary-service signals, hosting signals, online-platform or marketplace signals, online-search-engine signals, recommender or ranking signals, advertising workflows, trader interactions, user content flows, platform owners, trust-and-safety owners, privacy owners, security owners, risk owners, environments, data stores, observability systems, and VLOP or VLOSE indicators
+  And the skill escalates intermediary classification, platform classification, VLOP or VLOSE status, illegal-content determinations, advertising or recommender interpretation, audit or researcher access duties, systemic-risk conclusions, and regulatory interpretation to legal, compliance, trust-and-safety, privacy, security, product, risk, audit, research-access, or executive accountability owners
+  And the skill reviews Java implementation, DTOs, controllers, moderation or policy services if present, workflow state, schemas, migrations, messages, logs, metrics, traces, search or ranking behavior, recommender configuration, advertising metadata, user-control settings, complaint and appeal records, transparency reporting jobs, tests, deployment workflows, and provider documentation
+  And the skill identifies risk signals for unclear DSA scope, missing owner classification evidence, missing content decision audit logs where moderation exists, missing notice intake and response tracking where hosting exists, missing complaint and appeal workflow evidence where online platform duties apply, missing recommender and ranking explanation evidence, missing ad transparency metadata where ads exist, missing user controls, missing trader traceability where marketplace duties apply, missing risk assessment evidence where VLOP or VLOSE duties may apply, missing incident escalation, missing auditor or researcher data-access controls where applicable, privacy-safe observability gaps, database migration, Kafka message contract, CI/CD pipeline, and production side-effect signals
+  And the skill maps potential Digital Services Act violation or non-compliance signals to article or chapter references with associated official-source links using only the reviewed delivery evidence
+  And the skill analyzes the CheckoutService feature request as a pipeline-delivered change that modifies order database structure and outbound Kafka event data for a customer-facing ecommerce platform
+  And the skill uses Java examples to explain content decision audit logging, notice tracking, recommender explanation evidence, ad transparency metadata, complaint and appeal workflow state, risk assessment evidence, auditor or researcher data access, incident escalation, and privacy-safe observability controls
+  And the skill recommends engineering controls for DSA scope inventory, owner classification evidence, content decision audit logs, moderation workflow state, notice intake and response tracking, statement-of-reasons records, recommender and ranking explanation evidence, ad transparency metadata, user controls, complaint and appeal workflows, trader traceability, risk assessment evidence, incident escalation, auditor or researcher data access where applicable, privacy-safe observability, database migration approval, Kafka schema compatibility, and owner escalation
+  And the skill reports conclusions and actions using the Digital Services Act engineering review report template
+  And the skill overwrites the Digital Services Act engineering review report at "examples/regulations/eu-digital-services-act/DSA-ENGINEERING-REVIEW-REPORT.md"
+  And any git changes produced during skill execution and verification are reset
+
+@acceptance-test
+Scenario: Review a Java ecommerce platform change with direct-to-main Digital Services Act controls
+  Given the system description file "examples/diagrams/deployment/system-example-cicd-model.md"
+  And the deployment and delivery pipeline diagram file "examples/diagrams/deployment/expected-system-deployment.puml"
+  And the simulated feature request file "examples/diagrams/deployment/checkout-service-feature-request.md"
+  And the local generated skill path ".agents/skills/807-regulations-eu-digital-services-act"
+  And the requested report output path is "examples/regulations/eu-digital-services-act/DSA-DIRECT-MAIN-ENGINEERING-REVIEW-REPORT.md"
+  And any existing report at the requested output path must be overwritten
+  And the folder "examples/regulations/eu-digital-services-act" has no git changes
+  And the feature request is expected to be committed directly to main and released through the described CI/CD pipeline
+  And the Digital Services Act review facts are based only on information present in "examples/diagrams/deployment/system-example-cicd-model.md" and "examples/diagrams/deployment/checkout-service-feature-request.md"
+  When the skill ".agents/skills/807-regulations-eu-digital-services-act" is applied to the direct-to-main system description, diagram, and feature request files
+  Then the skill reads "references/807-regulations-eu-digital-services-act-chapters-summary.md"
+  And the skill reads "references/807-regulations-eu-digital-services-act-engineering-examples.md"
+  And the skill reads "assets/reports/807-eu-digital-services-act-engineering-review-report-template.md"
+  And the skill frames Digital Services Act findings as engineering controls rather than legal advice
+  And review findings do not use facts outside "examples/diagrams/deployment/system-example-cicd-model.md" and "examples/diagrams/deployment/checkout-service-feature-request.md"
+  And the skill scopes intermediary-service signals, hosting signals, online-platform or marketplace signals, online-search-engine signals, recommender or ranking signals, advertising workflows, trader interactions, user content flows, platform owners, trust-and-safety owners, privacy owners, security owners, risk owners, environments, data stores, observability systems, and VLOP or VLOSE indicators
+  And the skill escalates missing pre-merge review, protected-main bypass, intermediary classification, platform classification, VLOP or VLOSE status, illegal-content determinations, advertising or recommender interpretation, audit or researcher access duties, systemic-risk conclusions, and regulatory interpretation to legal, compliance, trust-and-safety, privacy, security, platform, product, risk, audit, research-access, or executive accountability owners
+  And the skill reviews Java implementation, DTOs, controllers, moderation or policy services if present, workflow state, schemas, migrations, messages, logs, metrics, traces, search or ranking behavior, recommender configuration, advertising metadata, user-control settings, complaint and appeal records, transparency reporting jobs, tests, deployment workflows, and provider documentation
+  And the skill identifies risk signals for unclear DSA scope, missing owner classification evidence, missing content decision audit logs where moderation exists, missing notice intake and response tracking where hosting exists, missing complaint and appeal workflow evidence where online platform duties apply, missing recommender and ranking explanation evidence, missing ad transparency metadata where ads exist, missing user controls, missing trader traceability where marketplace duties apply, missing risk assessment evidence where VLOP or VLOSE duties may apply, missing incident escalation, missing auditor or researcher data-access controls where applicable, privacy-safe observability gaps, direct-to-main commit policy, database migration, Kafka message contract, CI/CD pipeline, and production side-effect signals
+  And the skill maps potential Digital Services Act violation or non-compliance signals to article or chapter references with associated official-source links using only the reviewed direct-to-main delivery evidence
+  And the skill analyzes the CheckoutService feature request as a direct-to-main pipeline-delivered change that modifies order database structure and outbound Kafka event data for a customer-facing ecommerce platform
+  And the skill uses Java examples to explain content decision audit logging, notice tracking, recommender explanation evidence, ad transparency metadata, complaint and appeal workflow state, risk assessment evidence, auditor or researcher data access, incident escalation, and privacy-safe observability controls
+  And the skill recommends engineering controls for pre-commit review, main-branch protection, DSA scope inventory, owner classification evidence, content decision audit logs, moderation workflow state, notice intake and response tracking, statement-of-reasons records, recommender and ranking explanation evidence, ad transparency metadata, user controls, complaint and appeal workflows, trader traceability, risk assessment evidence, incident escalation, auditor or researcher data access where applicable, privacy-safe observability, database migration approval, Kafka schema compatibility, and owner escalation
+  And the skill reports conclusions and actions using the Digital Services Act engineering review report template
+  And the skill overwrites the Digital Services Act engineering review report at "examples/regulations/eu-digital-services-act/DSA-DIRECT-MAIN-ENGINEERING-REVIEW-REPORT.md"
+  And any git changes produced during skill execution and verification are reset

--- a/skills-generator/src/test/resources/gherkin/acceptance-tests-prompts-skills.md
+++ b/skills-generator/src/test/resources/gherkin/acceptance-tests-prompts-skills.md
@@ -69,3 +69,10 @@ and verify that acceptance-tests passes.
 execute @skills-generator/src/test/resources/gherkin/804-regulations-eu-nis2.feature
 and verify that acceptance-tests passes.
 ```
+
+## 807-regulations-eu-digital-services-act
+
+```bash
+execute @skills-generator/src/test/resources/gherkin/807-regulations-eu-digital-services-act.feature
+and verify that acceptance-tests passes.
+```


### PR DESCRIPTION
## Summary
- Add the 807 EU Digital Services Act regulation skill, references, report template, and generator registration.
- Add DSA acceptance coverage and example reports for PR and direct-to-main delivery scenarios.
- Mark the matching OpenSpec implementation tasks complete with a note for manual acceptance coverage.

## Test plan
- `xmllint --noout skills-generator/src/main/resources/skill-indexes/807-skill.xml skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-chapters-summary.xml skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-engineering-examples.xml skills-generator/src/main/resources/skills.xml`
- `./mvnw clean install -pl skills-generator`
- Inspected `.agents/skills/807-regulations-eu-digital-services-act/SKILL.md`, generated references, and report asset for unresolved includes and local path issues.
- `./mvnw clean verify -pl skills-generator`
- `openspec validate --all`
- Manual acceptance coverage through `examples/regulations/eu-digital-services-act/DSA-ENGINEERING-REVIEW-REPORT.md` and `examples/regulations/eu-digital-services-act/DSA-DIRECT-MAIN-ENGINEERING-REVIEW-REPORT.md`; no automated acceptance runner beyond the documented prompt was found.

## Refs
- https://github.com/jabrena/cursor-rules-java/issues/855

Made with [Cursor](https://cursor.com)