### PR TITLE
feat(skills): add EU Cyber Resilience Act regulation skill

### DIFF
--- a/documentation/openspec/changes/add-eu-cyber-resilience-act-regulation-skill/tasks.md
+++ b/documentation/openspec/changes/add-eu-cyber-resilience-act-regulation-skill/tasks.md
@@ -6,21 +6,21 @@
 - [x] 1.2 Confirm `801-regulations-eu-ai-act`, `802-regulations-dora`, and `803-regulations-gdpr` are already covered and the Cyber Resilience Act remains pending.
 - [x] 1.3 Create a per-regulation OpenSpec change for the Cyber Resilience Act.
 - [x] 1.4 Record source artifacts, derivation direction, scope boundary, and validation expectations.
-- [ ] 1.5 Add `skills-generator/src/main/resources/skill-indexes/805-skill.xml`.
-- [ ] 1.6 Add `skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-chapters-summary.xml` with direct official-source chapter links and article/annex mapping in the same style as `804-regulations-eu-nis2-chapters-summary.xml`.
-- [ ] 1.7 Add `skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-engineering-examples.xml` with Java-focused examples and output guidance.
-- [ ] 1.8 Add `skills-generator/src/main/resources/skill-references/assets/reports/805-eu-cyber-resilience-act-engineering-review-report-template.md` with a potential violation or non-compliance table that includes reference area and associated official-source link columns.
-- [ ] 1.9 Include engineering controls for secure-by-design development, threat modeling, secure defaults, vulnerability management, coordinated disclosure, security update mechanisms, dependency and SBOM evidence, cryptography, authentication and authorization, sensitive-data-safe logging, product security documentation, end-of-support signaling, and release readiness.
-- [ ] 1.10 Update `805-skill.xml` so the workflow reads chapter summary, engineering examples, and report template before implementation review.
-- [ ] 1.11 Register skill id `805` with explicit `skillId="805-regulations-eu-cyber-resilience-act"`, references, and report template resource in `skills-generator/src/main/resources/skills.xml`.
-- [ ] 1.12 Add `skills-generator/src/test/resources/gherkin/805-regulations-eu-cyber-resilience-act.feature` with pull-request and direct-to-main acceptance scenarios modeled after `801-804`.
-- [ ] 1.13 Ensure the Gherkin scenarios require reading the chapters summary, engineering examples, and report template, and require linked violation mapping in generated reports.
-- [ ] 1.14 Add Cyber Resilience Act report examples under `examples/regulations/eu-cyber-resilience-act`.
-- [ ] 1.15 Add `805-regulations-eu-cyber-resilience-act` to `skills-generator/src/test/resources/gherkin/acceptance-tests-prompts-skills.md`.
-- [ ] 1.16 Validate changed XML files with `xmllint --noout`.
-- [ ] 1.17 Run `./mvnw clean install -pl skills-generator`.
-- [ ] 1.18 Inspect generated local `.agents/skills/805-regulations-eu-cyber-resilience-act/SKILL.md`.
-- [ ] 1.19 Inspect generated local chapters summary, engineering examples, and report template outputs.
-- [ ] 1.20 Execute the listed `805-regulations-eu-cyber-resilience-act` acceptance prompt and verify it passes.
-- [ ] 1.21 Run `./mvnw clean verify -pl skills-generator`.
-- [ ] 1.22 Run `openspec validate --all`.
+- [x] 1.5 Add `skills-generator/src/main/resources/skill-indexes/805-skill.xml`.
+- [x] 1.6 Add `skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-chapters-summary.xml` with direct official-source chapter links and article/annex mapping in the same style as `804-regulations-eu-nis2-chapters-summary.xml`.
+- [x] 1.7 Add `skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-engineering-examples.xml` with Java-focused examples and output guidance.
+- [x] 1.8 Add `skills-generator/src/main/resources/skill-references/assets/reports/805-eu-cyber-resilience-act-engineering-review-report-template.md` with a potential violation or non-compliance table that includes reference area and associated official-source link columns.
+- [x] 1.9 Include engineering controls for secure-by-design development, threat modeling, secure defaults, vulnerability management, coordinated disclosure, security update mechanisms, dependency and SBOM evidence, cryptography, authentication and authorization, sensitive-data-safe logging, product security documentation, end-of-support signaling, and release readiness.
+- [x] 1.10 Update `805-skill.xml` so the workflow reads chapter summary, engineering examples, and report template before implementation review.
+- [x] 1.11 Register skill id `805` with explicit `skillId="805-regulations-eu-cyber-resilience-act"`, references, and report template resource in `skills-generator/src/main/resources/skills.xml`.
+- [x] 1.12 Add `skills-generator/src/test/resources/gherkin/805-regulations-eu-cyber-resilience-act.feature` with pull-request and direct-to-main acceptance scenarios modeled after `801-804`.
+- [x] 1.13 Ensure the Gherkin scenarios require reading the chapters summary, engineering examples, and report template, and require linked violation mapping in generated reports.
+- [x] 1.14 Add Cyber Resilience Act report examples under `examples/regulations/eu-cyber-resilience-act`.
+- [x] 1.15 Add `805-regulations-eu-cyber-resilience-act` to `skills-generator/src/test/resources/gherkin/acceptance-tests-prompts-skills.md`.
+- [x] 1.16 Validate changed XML files with `xmllint --noout`.
+- [x] 1.17 Run `./mvnw clean install -pl skills-generator`.
+- [x] 1.18 Inspect generated local `.agents/skills/805-regulations-eu-cyber-resilience-act/SKILL.md`.
+- [x] 1.19 Inspect generated local chapters summary, engineering examples, and report template outputs.
+- [x] 1.20 Execute the listed `805-regulations-eu-cyber-resilience-act` acceptance prompt and verify it passes. Manual coverage recorded through `examples/regulations/eu-cyber-resilience-act/CRA-ENGINEERING-REVIEW-REPORT.md` and `examples/regulations/eu-cyber-resilience-act/CRA-DIRECT-MAIN-ENGINEERING-REVIEW-REPORT.md`; no automated acceptance runner was found beyond the documented prompt.
+- [x] 1.21 Run `./mvnw clean verify -pl skills-generator`.
+- [x] 1.22 Run `openspec validate --all`.

--- a/examples/regulations/eu-cyber-resilience-act/CRA-DIRECT-MAIN-ENGINEERING-REVIEW-REPORT.md
+++ b/examples/regulations/eu-cyber-resilience-act/CRA-DIRECT-MAIN-ENGINEERING-REVIEW-REPORT.md
@@ -1,0 +1,196 @@
+# EU Cyber Resilience Act Engineering Review Report
+
+Use this report as engineering evidence for legal, compliance, product, product-security, security, support, market-access, platform, risk, architecture, executive accountability, and business-owner review.
+
+This report is not legal advice. It identifies engineering controls and escalation points from the reviewed direct-to-main delivery evidence. Product classification, economic-operator role, conformity assessment, CE marking implications, Article 14 reporting obligations, support-period interpretation, cybersecurity risk acceptance, and regulatory interpretation require qualified owner review.
+
+## 1. Review Context
+
+- Product, service, component, library, agent, plugin, or platform module: CheckoutService delivery instructions change
+- Repository or implementation path: Fictional Java Quarkus ecommerce platform with direct commits to `main`
+- Review date: 2026-06-14
+- Reviewers: AI-assisted Cyber Resilience Act engineering review
+- Business owner: Not identified in reviewed evidence
+- Product owner: Not identified in reviewed evidence
+- Technical owner: Software engineers, tech leads, and platform engineers are described, but no named CheckoutService owner is identified
+- Product security owner: Not identified in reviewed evidence
+- Support owner: Support and operations teams are described, but no named support owner is identified
+- Legal/compliance owner: Not identified in reviewed evidence
+- Market-access or conformity owner: Not identified in reviewed evidence
+- Source materials reviewed:
+  - `examples/diagrams/deployment/system-example-cicd-model.md`
+  - `examples/diagrams/deployment/expected-system-deployment.puml`
+  - `examples/diagrams/deployment/checkout-service-feature-request.md`
+  - `.agents/skills/805-regulations-eu-cyber-resilience-act/references/805-regulations-eu-cyber-resilience-act-chapters-summary.md`
+  - `.agents/skills/805-regulations-eu-cyber-resilience-act/references/805-regulations-eu-cyber-resilience-act-engineering-examples.md`
+  - `.agents/skills/805-regulations-eu-cyber-resilience-act/assets/reports/805-eu-cyber-resilience-act-engineering-review-report-template.md`
+
+## 2. Product Security Scope
+
+- Product or component description: CheckoutService coordinates checkout saga steps for price validation, inventory reservation, payment authorization, order creation, delivery slot booking, PostgreSQL order state, saga state, and Kafka events.
+- Possible product-with-digital-elements signal: The reviewed evidence describes a Java service and related platform components with network connectivity, APIs, databases, Kafka messages, identity, payment, delivery, and cloud dependencies. It does not establish whether the service is itself a product with digital elements or part of one.
+- Possible remote data processing signal: CheckoutService, payment adapter, inventory, delivery slot service, notification worker, analytics pipeline, and cloud services process data remotely as part of the platform. Qualified owners must decide whether any remote processing is under manufacturer responsibility for a product with digital elements.
+- Possible important or critical product signal: Not confirmed. Identity, API gateway, Kafka, container runtime, WAF, and platform services may be relevant dependencies, but the reviewed feature does not classify CheckoutService under Annex III or Annex IV.
+- Intended purpose: Add delivery instructions to checkout and order events while preserving checkout, delivery, notification, and analytics behavior.
+- Reasonably foreseeable use or misuse: Users may enter free-text delivery notes containing personal data, access codes, or unsafe content; downstream consumers may over-propagate or log the new fields; direct-to-main changes may reach product release without independent review.
+- Economic-operator role signals: No manufacturer, importer, distributor, open-source steward, authorised representative, or market-access role is recorded.
+- Deployment geography: Azure production environment is described; EU market availability is not specified.
+- Environments in scope: Development, test, staging, and production.
+- Users, integrators, or affected organizations: Shoppers, support and operations teams, platform engineers, downstream inventory, delivery, notification, analytics, and payment workflows.
+- Support-period signal: No support period, security update availability commitment, or end-of-support signaling appears in the reviewed evidence.
+- Security update delivery path: Main branch CI builds signed images, SBOM and provenance metadata, GitOps/CD deployment, automated promotion, health checks, and smoke tests. Security-update advisory, user notification, update availability, rollback evidence, and pre-merge review controls are not complete.
+- Open applicability questions:
+  - Is CheckoutService or the ecommerce platform a product with digital elements made available on the EU market?
+  - Which entity, if any, is the manufacturer or other economic operator for this product or component?
+  - Does direct-to-main delivery satisfy the organization's product-security release and evidence expectations for a potentially CRA-relevant change?
+  - Does the change create a substantial modification or affect a product with digital elements already placed on the market?
+  - Are Annex III important-product or Annex IV critical-product categories implicated by identity, gateway, container, security, or connected-product dependencies?
+  - Which qualified owners must approve conformity assessment, CE marking implications, Article 14 reporting handoffs, and support-period statements?
+
+## 3. Engineering Evidence Reviewed
+
+- Java applications, libraries, agents, plugins, APIs, jobs, or installers: Web storefront BFF, API gateway, identity, catalog, search, cart, pricing, CheckoutService, payment adapter, inventory, delivery slot, notification worker, analytics pipeline, checkout saga logic, and deployment workflows.
+- Data stores, queues, topics, caches, files, or remote processing: User Profile DB, Product DB, Search Index, Cart DB, Pricing DB, Order DB, Saga Support PostgreSQL, Inventory DB, Delivery DB, Kafka topics `order.created`, `payment.authorized`, `stock.reserved`, `slot.booked`, `delivery.slot.requested`, `order.confirmed`, and compensation events.
+- Authentication, authorization, IAM, secrets, keys, and privileged operations: Azure Key Vault, managed identities, API gateway authentication enforcement, identity provider integration, payment tokens, idempotency keys, database credentials, Kafka credentials, and deployment credentials.
+- CI/CD workflows, build provenance, artifact signing, and deployment paths: Direct commit to `main`, main branch CI, Artifactory, Docker registry, signed images, SBOM and provenance metadata, GitOps/CD pipeline, automated environment promotion, migration safety checks, health checks, and smoke tests.
+- Third-party components, open-source dependencies, containers, and generated clients: Quarkus services, common Java libraries, container images, build pipeline tools, Azure services, external identity provider, external payment gateway, and email/SMS provider.
+- SBOM, dependency scan, image scan, and vulnerability triage evidence: Pipeline generates SBOM and provenance and runs dependency, image, and secret scanning; concrete SBOM references, vulnerability triage records, owner assignments, and exception decisions are not present.
+- Threat model, secure-by-design, secure defaults, and attack-surface evidence: The deployment model describes WAF, API gateway authentication, private networking, managed identities, Azure Policy, and immutable images. A product threat model for delivery instructions, Kafka propagation, support access, direct-to-main release risk, and foreseeable misuse is not present.
+- Logging, monitoring, security event, and incident evidence: Azure Monitor, App Insights, Log Analytics, structured logs, metrics, traces, correlation IDs, dashboards, alerts, health checks, and smoke tests are described; sensitive-data-safe logging proof for delivery notes is not present.
+- Coordinated disclosure, vulnerability contact, advisory, and reporting handoff evidence: Not present.
+- Security update, rollback, and support-period evidence: Rollback by previous image and compatible database state are described. Security advisory workflow, update availability, user notification, support-period end date, and pre-merge review evidence are not present.
+- Product security documentation and user instructions: Not present beyond delivery and deployment documentation.
+
+## 4. Potential Violation Or Non-Compliance Mapping
+
+This section is not a legal finding. It lists concrete potential Cyber Resilience Act violation or non-compliance signals from the reviewed direct-to-main delivery evidence and routes each item to qualified owner review. No violation is confirmed by this engineering review.
+
+| Potential violation or non-compliance signal | CRA reference area | Associated official-source link | Evidence from reviewed system | Current status | Required owner review | Engineering action |
+| -------------------------------------------- | ------------------ | ------------------------------- | ----------------------------- | -------------- | --------------------- | ------------------ |
+| Unclear product-with-digital-elements scope and economic-operator role | Scope / product categories / economic-operator obligations | [Chapter I](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_I), [Chapter II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_II) | Java connected services, cloud deployment, APIs, Kafka, identity, payment, and delivery dependencies are described, but no product classification or operator role is recorded | Potential gap | Legal / compliance / product / market-access owner | Record product scope, EU market availability, manufacturer or supplier role, substantial modification decision, and accountable owner |
+| Missing pre-merge review for product-security-risk change | Secure development / release readiness / technical documentation | [Chapter II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_II), [Annex VII](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_VII) | Engineers commit directly to `main`; the feature modifies order database structure and Kafka event data | Potential gap | Product security / platform / architecture / risk owner | Require pre-commit or pre-merge review gate for product-security controls, database migrations, Kafka contracts, sensitive fields, and production-impacting changes |
+| Protected-main bypass or insufficient approval evidence | Release readiness / secure development evidence | [Chapter II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_II), [Chapter V](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_V) | The reviewed delivery path is `commit + push directly to main`; no protected-main rule, approval requirement, or exception workflow is shown | Potential gap | Platform / product security / executive accountability owner | Enforce branch protection or equivalent signed approval workflow before product release |
+| Missing product threat model and secure-default evidence for delivery instructions | Essential cybersecurity requirements for product properties | [Chapter I](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_I), [Annex I](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_I) | The feature adds free-text delivery notes and Kafka event changes; no threat model for foreseeable misuse, excessive data propagation, support access, logging, or direct-to-main release risk is present | Potential gap | Product security / architecture / security owner | Add threat model, secure default field propagation rules, authorization checks, data minimization, validation, and logging tests |
+| Missing coordinated disclosure, vulnerability contact, and advisory workflow evidence | Manufacturer obligations / reporting / vulnerability handling | [Chapter II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_II), [Annex I](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_I) | No vulnerability reporting contact, coordinated disclosure policy, advisory process, Article 14 reporting handoff, or user notification workflow appears in reviewed files | Potential gap | Product security / legal / compliance / support owner | Add CVD policy, vulnerability intake, triage, remediation, advisory, user notification, and reporting escalation workflow |
+| Incomplete security update and rollback evidence | Security updates / vulnerability remediation / user instructions | [Chapter II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_II), [Annex II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_II) | Signed images, automated deployment, and rollback by previous image are described; security-only update path, advisory, update availability, and user instructions are not shown | Potential gap | Product security / support / platform owner | Document signed security update path, advisory messages, rollback procedure, user mitigation guidance, and update availability commitment |
+| Incomplete dependency, open-source due diligence, and SBOM evidence | Component due diligence / SBOM / technical documentation | [Chapter II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_II), [Annex VII](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_VII) | Pipeline generates SBOM and scans dependencies/images, but concrete SBOM location, triage decisions, exception owners, and third-party review are absent | Potential gap | Product security / platform / procurement / risk owner | Attach SBOM, dependency and image scan evidence, vulnerability triage, remediation SLA, open-source due diligence, provider register, and exception records |
+| Missing product security documentation, support-period disclosure, and secure decommissioning guidance | User information / technical documentation / support period | [Annex II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_II), [Annex VII](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_VII) | No CRA-style user instructions, vulnerability contact, support-period end, end-of-support notice, security update instructions, or decommissioning guidance are present | Potential gap | Product / support / legal / market-access owner | Add product security documentation index, support-period rationale, end-of-support notice, secure installation, secure operation, update, and decommissioning instructions |
+
+## 5. Engineering Controls
+
+- Pre-commit review and main-branch protection: Replace direct-to-main release eligibility for this product-security-risk change with branch protection, required review, signed approval, or an equivalent auditable control before production deployment.
+- Product security scope inventory: Create a CheckoutService product security inventory covering product/component status, owners, intended purpose, foreseeable misuse, dependencies, support period, update path, evidence references, and qualified owner decisions.
+- Secure-by-design development: Require secure-by-design review for delivery notes, Kafka propagation, support access, database migration, direct-to-main release risk, and external provider paths before product release.
+- Threat modeling: Add threat model for free-text delivery instructions, excessive data collection, downstream Kafka exposure, replay/idempotency risks, support lookup access, direct-to-main bypass, and incident evidence handling.
+- Secure defaults and hardening: Keep WAF, API gateway authentication, managed identities, private networking, Azure Policy, signed images, and immutable deployment. Add secure default for not emitting full delivery notes to Kafka unless explicitly justified.
+- Authentication and authorization: Verify field-level authorization for full delivery-note lookup and least privilege for CheckoutService, support tools, Kafka, PostgreSQL, Key Vault, and deployment credentials.
+- Cryptography and key ownership: Confirm HTTPS ingress, service-to-service transport security, Kafka transport security, PostgreSQL encryption, Key Vault secret storage, key ownership, rotation, and privileged operation auditability.
+- Sensitive-data-safe logging and monitoring: Prove `delivery_instruction_note` is not logged, traced, indexed, or included in alert payloads; preserve correlation IDs, saga IDs, order IDs, schema versions, and event names.
+- Vulnerability intake and coordinated disclosure: Add vulnerability contact, CVD policy, triage workflow, severity model, remediation SLA, exception owner, advisory process, user notification, and Article 14 reporting handoff.
+- Security update mechanism: Document signed artifact release, security-only update route where feasible, rollback, smoke tests, vulnerability regression tests, and update availability.
+- Dependency and SBOM evidence: Attach SBOM, dependency scan, image scan, secret scan, Maven plugin inventory, container base image review, and generated-client review to the release.
+- Product security documentation: Add secure installation, operation, update, decommissioning, vulnerability contact, support-period, and integrator guidance.
+- Release readiness and owner approvals: Gate production release on product, product-security, platform, support, legal/compliance, market-access, risk, and executive owner approvals where applicable.
+
+## 6. Evidence Inventory
+
+- Product security scope inventory: Not present.
+- Product classification or economic-operator handoff: Not present.
+- Threat model: Not present for delivery instructions or direct-to-main release risk.
+- Secure default configuration: Partially described through platform controls; feature-specific secure defaults are not present.
+- Authentication and authorization review: API gateway authentication and managed identities are described; field-level authorization review is not present.
+- Cryptography review: HTTPS, private networking, and Key Vault are described; key ownership and rotation evidence are not present.
+- Logging and monitoring review: Observability stack is described; privacy and sensitive-data-safe logging evidence for delivery notes is not present.
+- Vulnerability disclosure policy: Not present.
+- Vulnerability contact address: Not present.
+- Vulnerability scan or triage evidence: Scans are described; triage records are not present.
+- Security advisory evidence: Not present.
+- Security update and rollback evidence: Rollback concepts are described; security advisory and update availability evidence are not present.
+- Dependency or SBOM evidence: Pipeline generates SBOM and provenance; concrete SBOM artifact is not linked.
+- Technical documentation: Not present in CRA-ready form.
+- User instructions: Not present.
+- Support-period rationale: Not present.
+- End-of-support notice: Not present.
+- Conformity or CE marking owner handoff: Not present.
+- Release decision: Not present.
+- Main-branch protection or equivalent approval: Not present.
+
+## 7. Residual Risks
+
+- Residual risk: Direct-to-main delivery may allow a database migration, Kafka contract change, sensitive field change, or product-security control gap to reach release without independent review.
+- Impact: Incomplete secure-by-design evidence, missing technical documentation, weak vulnerability or update evidence, customer-facing checkout disruption, and unapproved product-security risk.
+- Likelihood: Medium, because the reviewed delivery model commits every change directly to `main`.
+- Mitigation: Require protected-main rules or equivalent review controls, approval evidence, emergency exception process, and release gates for product-security, migration, Kafka, privacy, and security-risk changes.
+- Owner: Platform owner, product-security owner, architecture owner, CheckoutService owner, and executive accountability owner.
+- Acceptance decision: Required before production release.
+- Review date: Before the direct-to-main commit is eligible for deployment.
+
+- Residual risk: Product scope, economic-operator role, conformity route, CE marking implications, Article 14 reporting obligations, and support-period interpretation are unknown.
+- Impact: Late compliance escalation, missing owner approvals, incomplete technical documentation, or incorrect product-security release assumptions.
+- Likelihood: Unknown.
+- Mitigation: Route the classification and conformity questions to legal, compliance, product, product-security, support, market-access, risk, and executive accountability owners.
+- Owner: Legal/compliance owner, product owner, market-access owner, and product-security owner.
+- Acceptance decision: Required before treating the change as CRA-ready.
+- Review date: Before production release or product availability decision.
+
+- Residual risk: Delivery instruction free text may increase sensitive data, logging, support access, Kafka propagation, or incident evidence exposure.
+- Impact: Unnecessary data processing, unauthorized access, sensitive-data exposure, and incomplete secure-by-design evidence.
+- Likelihood: Medium, because the feature explicitly introduces free text and event changes.
+- Mitigation: Minimize fields, avoid Kafka payload propagation of full notes, add field-level authorization, redact logs, add tests, and document data removal.
+- Owner: CheckoutService owner, product-security owner, support owner, data/privacy owner, and legal/compliance owner.
+- Acceptance decision: Required before production release.
+- Review date: Before committing to `main` and before deployment.
+
+## 8. Release Decision
+
+- Decision: Blocked for production until direct-to-main delivery is supplemented with product-security change-control evidence and CRA owner handoffs.
+- Conditions:
+  - Protected-main or equivalent pre-commit approval control is enforced for this change.
+  - Product scope, economic-operator role, conformity, CE marking, reporting, and support-period questions are routed to qualified owners.
+  - Threat model covers delivery notes, Kafka events, database migration, support lookup, sensitive-data-safe logging, direct-to-main release risk, and foreseeable misuse.
+  - Secure defaults minimize delivery note propagation and restrict access to full notes.
+  - Vulnerability contact, coordinated disclosure policy, advisory workflow, and Article 14 handoff are documented.
+  - SBOM, dependency scan, image scan, secret scan, vulnerability triage, and exception records are linked.
+  - Security update path, rollback evidence, user mitigation guidance, and update availability are documented.
+  - Product security documentation, support-period rationale, end-of-support notice, and secure decommissioning guidance are linked where applicable.
+- Blockers:
+  - Direct-to-main commit path lacks explicit pre-merge review, protected-main approval, or exception evidence.
+  - Missing product security scope inventory and qualified owner handoffs.
+  - Missing threat model, CVD policy, vulnerability contact, advisory workflow, and support-period evidence.
+  - Missing concrete SBOM artifact, vulnerability triage, security update evidence, and product security documentation.
+  - Missing release evidence for migration approval, Kafka compatibility, sensitive-data-safe logging, and field-level authorization.
+- Required approvals: Product owner, technical owner, product-security owner, platform owner, support owner, architecture owner, data/privacy owner, legal/compliance owner, market-access owner when applicable, business owner, and executive accountability owner for direct-to-main exception or approval policy.
+- Expiry or review date: Before committing to `main` and again before production deployment.
+- Environments or product versions approved: Development and test only until blockers are resolved.
+- Emergency security update path: Signed security update through CI/CD with advisory, user mitigation guidance, vulnerability regression tests, and support owner approval.
+- Emergency rollback path: Previous signed image plus compatible database state. Confirm whether the order table migration can be safely rolled forward or rolled back without losing delivery instruction data.
+
+## 9. Action Plan
+
+| Priority | Action | Owner | Due date | Evidence expected | Status |
+| -------- | ------ | ----- | -------- | ----------------- | ------ |
+| High | Add protected-main or equivalent auditable review control for the CheckoutService delivery-instructions change | Platform owner / product-security owner | Before production deployment | Branch protection, approval, or exception evidence | Open |
+| High | Require cybersecurity and product-security pre-commit review for database migrations, Kafka contracts, sensitive fields, support workflows, and production-side-effect changes | Product security / architecture owner | Before committing to `main` | Review checklist and approval record | Open |
+| High | Create CRA product security scope inventory for CheckoutService and delivery-instructions change | Product owner / product-security owner | Before release approval | Inventory with product scope, intended purpose, owners, update path, support-period signal, and evidence links | Open |
+| High | Route product classification, economic-operator role, conformity assessment, CE marking, Article 14 reporting, and support-period interpretation to qualified owners | Legal / compliance / market-access / product owner | Before release approval | Owner decision record or explicit deferred decision | Open |
+| High | Add threat model and secure-default review for delivery notes, Kafka propagation, support lookup, direct-to-main delivery, and foreseeable misuse | Product security / architecture owner | Before release approval | Threat model and secure-default checklist | Open |
+| High | Add field-level authorization and sensitive-data-safe logging tests for delivery instruction data | CheckoutService owner / security owner | Before release approval | Test results and logging policy evidence | Open |
+| High | Add database migration approval and Kafka schema version 3 compatibility evidence | CheckoutService owner / data owner / downstream owners | Before release approval | Migration test results, contract tests, rollback or forward-fix plan | Open |
+| High | Attach SBOM, dependency scan, image scan, secret scan, and vulnerability triage records | Platform owner / product-security owner | Before production deployment | Evidence bundle and exception decisions | Open |
+| High | Add vulnerability contact, CVD policy, security advisory workflow, and Article 14 reporting handoff | Product security / legal / support owner | Before production deployment | Policy, contact, advisory template, and escalation workflow | Open |
+| Medium | Document signed security update path, update availability, user mitigation guidance, and rollback evidence | Platform owner / support owner | Before production deployment | Security update runbook and rollback rehearsal | Open |
+| Medium | Add product security documentation, support-period rationale, end-of-support signaling, and secure decommissioning instructions where applicable | Product owner / support owner | Before product availability decision | Documentation index and support-period record | Open |
+| Low | Schedule next CRA engineering review after deployment and first security update exercise | Product-security owner / support owner | After production validation | Review record and corrective actions | Open |
+
+## 10. Final Notes
+
+- Items requiring legal interpretation: Product-with-digital-elements scope, economic-operator role, substantial modification, Article 14 reporting obligations, applicability dates, conformity assessment, CE marking implications, and regulatory interpretation.
+- Items requiring product classification or economic-operator role decision: CheckoutService component status, EU market availability, manufacturer or supplier responsibilities, important or critical product category signals, and remote data processing responsibility.
+- Items requiring conformity assessment or CE marking review: Technical documentation expectations, declaration evidence, CE marking implications, and whether any notified body or certification route is needed.
+- Items requiring Article 14 reporting interpretation: Actively exploited vulnerability and severe incident criteria, reporting endpoints, notification timing, and user notification obligations.
+- Items requiring product security exception: Any release without protected-main or equivalent approval evidence, threat model, CVD policy, vulnerability triage, SBOM, security update path, sensitive-data-safe logging evidence, or support-period handoff.
+- Items requiring architecture decision: Direct-to-main release policy, Kafka schema versioning, older-consumer compatibility, free-text note lookup pattern, database migration rollout, rollback limits, and downstream service ownership.
+- Items requiring support or end-of-support review: Support-period statement, security update availability, customer advisory process, end-of-support notification, and secure decommissioning guidance.
+- Items requiring procurement, supplier, or open-source steward review: Azure services, external identity provider, external payment gateway, email/SMS provider, Artifactory, Docker registry, CI/CD actions, Quarkus libraries, Maven plugins, and container base images.
+- Items requiring product or business acceptance: Residual risk for direct-to-main delivery, delivery note privacy, product-security classification uncertainty, support workflow changes, possible checkout or delivery disruption, and customer-facing rollout timing.
+- Next review trigger: Direct-to-main approval request, production deployment request, product availability decision, security update, schema or event contract change, provider change, vulnerability report, incident, support-period change, or end-of-support notice.

--- a/examples/regulations/eu-cyber-resilience-act/CRA-ENGINEERING-REVIEW-REPORT.md
+++ b/examples/regulations/eu-cyber-resilience-act/CRA-ENGINEERING-REVIEW-REPORT.md
@@ -1,0 +1,193 @@
+# EU Cyber Resilience Act Engineering Review Report
+
+Use this report as engineering evidence for legal, compliance, product, product-security, security, support, market-access, risk, architecture, executive accountability, and business-owner review.
+
+This report is not legal advice. It identifies engineering controls and escalation points from the reviewed system evidence. Product classification, economic-operator role, conformity assessment, CE marking implications, Article 14 reporting obligations, support-period interpretation, cybersecurity risk acceptance, and regulatory interpretation require qualified owner review.
+
+## 1. Review Context
+
+- Product, service, component, library, agent, plugin, or platform module: CheckoutService delivery instructions change
+- Repository or implementation path: Fictional Java Quarkus ecommerce platform
+- Review date: 2026-06-14
+- Reviewers: AI-assisted Cyber Resilience Act engineering review
+- Business owner: Not identified in reviewed evidence
+- Product owner: Not identified in reviewed evidence
+- Technical owner: Software engineers, tech leads, reviewers, and platform engineers are described, but no named CheckoutService owner is identified
+- Product security owner: Not identified in reviewed evidence
+- Support owner: Support and operations teams are described, but no named support owner is identified
+- Legal/compliance owner: Not identified in reviewed evidence
+- Market-access or conformity owner: Not identified in reviewed evidence
+- Source materials reviewed:
+  - `examples/diagrams/deployment/system-example-cicd-pr-model.md`
+  - `examples/diagrams/deployment/expected-system-deployment.puml`
+  - `examples/diagrams/deployment/checkout-service-feature-request.md`
+  - `.agents/skills/805-regulations-eu-cyber-resilience-act/references/805-regulations-eu-cyber-resilience-act-chapters-summary.md`
+  - `.agents/skills/805-regulations-eu-cyber-resilience-act/references/805-regulations-eu-cyber-resilience-act-engineering-examples.md`
+  - `.agents/skills/805-regulations-eu-cyber-resilience-act/assets/reports/805-eu-cyber-resilience-act-engineering-review-report-template.md`
+
+## 2. Product Security Scope
+
+- Product or component description: CheckoutService coordinates checkout saga steps for price validation, inventory reservation, payment authorization, order creation, delivery slot booking, PostgreSQL order state, saga state, and Kafka events.
+- Possible product-with-digital-elements signal: The reviewed evidence describes a Java service and related platform components with network connectivity, APIs, databases, Kafka messages, identity, payment, delivery, and cloud dependencies. It does not establish whether the service is itself a product with digital elements or part of one.
+- Possible remote data processing signal: CheckoutService, payment adapter, inventory, delivery slot service, notification worker, analytics pipeline, and cloud services process data remotely as part of the platform. Qualified owners must decide whether any remote processing is under manufacturer responsibility for a product with digital elements.
+- Possible important or critical product signal: Not confirmed. Identity, API gateway, Kafka, container runtime, WAF, and platform services may be relevant dependencies, but the reviewed feature does not classify CheckoutService under Annex III or Annex IV.
+- Intended purpose: Add delivery instructions to checkout and order events while preserving checkout, delivery, notification, and analytics behavior.
+- Reasonably foreseeable use or misuse: Users may enter free-text delivery notes containing personal data, access codes, or unsafe content; downstream consumers may over-propagate or log the new fields; database and Kafka contract changes may disrupt checkout flows.
+- Economic-operator role signals: No manufacturer, importer, distributor, open-source steward, authorised representative, or market-access role is recorded.
+- Deployment geography: Azure production environment is described; EU market availability is not specified.
+- Environments in scope: Development, test, staging, and production.
+- Users, integrators, or affected organizations: Shoppers, support and operations teams, platform engineers, downstream inventory, delivery, notification, analytics, and payment workflows.
+- Support-period signal: No support period, security update availability commitment, or end-of-support signaling appears in the reviewed evidence.
+- Security update delivery path: CI/CD builds signed images, SBOM and provenance metadata, GitOps/CD deployment, automated promotion, health checks, and smoke tests. Security-update advisory, user notification, update availability, and rollback evidence are not complete.
+- Open applicability questions:
+  - Is CheckoutService or the ecommerce platform a product with digital elements made available on the EU market?
+  - Which entity, if any, is the manufacturer or other economic operator for this product or component?
+  - Does the change create a substantial modification or affect a product with digital elements already placed on the market?
+  - Are Annex III important-product or Annex IV critical-product categories implicated by identity, gateway, container, security, or connected-product dependencies?
+  - Which qualified owners must approve conformity assessment, CE marking implications, Article 14 reporting handoffs, and support-period statements?
+
+## 3. Engineering Evidence Reviewed
+
+- Java applications, libraries, agents, plugins, APIs, jobs, or installers: Web storefront BFF, API gateway, identity, catalog, search, cart, pricing, CheckoutService, payment adapter, inventory, delivery slot, notification worker, analytics pipeline, checkout saga logic, and deployment workflows.
+- Data stores, queues, topics, caches, files, or remote processing: User Profile DB, Product DB, Search Index, Cart DB, Pricing DB, Order DB, Saga Support PostgreSQL, Inventory DB, Delivery DB, Kafka topics `order.created`, `payment.authorized`, `stock.reserved`, `slot.booked`, `delivery.slot.requested`, `order.confirmed`, and compensation events.
+- Authentication, authorization, IAM, secrets, keys, and privileged operations: Azure Key Vault, managed identities, API gateway authentication enforcement, identity provider integration, payment tokens, idempotency keys, database credentials, Kafka credentials, and deployment credentials.
+- CI/CD workflows, build provenance, artifact signing, and deployment paths: Short-lived branch, pull request review and checks, CI/CD pipeline, Artifactory, Docker registry, signed images, SBOM and provenance metadata, GitOps/CD pipeline, automated environment promotion, migration safety checks, health checks, and smoke tests.
+- Third-party components, open-source dependencies, containers, and generated clients: Quarkus services, common Java libraries, container images, build pipeline tools, Azure services, external identity provider, external payment gateway, and email/SMS provider.
+- SBOM, dependency scan, image scan, and vulnerability triage evidence: Pipeline generates SBOM and provenance and runs dependency, image, and secret scanning; concrete SBOM references, vulnerability triage records, owner assignments, and exception decisions are not present.
+- Threat model, secure-by-design, secure defaults, and attack-surface evidence: The deployment model describes WAF, API gateway authentication, private networking, managed identities, Azure Policy, and immutable images. A product threat model for delivery instructions, Kafka propagation, support access, and foreseeable misuse is not present.
+- Logging, monitoring, security event, and incident evidence: Azure Monitor, App Insights, Log Analytics, structured logs, metrics, traces, correlation IDs, dashboards, alerts, health checks, and smoke tests are described; sensitive-data-safe logging proof for delivery notes is not present.
+- Coordinated disclosure, vulnerability contact, advisory, and reporting handoff evidence: Not present.
+- Security update, rollback, and support-period evidence: Rollback by previous image and compatible database state are described. Security advisory workflow, update availability, user notification, and support-period end date are not present.
+- Product security documentation and user instructions: Not present beyond delivery and deployment documentation.
+
+## 4. Potential Violation Or Non-Compliance Mapping
+
+This section is not a legal finding. It lists concrete potential Cyber Resilience Act violation or non-compliance signals from the reviewed evidence and routes each item to qualified owner review. No violation is confirmed by this engineering review.
+
+| Potential violation or non-compliance signal | CRA reference area | Associated official-source link | Evidence from reviewed system | Current status | Required owner review | Engineering action |
+| -------------------------------------------- | ------------------ | ------------------------------- | ----------------------------- | -------------- | --------------------- | ------------------ |
+| Unclear product-with-digital-elements scope and economic-operator role | Scope / product categories / economic-operator obligations | [Chapter I](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_I), [Chapter II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_II) | Java connected services, cloud deployment, APIs, Kafka, identity, payment, and delivery dependencies are described, but no product classification or operator role is recorded | Potential gap | Legal / compliance / product / market-access owner | Record product scope, EU market availability, manufacturer or supplier role, substantial modification decision, and accountable owner |
+| Missing product threat model and secure-default evidence for delivery instructions | Essential cybersecurity requirements for product properties | [Chapter I](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_I), [Annex I](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_I) | The feature adds free-text delivery notes and Kafka event changes; no threat model for foreseeable misuse, excessive data propagation, support access, or logging is present | Potential gap | Product security / architecture / security owner | Add threat model, secure default field propagation rules, authorization checks, data minimization, validation, and logging tests |
+| Missing coordinated disclosure, vulnerability contact, and advisory workflow evidence | Manufacturer obligations / reporting / vulnerability handling | [Chapter II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_II), [Annex I](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_I) | No vulnerability reporting contact, coordinated disclosure policy, advisory process, Article 14 reporting handoff, or user notification workflow appears in reviewed files | Potential gap | Product security / legal / compliance / support owner | Add CVD policy, vulnerability intake, triage, remediation, advisory, user notification, and reporting escalation workflow |
+| Incomplete security update and rollback evidence | Security updates / vulnerability remediation / user instructions | [Chapter II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_II), [Annex II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_II) | Signed images, automated deployment, and rollback by previous image are described; security-only update path, advisory, update availability, and user instructions are not shown | Potential gap | Product security / support / platform owner | Document signed security update path, advisory messages, rollback procedure, user mitigation guidance, and update availability commitment |
+| Incomplete dependency, open-source due diligence, and SBOM evidence | Component due diligence / SBOM / technical documentation | [Chapter II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_II), [Annex VII](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_VII) | Pipeline generates SBOM and scans dependencies/images, but concrete SBOM location, triage decisions, exception owners, and third-party review are absent | Potential gap | Product security / platform / procurement / risk owner | Attach SBOM, dependency and image scan evidence, vulnerability triage, remediation SLA, open-source due diligence, provider register, and exception records |
+| Missing product security documentation, support-period disclosure, and secure decommissioning guidance | User information / technical documentation / support period | [Annex II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_II), [Annex VII](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_VII) | No CRA-style user instructions, vulnerability contact, support-period end, end-of-support notice, security update instructions, or decommissioning guidance are present | Potential gap | Product / support / legal / market-access owner | Add product security documentation index, support-period rationale, end-of-support notice, secure installation, secure operation, update, and decommissioning instructions |
+| Missing conformity and CE marking owner handoff | Conformity / CE marking / technical documentation / market surveillance | [Chapter III](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_III), [Chapter V](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_V) | No conformity assessment, declaration, CE marking, or technical documentation owner is identified | Potential gap | Legal / compliance / market-access / product owner | Create owner handoff for conformity assessment route, declaration evidence, CE marking implications, and market-surveillance documentation access |
+
+## 5. Engineering Controls
+
+- Product security scope inventory: Create a CheckoutService product security inventory covering product/component status, owners, intended purpose, foreseeable misuse, dependencies, support period, update path, evidence references, and qualified owner decisions.
+- Secure-by-design development: Require secure-by-design review for delivery notes, Kafka propagation, support access, database migration, and external provider paths before merge.
+- Threat modeling: Add threat model for free-text delivery instructions, excessive data collection, downstream Kafka exposure, replay/idempotency risks, support lookup access, and incident evidence handling.
+- Secure defaults and hardening: Keep WAF, API gateway authentication, managed identities, private networking, Azure Policy, signed images, and immutable deployment. Add secure default for not emitting full delivery notes to Kafka unless explicitly justified.
+- Attack-surface reduction: Limit external interfaces, event fields, support APIs, and service-to-service lookup operations to the minimum needed.
+- Authentication and authorization: Verify field-level authorization for full delivery-note lookup and least privilege for CheckoutService, support tools, Kafka, PostgreSQL, Key Vault, and deployment credentials.
+- Cryptography and key ownership: Confirm HTTPS ingress, service-to-service transport security, Kafka transport security, PostgreSQL encryption, Key Vault secret storage, key ownership, rotation, and privileged operation auditability.
+- Data minimization and secure data removal: Store only necessary delivery note data, avoid unnecessary propagation to Kafka, define retention and deletion behavior, and document secure removal where product context requires it.
+- Sensitive-data-safe logging and monitoring: Prove `delivery_instruction_note` is not logged, traced, indexed, or included in alert payloads; preserve correlation IDs, saga IDs, order IDs, schema versions, and event names.
+- Vulnerability intake and triage: Add vulnerability contact, CVD policy, triage workflow, severity model, remediation SLA, exception owner, and Article 14 reporting handoff.
+- Coordinated vulnerability disclosure: Define researcher intake, maintainer coordination, affected-component handling, embargo decisions, advisory publication, and user communication workflow.
+- Security advisory and user notification: Add advisory template and owner approvals for security updates, mitigations, and user notifications.
+- Security update mechanism: Document signed artifact release, security-only update route where feasible, rollback, smoke tests, vulnerability regression tests, and update availability.
+- Dependency and SBOM evidence: Attach SBOM, dependency scan, image scan, secret scan, Maven plugin inventory, container base image review, and generated-client review to the release.
+- Product security documentation: Add secure installation, operation, update, decommissioning, vulnerability contact, support-period, and integrator guidance.
+- Support-period and end-of-support signaling: Record support-period rationale and end-of-support user notification approach.
+- Release readiness and owner approvals: Gate production release on product, product-security, platform, support, legal/compliance, market-access, and risk owner approvals where applicable.
+
+## 6. Evidence Inventory
+
+- Product security scope inventory: Not present.
+- Product classification or economic-operator handoff: Not present.
+- Threat model: Not present for delivery instructions.
+- Secure default configuration: Partially described through platform controls; feature-specific secure defaults not present.
+- Authentication and authorization review: API gateway authentication and managed identities are described; field-level authorization review is not present.
+- Cryptography review: HTTPS, private networking, and Key Vault are described; key ownership and rotation evidence are not present.
+- Logging and monitoring review: Observability stack is described; privacy and sensitive-data-safe logging evidence for delivery notes is not present.
+- Vulnerability disclosure policy: Not present.
+- Vulnerability contact address: Not present.
+- Vulnerability scan or triage evidence: Scans are described; triage records are not present.
+- Security advisory evidence: Not present.
+- Security update and rollback evidence: Rollback concepts are described; security advisory and update availability evidence are not present.
+- Dependency or SBOM evidence: Pipeline generates SBOM and provenance; concrete SBOM artifact is not linked.
+- Technical documentation: Not present in CRA-ready form.
+- User instructions: Not present.
+- Support-period rationale: Not present.
+- End-of-support notice: Not present.
+- Conformity or CE marking owner handoff: Not present.
+- Release decision: Not present.
+
+## 7. Residual Risks
+
+- Residual risk: Product scope, economic-operator role, conformity route, CE marking implications, Article 14 reporting obligations, and support-period interpretation are unknown.
+- Impact: Late compliance escalation, missing owner approvals, incomplete technical documentation, or incorrect product-security release assumptions.
+- Likelihood: Unknown.
+- Mitigation: Route the classification and conformity questions to legal, compliance, product, product-security, support, market-access, risk, and executive accountability owners.
+- Owner: Legal/compliance owner, product owner, market-access owner, and product-security owner.
+- Acceptance decision: Required before treating the change as CRA-ready.
+- Review date: Before production release or product availability decision.
+
+- Residual risk: Delivery instruction free text may increase sensitive data, logging, support access, Kafka propagation, or incident evidence exposure.
+- Impact: Unnecessary data processing, unauthorized access, sensitive-data exposure, and incomplete secure-by-design evidence.
+- Likelihood: Medium, because the feature explicitly introduces free text and event changes.
+- Mitigation: Minimize fields, avoid Kafka payload propagation of full notes, add field-level authorization, redact logs, add tests, and document data removal.
+- Owner: CheckoutService owner, product-security owner, support owner, data/privacy owner, and legal/compliance owner.
+- Acceptance decision: Required before production release.
+- Review date: Before merge and before deployment.
+
+- Residual risk: Database migration and Kafka schema change may disrupt product functionality, update safety, or rollback.
+- Impact: Checkout failure, delivery booking errors, stale consumers, failed security update rollback, and customer-impacting incidents.
+- Likelihood: Medium, because the feature changes persisted order structure and event contracts.
+- Mitigation: Backward-compatible migration, consumer compatibility tests, schema version 3 contract evidence, rollback or forward-fix plan, and post-deployment monitoring.
+- Owner: Architecture owner, CheckoutService owner, platform owner, product-security owner, and downstream service owners.
+- Acceptance decision: Required before production release.
+- Review date: During PR review and release readiness.
+
+## 8. Release Decision
+
+- Decision: Conditionally blocked for production until CRA product-security evidence and owner handoffs are attached to the PR and release record.
+- Conditions:
+  - Product scope, economic-operator role, conformity, CE marking, reporting, and support-period questions are routed to qualified owners.
+  - Threat model covers delivery notes, Kafka events, database migration, support lookup, sensitive-data-safe logging, and foreseeable misuse.
+  - Secure defaults minimize delivery note propagation and restrict access to full notes.
+  - Vulnerability contact, coordinated disclosure policy, advisory workflow, and Article 14 handoff are documented.
+  - SBOM, dependency scan, image scan, secret scan, vulnerability triage, and exception records are linked.
+  - Security update path, rollback evidence, user mitigation guidance, and update availability are documented.
+  - Product security documentation, support-period rationale, end-of-support notice, and secure decommissioning guidance are linked where applicable.
+- Blockers:
+  - Missing product security scope inventory and qualified owner handoffs.
+  - Missing threat model, CVD policy, vulnerability contact, advisory workflow, and support-period evidence.
+  - Missing concrete SBOM artifact, vulnerability triage, security update evidence, and product security documentation.
+  - Missing release evidence for migration approval, Kafka compatibility, sensitive-data-safe logging, and field-level authorization.
+- Required approvals: Product owner, technical owner, product-security owner, platform owner, support owner, architecture owner, data/privacy owner, legal/compliance owner, market-access owner when applicable, and business owner.
+- Expiry or review date: Before merge and again before production deployment.
+- Environments or product versions approved: Development and test only until blockers are resolved.
+- Emergency security update path: Signed security update through CI/CD with advisory, user mitigation guidance, vulnerability regression tests, and support owner approval.
+- Emergency rollback path: Previous signed image plus compatible database state. Confirm whether the order table migration can be safely rolled forward or rolled back without losing delivery instruction data.
+
+## 9. Action Plan
+
+| Priority | Action | Owner | Due date | Evidence expected | Status |
+| -------- | ------ | ----- | -------- | ----------------- | ------ |
+| High | Create CRA product security scope inventory for CheckoutService and delivery-instructions change | Product owner / product-security owner | Before PR approval | Inventory with product scope, intended purpose, owners, update path, support-period signal, and evidence links | Open |
+| High | Route product classification, economic-operator role, conformity assessment, CE marking, Article 14 reporting, and support-period interpretation to qualified owners | Legal / compliance / market-access / product owner | Before release approval | Owner decision record or explicit deferred decision | Open |
+| High | Add threat model and secure-default review for delivery notes, Kafka propagation, support lookup, and foreseeable misuse | Product security / architecture owner | Before merge | Threat model and secure-default checklist | Open |
+| High | Add field-level authorization and sensitive-data-safe logging tests for delivery instruction data | CheckoutService owner / security owner | Before merge | Test results and logging policy evidence | Open |
+| High | Add database migration approval and Kafka schema version 3 compatibility evidence | CheckoutService owner / data owner / downstream owners | Before merge | Migration test results, contract tests, rollback or forward-fix plan | Open |
+| High | Attach SBOM, dependency scan, image scan, secret scan, and vulnerability triage records | Platform owner / product-security owner | Before production deployment | Evidence bundle and exception decisions | Open |
+| High | Add vulnerability contact, CVD policy, security advisory workflow, and Article 14 reporting handoff | Product security / legal / support owner | Before production deployment | Policy, contact, advisory template, and escalation workflow | Open |
+| Medium | Document signed security update path, update availability, user mitigation guidance, and rollback evidence | Platform owner / support owner | Before production deployment | Security update runbook and rollback rehearsal | Open |
+| Medium | Add product security documentation, support-period rationale, end-of-support signaling, and secure decommissioning instructions where applicable | Product owner / support owner | Before product availability decision | Documentation index and support-period record | Open |
+| Low | Schedule next CRA engineering review after deployment and first security update exercise | Product-security owner / support owner | After production validation | Review record and corrective actions | Open |
+
+## 10. Final Notes
+
+- Items requiring legal interpretation: Product-with-digital-elements scope, economic-operator role, substantial modification, Article 14 reporting obligations, applicability dates, conformity assessment, CE marking implications, and regulatory interpretation.
+- Items requiring product classification or economic-operator role decision: CheckoutService component status, EU market availability, manufacturer or supplier responsibilities, important or critical product category signals, and remote data processing responsibility.
+- Items requiring conformity assessment or CE marking review: Technical documentation expectations, declaration evidence, CE marking implications, and whether any notified body or certification route is needed.
+- Items requiring Article 14 reporting interpretation: Actively exploited vulnerability and severe incident criteria, reporting endpoints, notification timing, and user notification obligations.
+- Items requiring product security exception: Any release without threat model, CVD policy, vulnerability triage, SBOM, security update path, sensitive-data-safe logging evidence, or support-period handoff.
+- Items requiring architecture decision: Kafka schema versioning, older-consumer compatibility, free-text note lookup pattern, database migration rollout, rollback limits, and downstream service ownership.
+- Items requiring support or end-of-support review: Support-period statement, security update availability, customer advisory process, end-of-support notification, and secure decommissioning guidance.
+- Items requiring procurement, supplier, or open-source steward review: Azure services, external identity provider, external payment gateway, email/SMS provider, Artifactory, Docker registry, CI/CD actions, Quarkus libraries, Maven plugins, and container base images.
+- Items requiring product or business acceptance: Residual risk for delivery note privacy, product-security classification uncertainty, support workflow changes, possible checkout or delivery disruption, and customer-facing rollout timing.
+- Next review trigger: PR approval request, production deployment request, product availability decision, security update, schema or event contract change, provider change, vulnerability report, incident, support-period change, or end-of-support notice.

--- a/skills-generator/src/main/resources/skill-indexes/805-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/805-skill.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="https://jabrena.github.io/pml/schemas/0.7.0/pml.xsd"
+      id="805-regulations-eu-cyber-resilience-act">
+  <metadata>
+    <author>Juan Antonio Breña Moral</author>
+    <version>0.16.0-SNAPSHOT</version>
+    <license>Apache-2.0</license>
+    <description>Use when reviewing, designing, or modifying Java enterprise products, services, libraries, agents, plugins, connected components, or platform modules that may qualify as products with digital elements and need EU Cyber Resilience Act secure-by-design, vulnerability handling, security update, SBOM, product documentation, or release-readiness controls.</description>
+  </metadata>
+
+  <title>EU Cyber Resilience Act Regulation for Java Product Security Engineering</title>
+  <goal><![CDATA[
+Use this Skill to review Java enterprise applications, libraries, agents, plugins, connected components, platform modules, CI/CD workflows, product security documentation, and release evidence that may support products with digital elements under Regulation (EU) 2024/2847, the Cyber Resilience Act.
+
+Apply this Skill to determine what secure-by-design controls, vulnerability handling evidence, update mechanisms, dependency and SBOM records, product documentation, support-period signals, and owner handoffs are needed before a product, component, or product-adjacent Java change is released or made available.
+
+This Skill is not legal advice. It helps Java engineers, architects, tech leads, platform teams, product security teams, and reviewers identify when Cyber Resilience Act concerns may apply and how to translate product-security expectations into engineering controls such as secure defaults, threat modeling, least privilege, cryptography, sensitive-data-safe logging, coordinated vulnerability disclosure, security update delivery, SBOM evidence, product security documentation, end-of-support signaling, and release gates.
+
+The purpose of this Skill is to increase awareness of potential gaps in the system and create engineering evidence for qualified review. The response produced by this Skill does not represent legal advice, a legal opinion, a conformity assessment, a CE marking decision, or a final regulatory determination.
+
+The main question is:
+
+> When does a Java product or product-adjacent component require EU Cyber Resilience Act-aware secure-by-design and vulnerability-handling controls, and what should developers build differently?
+
+External reference: [Cyber Resilience Act Regulation (EU) 2024/2847](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847).
+
+Cyber Resilience Act chapters summary reference: [Cyber Resilience Act chapters summary](references/805-regulations-eu-cyber-resilience-act-chapters-summary.md).
+
+Java engineering examples reference: [Cyber Resilience Act engineering examples](references/805-regulations-eu-cyber-resilience-act-engineering-examples.md).
+
+Report template asset: [Cyber Resilience Act engineering review report template](assets/reports/805-eu-cyber-resilience-act-engineering-review-report-template.md).
+
+## Scope
+
+This Skill applies to:
+
+- Java software or hardware-adjacent products with direct or indirect logical or physical connections to devices or networks
+- Java libraries, SDKs, plugins, agents, embedded components, device gateways, product APIs, installers, update clients, and product management services
+- Spring Boot, Quarkus, Micronaut, and framework-agnostic Java components used in products with digital elements or remote data processing solutions
+- Product security architecture, secure-by-design reviews, threat models, secure defaults, authentication, authorization, cryptography, logging, update, and decommissioning controls
+- Vulnerability handling, coordinated disclosure, security advisory, SBOM, dependency, third-party component, and open-source due diligence workflows
+- Product security documentation, user instructions, support-period disclosure, end-of-support notification, release readiness, and market-surveillance evidence handoffs
+
+## Cyber Resilience Act Engineering Review
+
+Treat product classification, economic-operator role, important or critical product category, conformity assessment route, CE marking implications, Article 14 reporting obligations, support-period legal interpretation, and regulatory interpretation as qualified decisions for legal, compliance, product, product-security, risk, market-access, and executive accountability owners.
+
+Engineering teams should still create evidence that makes those decisions reviewable:
+
+- Which product, component, remote data processing solution, or product-adjacent Java module is in scope
+- Which manufacturer, importer, distributor, open-source steward, product owner, security owner, and support owner signals exist
+- Which cybersecurity risks, intended uses, reasonably foreseeable uses, and reasonably foreseeable misuse cases were threat modeled
+- Which secure defaults, authentication, authorization, cryptography, logging, minimization, update, and secure decommissioning controls are implemented
+- Which vulnerabilities, dependencies, SBOM records, third-party components, coordinated disclosure paths, and security advisories are tracked
+- Which product security documentation, support-period, end-of-support, release decision, and owner approval evidence exists
+]]></goal>
+
+  <constraints>
+    <constraints-description>Translate Cyber Resilience Act concerns into engineering controls for Java products and product-adjacent systems. Do not provide legal advice or replace review by legal, compliance, product, security, product-security, market-access, risk, or executive accountability owners.</constraints-description>
+    <constraint-list>
+      <constraint>**NOT LEGAL ADVICE**: Frame findings as product-security engineering controls and escalation points; recommend qualified review for product classification, economic-operator role, conformity assessment, CE marking implications, Article 14 reporting obligations, support-period interpretation, and regulatory interpretation</constraint>
+      <constraint>**SCOPE FIRST**: Identify the product with digital elements, remote data processing solution, software component, Java module, product owner, security owner, support owner, and release context before recommending controls</constraint>
+      <constraint>**SECURE BY DESIGN**: Review threat modeling, secure defaults, least privilege, attack-surface reduction, exploitation mitigation, data minimization, authentication, authorization, cryptography, and secure decommissioning</constraint>
+      <constraint>**VULNERABILITY HANDLING**: Require coordinated disclosure, vulnerability intake, triage, remediation, advisory, user notification, secure update delivery, and verification evidence</constraint>
+      <constraint>**DEPENDENCY AND SBOM EVIDENCE**: Treat libraries, Maven plugins, containers, generated clients, third-party components, open-source dependencies, build tools, and runtime platforms as product supply-chain inputs requiring reviewable records</constraint>
+      <constraint>**PRODUCT DOCUMENTATION**: Review technical documentation, user instructions, secure installation and operation guidance, support-period disclosure, end-of-support signaling, and evidence retention</constraint>
+      <constraint>**SENSITIVE-DATA-SAFE LOGGING**: Preserve product security evidence without logging secrets, credentials, personal data, support tokens, vulnerability exploit details, private keys, or sensitive incident details unnecessarily</constraint>
+      <constraint>**RELEASE READINESS**: Do not mark a product ready when secure-by-design, vulnerability handling, update, dependency, SBOM, documentation, support-period, or owner handoff controls are undocumented, untested, ownerless, or unresolved</constraint>
+    </constraint-list>
+  </constraints>
+
+  <triggers>
+    <trigger-list>
+        <trigger>Review a Java product for EU Cyber Resilience Act controls</trigger>
+        <trigger>Design secure-by-design and vulnerability handling evidence for products with digital elements</trigger>
+        <trigger>Add coordinated disclosure, security update, SBOM, product security documentation, or end-of-support controls</trigger>
+        <trigger>Assess CRA release readiness before making a Java component, agent, plugin, library, or connected product available</trigger>
+        <trigger>Check whether Java product dependencies, CI/CD workflows, update mechanisms, or support-period evidence are CRA-aware</trigger>
+    </trigger-list>
+  </triggers>
+  <steps>
+    <step number="1"><step-title>Read regulation summary, engineering examples, and report template</step-title><step-content>Read `references/805-regulations-eu-cyber-resilience-act-chapters-summary.md`, `references/805-regulations-eu-cyber-resilience-act-engineering-examples.md`, and `assets/reports/805-eu-cyber-resilience-act-engineering-review-report-template.md` in that order. Use the chapters summary for Cyber Resilience Act chapter, article, annex, scope, product-category, manufacturer, reporting, conformity, market-surveillance, enforcement, support-period, and owner-handoff context. Use the engineering examples for Java control patterns such as product security scope inventory, threat modeling and secure defaults, vulnerability and coordinated disclosure evidence, security update delivery, dependency and SBOM evidence, product documentation, end-of-support signaling, and release gates. Do not start implementation review until the chapters summary, examples reference, and report template are understood.</step-content></step>
+    <step number="2"><step-title>Classify the product-security scope</step-title><step-content>Identify the product, component, remote data processing solution, Java module, intended purpose, reasonably foreseeable use, possible product-with-digital-elements signal, possible important or critical product signal, economic-operator signals, support period, deployment environments, user population, update path, vulnerability intake path, dependencies, SBOM evidence, and product documentation. Escalate unclear product classification, economic-operator role, conformity assessment route, CE marking implications, Article 14 reporting duties, support-period interpretation, or regulatory interpretation to qualified legal, compliance, product, product-security, market-access, risk, or executive accountability owners.</step-content></step>
+    <step number="3"><step-title>Review implementation and product evidence</step-title><step-content>Review Java code, configuration, product documentation, threat models, test evidence, CI/CD workflows, dependency inventories, SBOMs, vulnerability records, coordinated disclosure policy, update mechanisms, logging, cryptography, authentication, authorization, support-period notices, end-of-support behavior, release approvals, and user instructions. Check for gaps between claimed controls and reviewable evidence.</step-content></step>
+    <step number="4"><step-title>Recommend engineering controls</step-title><step-content>Map Cyber Resilience Act concerns to engineering actions: secure-by-design development, threat modeling, secure defaults, least privilege, authentication, authorization, cryptography, data minimization, sensitive-data-safe logging, attack-surface reduction, vulnerability management, coordinated disclosure, security update delivery, advisory publication, dependency and SBOM evidence, product security documentation, support-period disclosure, end-of-support signaling, and release readiness.</step-content></step>
+    <step number="5"><step-title>Generate review report and owner handoffs</step-title><step-content>Use `assets/reports/805-eu-cyber-resilience-act-engineering-review-report-template.md` to produce a concise engineering review with scope, evidence reviewed, CRA product-security signals, potential violation or non-compliance signals, engineering gaps, recommended controls, owner handoffs, residual risks, release decision, and validation steps. State explicitly that product classification, economic-operator role, conformity assessment, CE marking implications, Article 14 reporting obligations, and regulatory interpretation require qualified owner review.</step-content></step>
+  </steps>
+</prompt>

--- a/skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-chapters-summary.xml
+++ b/skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-chapters-summary.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <metadata>
+        <author>Juan Antonio Breña Moral</author>
+        <version>0.16.0-SNAPSHOT</version>
+        <license>Apache-2.0</license>
+        <title>EU Cyber Resilience Act Regulation for Java Product Security Engineering</title>
+        <description>Use as a chapter-by-chapter, article-by-article, and annex-level summary of Regulation (EU) 2024/2847 to enrich Java product security reviews with Cyber Resilience Act context.</description>
+    </metadata>
+
+    <role>You are a senior Java enterprise architect and product security reviewer using the Cyber Resilience Act article structure to map product-security themes to engineering controls and owner handoffs</role>
+
+    <goal><![CDATA[
+Summarize the official chapter, article, and annex structure of Regulation (EU) 2024/2847, the Cyber Resilience Act, for engineering review of Java products, libraries, agents, plugins, connected components, product APIs, update mechanisms, CI/CD pipelines, and product security evidence.
+
+Source reviewed: [EUR-Lex Regulation (EU) 2024/2847 HTML text](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847).
+
+This reference is not legal advice. Use it to orient engineering discovery, architecture review, product security evidence collection, release gates, and escalation conversations with legal, compliance, product, product-security, market-access, security, risk, support, executive accountability, and business owners.
+
+Use `references/805-regulations-eu-cyber-resilience-act-engineering-examples.md` for Java examples and implementation control patterns. Keep this chapters summary focused on Cyber Resilience Act structure and article-level obligations.
+
+Report template asset: [Cyber Resilience Act engineering review report template](../assets/reports/805-eu-cyber-resilience-act-engineering-review-report-template.md).
+
+## [Chapter I: General provisions (Articles 1-12)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_I)
+
+Sets the scope for products with digital elements, product categories, procurement considerations, and interaction with other Union frameworks such as NIS2 and the EU AI Act. For Java teams, this chapter is the starting point for determining whether a service, library, agent, plugin, connected component, remote processing solution, or platform module needs CRA-aware product security evidence.
+
+Article map:
+- Article 1, Subject matter: establishes rules for making products with digital elements available, essential cybersecurity requirements for design, development, production, vulnerability handling, and market surveillance.
+- Article 2, Scope: applies to products with digital elements made available on the market whose intended purpose or reasonably foreseeable use includes a direct or indirect logical or physical data connection to a device or network, with exclusions and interaction with sectoral rules.
+- Article 3, Definitions: defines product with digital elements, remote data processing, cybersecurity risk, software bill of materials, vulnerability, actively exploited vulnerability, incident, economic operator, manufacturer, support period, substantial modification, and CE marking.
+- Article 4, Free movement: protects free movement for compliant products and addresses prototypes or unfinished software used for testing.
+- Article 5, Procurement or use of products with digital elements: allows additional procurement or use requirements and requires public procurement consideration of Annex I requirements and vulnerability handling.
+- Article 6, Requirements for products with digital elements: requires products to meet Annex I Part I and manufacturers' processes to meet Annex I Part II.
+- Article 7, Important products with digital elements: identifies important product categories in Annex III and related conformity assessment implications.
+- Article 8, Critical products with digital elements: covers critical categories in Annex IV and potential European cybersecurity certification requirements.
+- Article 9, Stakeholder consultation: requires consultation when preparing implementing measures, technical descriptions, and reviews.
+- Article 10, Enhancing skills in a cyber resilient digital environment: promotes cybersecurity skills and support for authorities and economic operators.
+- Article 11, General product safety: aligns product safety rules for risks not covered by CRA cybersecurity requirements.
+- Article 12, High-risk AI systems: explains interaction with EU AI Act high-risk AI systems and CRA cybersecurity requirements.
+
+Engineering impact:
+- Record whether the Java software, component, agent, plugin, API, remote processing solution, or update service may be part of a product with digital elements.
+- Record product owner, manufacturer or supplier signals, support owner, security owner, market geography, intended purpose, reasonably foreseeable use, and reasonably foreseeable misuse.
+- Treat product classification, important or critical category, high-risk AI interaction, procurement obligations, and scope exclusions as qualified owner decisions; engineering should collect evidence, not make legal determinations.
+
+## [Chapter II: Obligations of economic operators and provisions in relation to free and open-source software (Articles 13-26)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_II)
+
+Defines the most direct obligations for product security engineering: manufacturer risk assessment, secure design, due diligence for third-party components, vulnerability handling, support periods, security updates, documentation, user information, reporting, and economic-operator handoffs.
+
+Article map:
+- Article 13, Obligations of manufacturers: requires secure design, cybersecurity risk assessment, third-party component due diligence, vulnerability documentation and remediation, support-period determination, coordinated vulnerability disclosure policies, security update availability, technical documentation, conformity assessment, EU declaration of conformity, CE marking, user information, support-period disclosure, corrective measures, authority cooperation, and SBOM-related implementation acts.
+- Article 14, Reporting obligations of manufacturers: sets notifications for actively exploited vulnerabilities and severe incidents, including early warning within 24 hours, 72-hour notification, final reports, user information, and ENISA or CSIRT handoff through a single reporting platform.
+- Article 15, Voluntary reporting: allows voluntary notification of vulnerabilities, cyber threats, incidents, and near misses.
+- Article 16, Establishment of a single reporting platform: establishes ENISA-managed notification routing and security handling.
+- Article 17, Other provisions related to reporting: covers ENISA trends, public awareness, European vulnerability database additions, helpdesk support, and liability effect of notification.
+- Article 18, Authorised representatives: describes representative mandates and retained manufacturer obligations.
+- Article 19, Obligations of importers: requires importers to verify conformity assessment, CE marking, documentation, manufacturer obligations, vulnerability escalation, corrective measures, and authority cooperation.
+- Article 20, Obligations of distributors: requires distributors to verify CE marking, documentation, manufacturer and importer obligations, vulnerability escalation, corrective measures, and authority cooperation.
+- Article 21, Cases in which obligations of manufacturers apply to importers and distributors: applies manufacturer obligations when importers or distributors market under their name or substantially modify products.
+- Article 22, Other cases in which obligations of manufacturers apply: applies manufacturer obligations to other actors carrying out substantial modifications and making the product available.
+- Article 23, Identification of economic operators: requires traceability of supplied and supplied-to economic operators for 10 years.
+- Article 24, Obligations of open-source software stewards: requires verifiable cybersecurity policy, vulnerability handling support, authority cooperation, and certain reporting obligations where applicable.
+- Article 25, Security attestation of free and open-source software: enables voluntary security attestation programmes for free and open-source software.
+- Article 26, Guidance: requires Commission guidance on scope, remote data processing, free and open-source software, support periods, other Union acts, and substantial modification.
+
+Engineering impact:
+- Require secure-by-design evidence across planning, design, development, production, delivery, maintenance, and support-period phases.
+- Link threat models, secure defaults, vulnerability intake, coordinated disclosure policy, security advisory workflow, update delivery mechanism, SBOM records, dependency review, and support-period decisions to the release record.
+- Escalate economic-operator role, manufacturer status, importer or distributor obligations, substantial modification, Article 14 reporting duties, and open-source steward status to qualified owners.
+
+## [Chapter III: Conformity of the product with digital elements (Articles 27-34)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_III)
+
+Defines presumption of conformity, EU declaration of conformity, CE marking, technical documentation, and conformity assessment procedures. For engineering review, this chapter explains why product security evidence must be traceable, test-backed, and suitable for qualified conformity or market-access review.
+
+Article map:
+- Article 27, Presumption of conformity: allows harmonised standards, common specifications, or European cybersecurity certification schemes to support presumption of conformity.
+- Article 28, EU declaration of conformity: requires declaration structure, language, updates, single declaration for multiple Union acts, and manufacturer responsibility.
+- Article 29, General principles of the CE marking: applies CE marking general principles.
+- Article 30, Rules and conditions for affixing the CE marking: sets CE marking placement, software placement, notified body number where relevant, and possible security labels or support-period marks.
+- Article 31, Technical documentation: requires documentation containing the means used to satisfy Annex I, before market placement and continuously updated at least during the support period.
+- Article 32, Conformity assessment procedures for products with digital elements: defines internal control, EU-type examination, full quality assurance, certification, and special routes for important and critical products.
+- Article 33, Support measures for microenterprises and small and medium-sized enterprises, including start-ups: covers support, regulatory sandboxes, and simplified technical documentation.
+- Article 34, Mutual recognition agreements: enables mutual recognition agreements for conformity assessment.
+
+Engineering impact:
+- Treat technical documentation as an engineering artifact: architecture, threat model, risk assessment, test reports, SBOM, vulnerability handling process, update mechanism, user instructions, and release evidence should be reviewable.
+- Do not decide conformity assessment route, CE marking, certification, or declaration completeness as an engineer unless qualified and authorised; route decisions to product, legal, compliance, market-access, and notified-body owners.
+
+## [Chapter IV: Notification of conformity assessment bodies (Articles 35-51)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_IV)
+
+Defines notifying authorities, notified bodies, competence, impartiality, subcontracting, notification changes, operational obligations, appeals, information sharing, and coordination.
+
+Article map:
+- Articles 35-38: notification, notifying authorities, authority requirements, and information obligations.
+- Articles 39-47: requirements for notified bodies, presumption of conformity, subsidiaries, application, notification procedure, identification, changes, competence challenges, and operational obligations.
+- Articles 48-51: appeal, information obligations, exchange of experience, and coordination of notified bodies.
+
+Engineering impact:
+- When a product category requires third-party assessment or certification, engineering evidence should be reproducible, testable, and suitable for independent review.
+- Escalate notified-body involvement, assessment scope, certificates, and quality assurance routes to qualified conformity and market-access owners.
+
+## [Chapter V: Market surveillance and enforcement (Articles 52-60)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_V)
+
+Defines market surveillance, access to data and documentation, procedures for significant cybersecurity risk, Union safeguard procedures, formal non-compliance, joint activities, and sweeps.
+
+Article map:
+- Article 52, Market surveillance and control of products with digital elements in the Union market: designates surveillance authorities and cooperation with CSIRTs, ENISA, data protection authorities, and ADCO.
+- Article 53, Access to data and documentation: grants market surveillance access to data required to assess design, development, production, and vulnerability handling.
+- Article 54, Procedure at national level concerning products with digital elements presenting a significant cybersecurity risk: covers evaluation, corrective action, withdrawal, recall, and Union-wide coordination.
+- Article 55, Union safeguard procedure: covers objections, Commission evaluation, and treatment of standards, certification schemes, or common specification shortcomings.
+- Article 56, Procedure at Union level concerning products with digital elements presenting a significant cybersecurity risk: allows Union-level corrective or restrictive measures.
+- Article 57, Compliant products with digital elements which present a significant cybersecurity risk: allows corrective action even for compliant products when significant risks remain.
+- Article 58, Formal non-compliance: addresses CE marking, declarations, notified body identification, and missing technical documentation.
+- Article 59, Joint activities of market surveillance authorities: supports coordinated compliance activities.
+- Article 60, Sweeps: supports coordinated checks for product categories or products.
+
+Engineering impact:
+- Keep documentation, tests, vulnerability records, update evidence, SBOMs, and support-period decisions accessible and defensible.
+- Treat missing, incomplete, misleading, or untraceable evidence as a product security release risk.
+
+## [Chapter VI: Delegated powers and committee procedure (Articles 61-62)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_VI)
+
+Defines delegated acts and committee procedure for updates and implementing measures.
+
+Article map:
+- Article 61, Exercise of the delegation: governs delegated powers for scope, product categories, support periods, notification conditions, security attestation, certification, declaration, and technical documentation updates.
+- Article 62, Committee procedure: establishes committee procedure for implementing acts.
+
+Engineering impact:
+- Treat CRA implementation as evolving. Track delegated acts, implementing acts, harmonised standards, common specifications, certification schemes, and guidance.
+- Revisit product security evidence when a product category, support period, reporting procedure, or documentation expectation changes.
+
+## [Chapter VII: Confidentiality and penalties (Articles 63-65)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_VII)
+
+Defines confidentiality, penalties, and representative actions.
+
+Article map:
+- Article 63, Confidentiality: protects intellectual property, confidential business information, trade secrets, inspection and investigation effectiveness, public and national security, and proceedings integrity.
+- Article 64, Penalties: establishes administrative fine ranges for Annex I, Articles 13 and 14, other economic-operator obligations, technical documentation, CE marking, conformity, and misleading information.
+- Article 65, Representative actions: applies representative actions for consumer collective interests.
+
+Engineering impact:
+- Preserve product security evidence while redacting source code, secrets, exploit details, personal data, and sensitive vulnerability information where disclosure would be unsafe.
+- Escalate penalty exposure and consumer action risks to legal, compliance, product, market-access, and executive owners.
+
+## [Chapter VIII: Transitional and final provisions (Articles 66-71)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_VIII)
+
+Covers amendments, transitional provisions, evaluation, entry into force, and application dates.
+
+Article map:
+- Articles 66-68: amend Regulation (EU) 2019/1020, Directive (EU) 2020/1828, and Regulation (EU) No 168/2013.
+- Article 69, Transitional provisions: addresses certificates and products placed on the market before 11 December 2027, with Article 14 reporting obligations applying to in-scope products placed on the market before that date.
+- Article 70, Evaluation and review: sets review and single reporting platform assessment timing.
+- Article 71, Entry into force and application: applies the Regulation from 11 December 2027, with Article 14 from 11 September 2026 and Chapter IV from 11 June 2026.
+
+Engineering impact:
+- Track readiness dates, legacy product modifications, reporting obligations, and support-period commitments for long-lived Java products.
+- Review product security release gates before substantial modifications, product category changes, or support lifecycle changes.
+
+## Annex map for engineering review
+
+The annexes provide essential cybersecurity requirements, user information, product category, declaration, documentation, and conformity assessment structures that engineering teams need for evidence traceability.
+
+## Annex I: Essential cybersecurity requirements
+
+Part I covers product properties:
+- Risk-appropriate cybersecurity in design, development, and production
+- No known exploitable vulnerabilities when made available on the market
+- Secure-by-default configuration and reset capability
+- Security updates, automatic update defaults where applicable, notification, opt-out, and postponement
+- Protection against unauthorised access through authentication, identity, and access controls
+- Confidentiality, integrity, data minimisation, availability, resilience, attack-surface reduction, exploitation mitigation, activity recording and monitoring, and secure data removal or transfer
+
+Part II covers vulnerability handling:
+- Identify and document vulnerabilities and components, including SBOMs in commonly used machine-readable format
+- Address and remediate vulnerabilities without delay and provide security updates separately from functionality updates where technically feasible
+- Apply regular tests and reviews
+- Publicly disclose fixed vulnerability information when appropriate
+- Enforce coordinated vulnerability disclosure
+- Provide vulnerability reporting contact address
+- Securely distribute updates, including automatic security updates where applicable
+- Disseminate security updates without delay and free of charge unless tailor-made business-user terms apply
+
+Engineering impact:
+- Map code, configuration, tests, threat models, SBOMs, update mechanisms, CVD policy, advisory process, and logging controls directly to Annex I Part I and Part II evidence.
+
+## Annex II: Information and instructions to the user
+
+Requires manufacturer contact details, vulnerability reporting contact, product identification, intended purpose, security properties, significant cybersecurity risk circumstances, declaration access, technical security support, support-period end date, secure installation and operation guidance, security-relevant update instructions, secure decommissioning guidance, automatic update opt-out information, integrator guidance, and optional SBOM access information.
+
+Engineering impact:
+- Product teams need user-facing security documentation, support-period disclosure, secure update instructions, secure decommissioning instructions, and integrator guidance before release.
+
+## Annex III: Important products with digital elements
+
+Lists Class I and Class II important products including identity and privileged access management systems, browsers, password managers, anti-malware, VPNs, network management, SIEM, boot managers, PKI, network interfaces, operating systems, routers, security-related processors and microcontrollers, smart home security products, toys, wearables, hypervisors, container runtimes, firewalls, intrusion detection and prevention systems, and tamper-resistant chips.
+
+Engineering impact:
+- Java services, agents, libraries, installers, device gateways, identity modules, update clients, container tooling, security tooling, or management systems should be checked for important-product signals.
+
+## Annex IV: Critical products with digital elements
+
+Lists critical categories such as hardware devices with security boxes, smart meter gateways and secure cryptoprocessing devices, and smartcards or similar secure elements.
+
+Engineering impact:
+- Escalate critical-product signals immediately to product, security, legal, compliance, market-access, and certification owners.
+
+## Annex V and Annex VI: EU declaration of conformity
+
+Provide the full and simplified EU declaration structures.
+
+Engineering impact:
+- Engineers should provide traceable product identification, standards, certification, test evidence, and technical documentation inputs, but qualified owners decide declaration completeness and CE marking implications.
+
+## Annex VII: Content of the technical documentation
+
+Requires general product description, intended purpose, software versions affecting compliance, user information, design and development information, architecture, vulnerability handling process information, SBOM, coordinated vulnerability disclosure policy, vulnerability reporting contact, secure update distribution choices, production and monitoring processes, cybersecurity risk assessment, support-period rationale, standards or certification references, test reports, EU declaration copy, and SBOM where requested by market surveillance authorities.
+
+Engineering impact:
+- Technical documentation should be generated from engineering evidence rather than reconstructed after release.
+- Architecture diagrams, threat models, SBOMs, test reports, update mechanism descriptions, CVD policy, support-period rationale, and release decisions should be linked before release approval.
+
+## Annex VIII: Conformity assessment procedures
+
+Defines internal control, EU-type examination, conformity to type based on internal production control, and full quality assurance procedures.
+
+Engineering impact:
+- Map evidence to the chosen assessment route only after qualified owners select that route.
+- Keep evidence reproducible and versioned so independent reviewers can assess design, development, production, and vulnerability handling.
+
+## Engineering review focus
+
+When reviewing a Java product or product-adjacent component for CRA-aware controls, connect article themes to evidence:
+- Scope and product category: Articles 1-8, 11-12, Annex III, Annex IV
+- Manufacturer and economic-operator obligations: Articles 13, 18-23
+- Vulnerability handling and reporting: Articles 13-17, 24-25, Annex I Part II
+- Secure-by-design product properties: Article 6, Annex I Part I
+- Technical documentation, conformity, and CE marking: Articles 27-32, Annex V, Annex VI, Annex VII, Annex VIII
+- User instructions and support-period signaling: Article 13, Annex II, Annex VII
+- Market surveillance, corrective action, and evidence access: Articles 52-60
+- Confidentiality, penalties, and consumer actions: Articles 63-65
+- Transition and readiness dates: Articles 69-71
+
+]]></goal>
+
+    <constraints>
+        <constraints-description>
+            Use this reference as Cyber Resilience Act context for Java product security engineering review. Do not provide legal advice or replace review by legal, compliance, product, product-security, security, market-access, risk, support, executive accountability, or business owners.
+        </constraints-description>
+        <constraint-list>
+            <constraint>**NOT LEGAL ADVICE**: State when an article mapping requires legal, compliance, product, product-security, security, market-access, risk, support, or executive accountability review instead of giving legal conclusions</constraint>
+            <constraint>**SUMMARY ONLY**: Keep this reference focused on Cyber Resilience Act chapters, articles, annexes, and engineering implications; use the engineering examples reference for Java patterns</constraint>
+            <constraint>**ARTICLE MAPPING**: Map findings to regulation topic areas such as scope, product category, economic-operator role, secure-by-design requirements, vulnerability handling, reporting, conformity, CE marking, technical documentation, support period, market surveillance, or penalties</constraint>
+            <constraint>**OWNER ESCALATION**: Escalate product classification, economic-operator role, conformity assessment, CE marking implications, Article 14 reporting obligations, support-period interpretation, and regulatory interpretation to qualified owners</constraint>
+            <constraint>**EVIDENCE ORIENTATION**: Use article summaries to identify what engineering evidence is missing or weak, not to certify compliance</constraint>
+        </constraint-list>
+    </constraints>
+
+    <output-format>
+        <output-format-list>
+            <output-format-item>**READ** this Cyber Resilience Act chapters summary before applying Java examples or generating the review report</output-format-item>
+            <output-format-item>**MAP** reviewed findings to Cyber Resilience Act topic areas and article groups using only reviewed evidence</output-format-item>
+            <output-format-item>**ESCALATE** product classification, economic-operator role, conformity assessment, CE marking, Article 14 reporting duties, support-period interpretation, and regulatory interpretation to qualified owners</output-format-item>
+            <output-format-item>**HAND OFF** implementation control patterns to `references/805-regulations-eu-cyber-resilience-act-engineering-examples.md`</output-format-item>
+        </output-format-list>
+    </output-format>
+
+    <safeguards>
+        <safeguards-list>
+            <safeguards-item>**DO NOT CERTIFY COMPLIANCE**: This reference supports engineering review and owner handoff only</safeguards-item>
+            <safeguards-item>**CHECK CURRENT GUIDANCE**: Delegated acts, implementing acts, harmonised standards, common specifications, and market-surveillance guidance may change implementation expectations</safeguards-item>
+            <safeguards-item>**KEEP FACTS GROUNDED**: Do not infer product category, operator role, conformity route, reporting obligation, support-period adequacy, or CE marking implication without reviewed evidence and qualified owner input</safeguards-item>
+        </safeguards-list>
+    </safeguards>
+</prompt>

--- a/skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-engineering-examples.xml
+++ b/skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-engineering-examples.xml
@@ -1,0 +1,348 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <metadata>
+        <author>Juan Antonio Breña Moral</author>
+        <version>0.16.0-SNAPSHOT</version>
+        <license>Apache-2.0</license>
+        <title>EU Cyber Resilience Act Regulation for Java Product Security Engineering</title>
+        <description>Use as Java-focused Cyber Resilience Act engineering examples for secure-by-design development, vulnerability handling, coordinated disclosure, security updates, SBOM evidence, product security documentation, support-period signaling, and release gates.</description>
+    </metadata>
+
+    <role>You are a senior Java enterprise architect and product security reviewer who translates Cyber Resilience Act themes into concrete Java engineering examples and reviewable evidence patterns</role>
+
+    <goal>
+        Apply these Cyber Resilience Act-aware examples after the regulation summary has been read and the target product-security scope is understood.
+
+        These examples are not legal advice. They show engineering patterns that help Java teams create reviewable evidence for legal, compliance, product, product-security, security, support, market-access, risk, and executive accountability owners.
+
+        Use this examples reference together with `references/805-regulations-eu-cyber-resilience-act-chapters-summary.md` and the [Cyber Resilience Act engineering review report template](../assets/reports/805-eu-cyber-resilience-act-engineering-review-report-template.md).
+    </goal>
+
+    <constraints>
+        <constraints-description>
+            Translate Cyber Resilience Act concerns into engineering controls for Java products and product-adjacent systems without replacing qualified legal, compliance, product, product-security, market-access, security, support, risk, or executive accountability review.
+        </constraints-description>
+        <constraint-list>
+            <constraint>**NOT LEGAL ADVICE**: Treat the examples as engineering control patterns and escalation aids, not legal findings, conformity assessment conclusions, or CE marking decisions</constraint>
+            <constraint>**EVIDENCE FIRST**: Prefer reviewable evidence over claims that secure-by-design, vulnerability handling, update, SBOM, documentation, or support controls exist</constraint>
+            <constraint>**OWNER HANDOFFS**: Include product, manufacturer-role, security, support, release, legal, compliance, market-access, and risk owners in control records</constraint>
+            <constraint>**SECURE LOGGING**: Preserve security evidence without exposing secrets, credentials, personal data, support tokens, private keys, exploit details, or sensitive incident details unnecessarily</constraint>
+            <constraint>**RELEASE READINESS**: Do not mark a product ready when critical product-security, update, vulnerability, dependency, documentation, support-period, or owner handoff controls are undocumented, untested, ownerless, or unresolved</constraint>
+        </constraint-list>
+    </constraints>
+
+    <examples>
+        <toc auto-generate="true" />
+
+        <example number="1" id="product-security-scope-inventory">
+            <example-header>
+                <example-title>Document product security scope and owners</example-title>
+                <example-subtitle>product context, intended purpose, support period, update path, and owner handoffs</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Use this pattern when a Java application, library, agent, plugin, SDK, connected component, gateway, or remote processing solution may support a product with digital elements. The inventory creates evidence for product, legal, compliance, product-security, support, and market-access owners without making a legal classification decision.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="yaml"><![CDATA[craProductSecurityScope:
+  product: checkout-device-gateway
+  component: delivery-instructions-java-service
+  intendedPurpose: receive checkout delivery preferences and publish delivery slot events
+  possibleProductWithDigitalElementsSignal: connected software component used by a managed checkout product
+  classificationDecisionOwner: product-compliance
+  manufacturerRoleDecisionOwner: legal-market-access
+  productOwner: checkout-platform
+  productSecurityOwner: product-security
+  supportOwner: customer-support
+  environments: [staging, production]
+  supportPeriod:
+    proposedEnd: 2031-12
+    rationaleEvidence: evidence:support-period-review-2026-06
+  securityUpdatePath:
+    mechanism: signed container image plus rollout controller
+    rollback: previous signed image
+    advisoryChannel: security-advisories/checkout-device-gateway
+  evidence:
+    threatModel: docs/security/threat-model-checkout-device-gateway.md
+    sbom: evidence:sbom-2026-06-14
+    coordinatedDisclosurePolicy: security/CVD.md
+    userInstructions: docs/product/secure-operation.md]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="yaml"><![CDATA[craProductSecurityScope:
+  product: checkout stuff
+  owner: platform
+  updates: CI deploys it
+  classification: probably not applicable]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="2" id="threat-model-and-secure-defaults">
+            <example-header>
+                <example-title>Review threat model and secure defaults</example-title>
+                <example-subtitle>intended use, foreseeable misuse, attack surface, authentication, authorization, and crypto</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Use this pattern during design and release review. CRA-aware engineering should connect threat model decisions to secure-by-default configuration, least privilege, cryptography, data minimization, and exploitation mitigation evidence.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="java"><![CDATA[public ReleaseDecision evaluateSecureDefaults(CraSecurityReview review) {
+    List<String> blockers = new ArrayList<>();
+
+    requirePresent(review.threatModel(), "threat model for intended and foreseeable use", blockers);
+    requirePassing(review.authenticationReview(), "authentication review", blockers);
+    requirePassing(review.authorizationReview(), "least-privilege authorization review", blockers);
+    requirePassing(review.cryptoReview(), "state-of-the-art transport and storage protection", blockers);
+    requirePassing(review.loggingReview(), "sensitive-data-safe logging", blockers);
+    requirePassing(review.attackSurfaceReview(), "external interface and attack-surface reduction", blockers);
+
+    if (!blockers.isEmpty()) {
+        return ReleaseDecision.blocked(
+            review.productId(),
+            blockers,
+            Escalation.required("product-security", "architecture", "product-owner")
+        );
+    }
+
+    return ReleaseDecision.approvedWithEvidence(
+        review.productId(),
+        review.evidenceReferences(),
+        review.approvers()
+    );
+}]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="java"><![CDATA[public boolean secureEnough() {
+    return true; // defaults are handled by the framework
+}]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="3" id="vulnerability-and-coordinated-disclosure">
+            <example-header>
+                <example-title>Track vulnerabilities and coordinated disclosure</example-title>
+                <example-subtitle>intake, triage, remediation, advisory, user notification, and reporting handoff</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Use this pattern when reviewing vulnerability handling for Java products and components. CRA-aware engineering should make vulnerability decisions traceable, coordinate with component maintainers, and escalate Article 14 reporting interpretation to qualified owners.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="yaml"><![CDATA[vulnerabilityHandling:
+  product: checkout-device-gateway
+  vulnerability: CVE-2026-1042
+  affectedComponent: org.example:delivery-client:2.4.1
+  discoveredBy: external-researcher
+  intakeChannel: security@example.com
+  coordinatedDisclosurePolicy: security/CVD.md
+  severity: high
+  exploitationStatus: unknown
+  article14ReportingDecisionOwner: legal-product-security
+  remediation:
+    targetVersion: org.example:delivery-client:2.4.3
+    securityUpdate: release:2026.06.18-security
+    advisory: advisory:CRA-2026-004
+    userMitigation: disable optional callback endpoint until update is installed
+  verification:
+    regressionTests: passed
+    scannerRun: evidence:vulnerability-scan-2026-06-18
+    affectedUsersNotified: pending-owner-approval]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="yaml"><![CDATA[vulnerabilityHandling:
+  vulnerability: CVE-2026-1042
+  decision: wait for next quarterly release
+  users: not notified]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="4" id="security-update-mechanism">
+            <example-header>
+                <example-title>Verify secure update delivery</example-title>
+                <example-subtitle>signed artifacts, advisory messages, automatic update defaults, rollback, and availability</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Use this pattern for products that deliver Java services, agents, installers, container images, libraries, or plugins. CRA-aware engineering should show that security updates can be distributed securely, promptly, and separately from feature updates where feasible.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="markdown"><![CDATA[Security update evidence
+
+- Product: checkout-device-gateway
+- Update package: registry.example.com/checkout-device-gateway@sha256:abc123
+- Signature: cosign bundle evidence:update-signature-2026-06-18
+- Advisory: security-advisories/CRA-2026-004.md
+- User action: automatic update enabled by default with clear opt-out for business users
+- Feature changes included: none
+- Rollback package: registry.example.com/checkout-device-gateway@sha256:prev789
+- Validation: smoke tests, migration compatibility tests, vulnerability regression tests
+- Availability commitment: update remains available through support period evidence:support-policy-2026]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="markdown"><![CDATA[Security update evidence
+
+- Update: latest Docker tag
+- Signature: not used
+- Advisory: Slack message
+- Rollback: rebuild old code if needed]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="5" id="dependency-and-sbom-evidence">
+            <example-header>
+                <example-title>Make dependency and SBOM evidence reviewable</example-title>
+                <example-subtitle>libraries, Maven plugins, containers, generated clients, and third-party components</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Use this pattern when the product depends on Java libraries, Maven plugins, containers, generated clients, runtime images, CI/CD actions, or third-party services. The goal is to connect SBOM output to vulnerability handling and product release decisions.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="yaml"><![CDATA[dependencyEvidence:
+  product: checkout-device-gateway
+  sbom:
+    format: CycloneDX
+    location: evidence/sbom/checkout-device-gateway-2026-06-14.json
+    includesTopLevelDependencies: true
+  components:
+    - coordinate: io.quarkus:quarkus-rest
+      version: 3.24.0
+      owner: platform-runtime
+      vulnerabilityMonitoring: evidence:dependency-scan-2026-06-14
+    - coordinate: org.example:delivery-client
+      version: 2.4.3
+      owner: checkout-platform
+      vulnerabilityMonitoring: evidence:dependency-scan-2026-06-18
+  containerBaseImage:
+    name: eclipse-temurin:25-jre
+    digestPinned: true
+    scanEvidence: evidence:image-scan-2026-06-14
+  releaseDecision: acceptable-with-open-medium-findings-owned]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="yaml"><![CDATA[dependencyEvidence:
+  sbom: generated somewhere in CI
+  dependencies: managed by Maven
+  vulnerabilities: scanner did not block]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="6" id="product-documentation-and-support-period">
+            <example-header>
+                <example-title>Document product security instructions and support signaling</example-title>
+                <example-subtitle>secure operation, vulnerability contact, support end, decommissioning, and user guidance</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Use this pattern before release or substantial modification. CRA-aware engineering should provide user instructions and technical documentation that product, support, and market-access owners can review.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="markdown"><![CDATA[Product security documentation evidence
+
+- Product identifier: checkout-device-gateway 2026.06
+- Intended purpose: connect checkout order events to delivery-slot systems
+- Vulnerability contact: security@example.com
+- Coordinated disclosure policy: security/CVD.md
+- Secure installation: docs/product/secure-installation.md
+- Secure operation: docs/product/secure-operation.md
+- Security update instructions: docs/product/security-updates.md
+- Secure decommissioning: docs/product/secure-decommissioning.md
+- Support period end: 2031-12
+- End-of-support user notice: in-product notification and support portal article
+- SBOM access: available to qualified customers and authorities via support workflow
+- Technical documentation evidence: docs/product/technical-documentation-index.md]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="markdown"><![CDATA[Product security documentation evidence
+
+- Docs: README
+- Vulnerabilities: open a GitHub issue
+- Support period: until we stop maintaining it]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="7" id="cra-release-readiness-gate">
+            <example-header>
+                <example-title>Block release until CRA evidence is complete</example-title>
+                <example-subtitle>secure-by-design, updates, SBOM, documentation, support, and owner decisions</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Use this pattern before placing a product or product-adjacent change into a release stream. The release decision should identify missing engineering evidence and route legal or conformity questions to qualified owners.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="java"><![CDATA[public ReleaseDecision evaluate(CraEngineeringReview review) {
+    List<String> blockers = new ArrayList<>();
+
+    requirePresent(review.productSecurityScope(), "product security scope inventory", blockers);
+    requirePresent(review.productClassificationOwnerDecision(), "qualified product classification handoff", blockers);
+    requirePresent(review.threatModel(), "threat model and secure defaults evidence", blockers);
+    requirePassing(review.vulnerabilityHandlingReview(), "vulnerability handling review", blockers);
+    requirePassing(review.securityUpdateMechanism(), "secure security-update mechanism", blockers);
+    requirePresent(review.sbom(), "SBOM evidence", blockers);
+    requirePresent(review.productSecurityDocumentation(), "product security documentation", blockers);
+    requirePresent(review.supportPeriodDisclosure(), "support-period and end-of-support signaling", blockers);
+    requirePresent(review.conformityOwnerDecision(), "qualified conformity and CE marking handoff", blockers);
+
+    if (!blockers.isEmpty()) {
+        return ReleaseDecision.blocked(
+            review.productId(),
+            blockers,
+            Escalation.required("product", "product-security", "legal", "compliance", "market-access")
+        );
+    }
+
+    return ReleaseDecision.approvedWithEvidence(
+        review.productId(),
+        review.evidenceReferences(),
+        review.approvers()
+    );
+}]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="java"><![CDATA[public ReleaseDecision evaluate(CraEngineeringReview review) {
+    return ReleaseDecision.approved(review.productId(), "CI passed");
+}]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+    </examples>
+
+    <output-format>
+        <output-format-list>
+            <output-format-item>**MATCH** the relevant example patterns: product security scope inventory, threat model and secure defaults, vulnerability and coordinated disclosure evidence, security update delivery, dependency and SBOM evidence, product documentation and support-period signaling, or CRA release readiness gate</output-format-item>
+            <output-format-item>**RECOMMEND** engineering controls: secure-by-design development, threat modeling, secure defaults, vulnerability remediation, coordinated disclosure, security advisory workflow, secure update delivery, SBOM publication, dependency monitoring, authentication, authorization, cryptography, sensitive-data-safe logging, user instructions, support-period disclosure, end-of-support notices, and release approval</output-format-item>
+            <output-format-item>**REPORT** conclusions and actions using `assets/reports/805-eu-cyber-resilience-act-engineering-review-report-template.md`, including review context, product-security scope, evidence reviewed, CRA risk signals, potential violation or non-compliance signals with owner handoff, engineering controls, residual risks, release decision, and prioritized action plan with owners and due dates</output-format-item>
+        </output-format-list>
+    </output-format>
+
+    <safeguards>
+        <safeguards-list>
+            <safeguards-item>**PRODUCT SECURITY EVIDENCE**: Do not accept undocumented claims that secure-by-design controls, vulnerability handling, updates, SBOMs, product documentation, or support-period controls exist; ask for reviewable evidence</safeguards-item>
+            <safeguards-item>**PRODUCT RELIANCE**: Apply stronger controls when a Java product or component supports identity, access management, security tooling, network management, connected devices, remote processing, customer data, safety-relevant functions, or critical-sector users</safeguards-item>
+            <safeguards-item>**SUPPLY-CHAIN DEPENDENCY**: Treat libraries, Maven plugins, CI/CD actions, generated clients, containers, cloud services, update infrastructure, and open-source components as product inputs requiring ownership and monitoring</safeguards-item>
+        </safeguards-list>
+    </safeguards>
+</prompt>

--- a/skills-generator/src/main/resources/skill-references/assets/reports/805-eu-cyber-resilience-act-engineering-review-report-template.md
+++ b/skills-generator/src/main/resources/skill-references/assets/reports/805-eu-cyber-resilience-act-engineering-review-report-template.md
@@ -1,0 +1,153 @@
+# EU Cyber Resilience Act Engineering Review Report
+
+Use this template after reviewing `references/805-regulations-eu-cyber-resilience-act-chapters-summary.md` and matching the relevant examples from `references/805-regulations-eu-cyber-resilience-act-engineering-examples.md` for product security scope, secure-by-design controls, vulnerability handling, coordinated disclosure, security updates, SBOM evidence, product documentation, support-period signaling, and release gates.
+
+This report is not legal advice. Use it as engineering evidence for legal, compliance, product, product-security, security, support, market-access, risk, architecture, executive accountability, and business-owner review.
+
+The purpose of this report is to increase awareness of potential gaps in the system and create engineering evidence for qualified review. The response produced from this template does not represent legal advice, a legal opinion, a conformity assessment, a CE marking decision, or a final regulatory determination.
+
+## 1. Review Context
+
+- Product, service, component, library, agent, plugin, or platform module:
+- Repository or implementation path:
+- Review date:
+- Reviewers:
+- Business owner:
+- Product owner:
+- Technical owner:
+- Product security owner:
+- Support owner:
+- Legal/compliance owner:
+- Market-access or conformity owner:
+- Source materials reviewed:
+
+## 2. Product Security Scope
+
+- Product or component description:
+- Possible product-with-digital-elements signal:
+- Possible remote data processing signal:
+- Possible important or critical product signal:
+- Intended purpose:
+- Reasonably foreseeable use or misuse:
+- Economic-operator role signals:
+- Deployment geography:
+- Environments in scope:
+- Users, integrators, or affected organizations:
+- Support-period signal:
+- Security update delivery path:
+- Open applicability questions:
+
+## 3. Engineering Evidence Reviewed
+
+- Java applications, libraries, agents, plugins, APIs, jobs, or installers:
+- Data stores, queues, topics, caches, files, or remote processing:
+- Authentication, authorization, IAM, secrets, keys, and privileged operations:
+- CI/CD workflows, build provenance, artifact signing, and deployment paths:
+- Third-party components, open-source dependencies, containers, and generated clients:
+- SBOM, dependency scan, image scan, and vulnerability triage evidence:
+- Threat model, secure-by-design, secure defaults, and attack-surface evidence:
+- Logging, monitoring, security event, and incident evidence:
+- Coordinated disclosure, vulnerability contact, advisory, and reporting handoff evidence:
+- Security update, rollback, and support-period evidence:
+- Product security documentation and user instructions:
+
+## 4. Potential Violation Or Non-Compliance Mapping
+
+This section is not a legal finding. Use it to list concrete potential Cyber Resilience Act violation or non-compliance signals from the reviewed evidence and route each item to qualified legal, compliance, product, product-security, security, support, market-access, risk, architecture, or executive accountability review. When no violation is confirmed, say so explicitly and keep open items as potential gaps. Use the chapter links from `references/805-regulations-eu-cyber-resilience-act-chapters-summary.md`; add more official-source links when one finding spans multiple CRA areas.
+
+| Potential violation or non-compliance signal | CRA reference area | Associated official-source link | Evidence from reviewed system | Current status | Required owner review | Engineering action |
+| -------------------------------------------- | ------------------ | ------------------------------- | ----------------------------- | -------------- | --------------------- | ------------------ |
+| Unclear product-with-digital-elements scope, important product category, critical product category, or economic-operator role | Scope / product categories / economic-operator obligations | [Chapter I](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_I), [Chapter II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_II) | TBD | None identified / Potential gap / Confirmed concern | Legal / compliance / product / market-access owner | TBD |
+| Missing secure-by-design, threat model, secure default, authentication, authorization, cryptography, or sensitive-data-safe logging evidence | Essential cybersecurity requirements for product properties | [Chapter I](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_I), [Annex I](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_I) | TBD | None identified / Potential gap / Confirmed concern | Product security / architecture / security owner | TBD |
+| Missing vulnerability handling, coordinated disclosure, advisory, user notification, or Article 14 reporting handoff evidence | Manufacturer obligations / reporting / vulnerability handling | [Chapter II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_II), [Annex I](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_I) | TBD | None identified / Potential gap / Confirmed concern | Product security / legal / compliance / support owner | TBD |
+| Missing secure update mechanism, rollback, automatic update default, update advisory, or update availability evidence | Security updates / vulnerability remediation / user instructions | [Chapter II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_II), [Annex II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_II) | TBD | None identified / Potential gap / Confirmed concern | Product security / support / platform owner | TBD |
+| Missing dependency, third-party component, open-source due diligence, SBOM, or vulnerability triage evidence | Component due diligence / SBOM / technical documentation | [Chapter II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_II), [Annex VII](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_VII) | TBD | None identified / Potential gap / Confirmed concern | Product security / platform / procurement / risk owner | TBD |
+| Missing product security documentation, secure operation instructions, support-period disclosure, end-of-support signaling, or secure decommissioning guidance | User information / technical documentation / support period | [Annex II](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_II), [Annex VII](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#anx_VII) | TBD | None identified / Potential gap / Confirmed concern | Product / support / legal / market-access owner | TBD |
+| Missing conformity assessment, EU declaration, CE marking, or market-surveillance evidence handoff | Conformity / CE marking / technical documentation / market surveillance | [Chapter III](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_III), [Chapter V](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847#cpt_V) | TBD | None identified / Potential gap / Confirmed concern | Legal / compliance / market-access / product owner | TBD |
+
+## 5. Engineering Controls
+
+- Product security scope inventory:
+- Secure-by-design development:
+- Threat modeling:
+- Secure defaults and hardening:
+- Attack-surface reduction:
+- Authentication and authorization:
+- Cryptography and key ownership:
+- Data minimization and secure data removal:
+- Sensitive-data-safe logging and monitoring:
+- Vulnerability intake and triage:
+- Coordinated vulnerability disclosure:
+- Security advisory and user notification:
+- Security update mechanism:
+- Rollback and update availability:
+- Dependency and SBOM evidence:
+- Third-party component and open-source due diligence:
+- Product security documentation:
+- Secure installation, operation, update, and decommissioning instructions:
+- Support-period and end-of-support signaling:
+- Release readiness and owner approvals:
+
+## 6. Evidence Inventory
+
+- Product security scope inventory:
+- Product classification or economic-operator handoff:
+- Threat model:
+- Secure default configuration:
+- Authentication and authorization review:
+- Cryptography review:
+- Logging and monitoring review:
+- Vulnerability disclosure policy:
+- Vulnerability contact address:
+- Vulnerability scan or triage evidence:
+- Security advisory evidence:
+- Security update and rollback evidence:
+- Dependency or SBOM evidence:
+- Technical documentation:
+- User instructions:
+- Support-period rationale:
+- End-of-support notice:
+- Conformity or CE marking owner handoff:
+- Release decision:
+
+## 7. Residual Risks
+
+- Residual risk:
+- Impact:
+- Likelihood:
+- Mitigation:
+- Owner:
+- Acceptance decision:
+- Review date:
+
+## 8. Release Decision
+
+- Decision:
+- Conditions:
+- Blockers:
+- Required approvals:
+- Expiry or review date:
+- Environments or product versions approved:
+- Emergency security update path:
+- Emergency rollback path:
+
+## 9. Action Plan
+
+| Priority | Action | Owner | Due date | Evidence expected | Status |
+| -------- | ------ | ----- | -------- | ----------------- | ------ |
+| High     |        |       |          |                   | Open   |
+| Medium   |        |       |          |                   | Open   |
+| Low      |        |       |          |                   | Open   |
+
+## 10. Final Notes
+
+- Items requiring legal interpretation:
+- Items requiring product classification or economic-operator role decision:
+- Items requiring conformity assessment or CE marking review:
+- Items requiring Article 14 reporting interpretation:
+- Items requiring product security exception:
+- Items requiring architecture decision:
+- Items requiring support or end-of-support review:
+- Items requiring procurement, supplier, or open-source steward review:
+- Items requiring product or business acceptance:
+- Next review trigger:

--- a/skills-generator/src/main/resources/skills.xml
+++ b/skills-generator/src/main/resources/skills.xml
@@ -590,4 +590,14 @@
                 target="assets/reports/804-nis2-engineering-review-report-template.md" />
         </resource-list>
     </skill>
+    <skill id="805" skillId="805-regulations-eu-cyber-resilience-act">
+        <reference-list>
+            <reference>805-regulations-eu-cyber-resilience-act-chapters-summary</reference>
+            <reference>805-regulations-eu-cyber-resilience-act-engineering-examples</reference>
+        </reference-list>
+        <resource-list>
+            <resource source="skill-references/assets/reports/805-eu-cyber-resilience-act-engineering-review-report-template.md"
+                target="assets/reports/805-eu-cyber-resilience-act-engineering-review-report-template.md" />
+        </resource-list>
+    </skill>
 </skill-inventory>

--- a/skills-generator/src/test/resources/gherkin/805-regulations-eu-cyber-resilience-act.feature
+++ b/skills-generator/src/test/resources/gherkin/805-regulations-eu-cyber-resilience-act.feature
@@ -1,0 +1,62 @@
+Feature: Validate changes from usage of EU Cyber Resilience Act regulation skill
+
+Background:
+  Given the skill "805-regulations-eu-cyber-resilience-act"
+
+@acceptance-test
+Scenario: Review a Java product-adjacent service with Cyber Resilience Act controls
+  Given the system description file "examples/diagrams/deployment/system-example-cicd-pr-model.md"
+  And the deployment and delivery pipeline diagram file "examples/diagrams/deployment/expected-system-deployment.puml"
+  And the simulated feature request file "examples/diagrams/deployment/checkout-service-feature-request.md"
+  And the local generated skill path ".agents/skills/805-regulations-eu-cyber-resilience-act"
+  And the requested report output path is "examples/regulations/eu-cyber-resilience-act/CRA-ENGINEERING-REVIEW-REPORT.md"
+  And any existing report at the requested output path must be overwritten
+  And the folder "examples/regulations/eu-cyber-resilience-act" has no git changes
+  And the feature request is expected to be developed and released through the described CI/CD pipeline
+  And the Cyber Resilience Act review facts are based only on information present in "examples/diagrams/deployment/system-example-cicd-pr-model.md" and "examples/diagrams/deployment/checkout-service-feature-request.md"
+  When the skill ".agents/skills/805-regulations-eu-cyber-resilience-act" is applied to the system description, diagram, and feature request files
+  Then the skill reads "references/805-regulations-eu-cyber-resilience-act-chapters-summary.md"
+  And the skill reads "references/805-regulations-eu-cyber-resilience-act-engineering-examples.md"
+  And the skill reads "assets/reports/805-eu-cyber-resilience-act-engineering-review-report-template.md"
+  And the skill frames Cyber Resilience Act findings as engineering controls rather than legal advice
+  And review findings do not use facts outside "examples/diagrams/deployment/system-example-cicd-pr-model.md" and "examples/diagrams/deployment/checkout-service-feature-request.md"
+  And the skill scopes product context, possible product-with-digital-elements signals, possible remote data processing signals, product owners, product security owners, support owners, environments, intended purpose, reasonably foreseeable use, update paths, vulnerabilities, dependencies, SBOM evidence, and product documentation
+  And the skill escalates product classification, economic-operator role, conformity assessment, CE marking implications, Article 14 reporting obligations, support-period interpretation, cybersecurity risk acceptance, and regulatory interpretation to legal, compliance, product, product-security, market-access, security, risk, support, or executive accountability owners
+  And the skill reviews Java implementation, configuration, tests, threat models, product documentation, observability, vulnerability records, coordinated disclosure policy, security update mechanisms, dependency inventories, SBOMs, support-period evidence, release records, and user instructions
+  And the skill identifies risk signals for unclear product scope, ownerless product security controls, missing threat model, weak secure defaults, incomplete vulnerability handling, missing coordinated disclosure evidence, weak update mechanism, incomplete dependency inventory, missing SBOM, weak authentication or authorization, weak cryptography, sensitive-data logging, missing product security documentation, missing support-period signal, database migration, Kafka message contract, CI/CD pipeline, and production side-effect signals
+  And the skill maps potential Cyber Resilience Act violation or non-compliance signals to regulation topic areas using only the reviewed delivery evidence with associated official-source links
+  And the skill analyzes the CheckoutService feature request as a pipeline-delivered product-adjacent change that modifies order database structure and outbound Kafka event data
+  And the skill uses Java examples to explain secure defaults, vulnerability handling, coordinated disclosure, security update delivery, dependency and SBOM evidence, product documentation, support-period signaling, and secure release-policy controls
+  And the skill recommends engineering controls for product security scope inventory, secure-by-design development, threat modeling, secure defaults, vulnerability remediation, coordinated disclosure, security advisory workflow, secure update delivery, dependency and SBOM evidence, cryptography, authentication, authorization, sensitive-data-safe logging, product security documentation, support-period and end-of-support signaling, database migration approval, Kafka schema compatibility, and release readiness
+  And the skill reports conclusions and actions using the Cyber Resilience Act engineering review report template
+  And the skill overwrites the Cyber Resilience Act engineering review report at "examples/regulations/eu-cyber-resilience-act/CRA-ENGINEERING-REVIEW-REPORT.md"
+  And any git changes produced during skill execution and verification are reset
+
+@acceptance-test
+Scenario: Review a Java product-adjacent checkout change with direct-to-main Cyber Resilience Act controls
+  Given the system description file "examples/diagrams/deployment/system-example-cicd-model.md"
+  And the deployment and delivery pipeline diagram file "examples/diagrams/deployment/expected-system-deployment.puml"
+  And the simulated feature request file "examples/diagrams/deployment/checkout-service-feature-request.md"
+  And the local generated skill path ".agents/skills/805-regulations-eu-cyber-resilience-act"
+  And the requested report output path is "examples/regulations/eu-cyber-resilience-act/CRA-DIRECT-MAIN-ENGINEERING-REVIEW-REPORT.md"
+  And any existing report at the requested output path must be overwritten
+  And the folder "examples/regulations/eu-cyber-resilience-act" has no git changes
+  And the feature request is expected to be committed directly to main and released through the described CI/CD pipeline
+  And the Cyber Resilience Act review facts are based only on information present in "examples/diagrams/deployment/system-example-cicd-model.md" and "examples/diagrams/deployment/checkout-service-feature-request.md"
+  When the skill ".agents/skills/805-regulations-eu-cyber-resilience-act" is applied to the direct-to-main system description, diagram, and feature request files
+  Then the skill reads "references/805-regulations-eu-cyber-resilience-act-chapters-summary.md"
+  And the skill reads "references/805-regulations-eu-cyber-resilience-act-engineering-examples.md"
+  And the skill reads "assets/reports/805-eu-cyber-resilience-act-engineering-review-report-template.md"
+  And the skill frames Cyber Resilience Act findings as engineering controls rather than legal advice
+  And review findings do not use facts outside "examples/diagrams/deployment/system-example-cicd-model.md" and "examples/diagrams/deployment/checkout-service-feature-request.md"
+  And the skill scopes product context, possible product-with-digital-elements signals, possible remote data processing signals, product owners, product security owners, support owners, environments, intended purpose, reasonably foreseeable use, update paths, vulnerabilities, dependencies, SBOM evidence, and product documentation
+  And the skill escalates missing pre-merge review, protected-main bypass, product classification, economic-operator role, conformity assessment, CE marking implications, Article 14 reporting obligations, support-period interpretation, cybersecurity risk acceptance, and regulatory interpretation to legal, compliance, product, product-security, market-access, security, platform, risk, support, or executive accountability owners
+  And the skill reviews Java implementation, configuration, tests, threat models, product documentation, observability, vulnerability records, coordinated disclosure policy, security update mechanisms, dependency inventories, SBOMs, support-period evidence, release records, and user instructions
+  And the skill identifies risk signals for unclear product scope, ownerless product security controls, missing threat model, weak secure defaults, incomplete vulnerability handling, missing coordinated disclosure evidence, weak update mechanism, incomplete dependency inventory, missing SBOM, weak authentication or authorization, weak cryptography, sensitive-data logging, missing product security documentation, missing support-period signal, direct-to-main commit policy, database migration, Kafka message contract, CI/CD pipeline, and production side-effect signals
+  And the skill maps potential Cyber Resilience Act violation or non-compliance signals to regulation topic areas using only the reviewed direct-to-main delivery evidence with associated official-source links
+  And the skill analyzes the CheckoutService feature request as a direct-to-main pipeline-delivered product-adjacent change that modifies order database structure and outbound Kafka event data
+  And the skill uses Java examples to explain secure defaults, vulnerability handling, coordinated disclosure, security update delivery, dependency and SBOM evidence, product documentation, support-period signaling, and secure release-policy controls
+  And the skill recommends engineering controls for pre-commit review, main-branch protection, product security scope inventory, secure-by-design development, threat modeling, secure defaults, vulnerability remediation, coordinated disclosure, security advisory workflow, secure update delivery, dependency and SBOM evidence, cryptography, authentication, authorization, sensitive-data-safe logging, product security documentation, support-period and end-of-support signaling, database migration approval, Kafka schema compatibility, and release readiness
+  And the skill reports conclusions and actions using the Cyber Resilience Act engineering review report template
+  And the skill overwrites the Cyber Resilience Act engineering review report at "examples/regulations/eu-cyber-resilience-act/CRA-DIRECT-MAIN-ENGINEERING-REVIEW-REPORT.md"
+  And any git changes produced during skill execution and verification are reset

--- a/skills-generator/src/test/resources/gherkin/acceptance-tests-prompts-skills.md
+++ b/skills-generator/src/test/resources/gherkin/acceptance-tests-prompts-skills.md
@@ -69,3 +69,10 @@ and verify that acceptance-tests passes.
 execute @skills-generator/src/test/resources/gherkin/804-regulations-eu-nis2.feature
 and verify that acceptance-tests passes.
 ```
+
+## 805-regulations-eu-cyber-resilience-act
+
+```bash
+execute @skills-generator/src/test/resources/gherkin/805-regulations-eu-cyber-resilience-act.feature
+and verify that acceptance-tests passes.
+```


### PR DESCRIPTION
## Summary
- Adds the `805-regulations-eu-cyber-resilience-act` skill source, CRA chapter summary, Java engineering examples, and report template.
- Registers skill 805 in the generator inventory and adds CRA Gherkin acceptance coverage plus documented prompt registration.
- Adds CRA engineering review example reports and marks the OpenSpec implementation tasks complete with manual acceptance coverage noted.

## Test plan
- `xmllint --noout skills-generator/src/main/resources/skill-indexes/805-skill.xml skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-chapters-summary.xml skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-engineering-examples.xml skills-generator/src/main/resources/skills.xml`
- `./mvnw clean install -pl skills-generator`
- Inspected `.agents/skills/805-regulations-eu-cyber-resilience-act/SKILL.md`, generated references, and report resource for unresolved includes and broken local paths.
- `./mvnw clean verify -pl skills-generator`
- `openspec validate --all`
- `jbang .github/scripts/MarkdownValidator.java --verbose .`
- Acceptance prompt manually covered by generated CRA example reports; no automated acceptance runner was found beyond the documented prompt.

## Refs
- https://github.com/jabrena/cursor-rules-java/issues/855

Made with [Cursor](https://cursor.com)