### PR TITLE
build(maven): add nullness compiler analysis

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,11 @@
 --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,9 @@
         <junit.version>6.1.0</junit.version>
         <assertj.version>3.27.7</assertj.version>
         <jackson.version>2.22.0</jackson.version>
+        <jspecify.version>1.0.0</jspecify.version>
+        <error-prone.version>2.50.0</error-prone.version>
+        <nullaway.version>0.13.7</nullaway.version>
 
         <!-- Core build plugin versions -->
         <maven-plugin-compiler.version>3.15.0</maven-plugin-compiler.version>
@@ -113,6 +116,12 @@
                 <version>${jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>${jspecify.version}</version>
+                <scope>provided</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/site-generator/pom.xml
+++ b/site-generator/pom.xml
@@ -9,6 +9,7 @@
         <groupId>info.jab</groupId>
         <artifactId>cursor-rules-java</artifactId>
         <version>0.16.0</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>cursor-rules-java-site</artifactId>

--- a/skills-generator/pom.xml
+++ b/skills-generator/pom.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>info.jab</groupId>
         <artifactId>cursor-rules-java</artifactId>
         <version>0.16.0</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>info.jab.pml</groupId>
@@ -27,6 +28,11 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test dependencies -->
@@ -55,6 +61,33 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <release>${java.version}</release>
+                    <compilerArgs>
+                        <arg>-Xlint:all</arg>
+                        <arg>-Werror</arg>
+                        <arg>-XDcompilePolicy=simple</arg>
+                        <arg>--should-stop=ifError=FLOW</arg>
+                        <arg>-Xplugin:ErrorProne
+                            -Xep:NullAway:ERROR
+                            -XepOpt:NullAway:JSpecifyMode=true
+                            -XepOpt:NullAway:TreatGeneratedAsUnannotated=true
+                            -XepOpt:NullAway:CheckOptionalEmptiness=true
+                            -XepOpt:NullAway:HandleTestAssertionLibraries=true
+                            -XepOpt:NullAway:AssertsEnabled=true
+                            -XepOpt:NullAway:AnnotatedPackages=info.jab.pml
+                        </arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>${error-prone.version}</version>
+                        </path>
+                        <path>
+                            <groupId>com.uber.nullaway</groupId>
+                            <artifactId>nullaway</artifactId>
+                            <version>${nullaway.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
 

--- a/skills-generator/src/main/java/info/jab/pml/CommandIndexes.java
+++ b/skills-generator/src/main/java/info/jab/pml/CommandIndexes.java
@@ -3,6 +3,7 @@ package info.jab.pml;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -49,7 +50,7 @@ public final class CommandIndexes {
                 if (!(commandNodes.item(i) instanceof Element commandEl)) {
                     continue;
                 }
-                if (commandEl.getParentNode() != root) {
+                if (!commandEl.getParentNode().isSameNode(root)) {
                     continue;
                 }
                 String file = commandEl.getAttribute("file").trim();
@@ -78,7 +79,7 @@ public final class CommandIndexes {
             cl = CommandIndexes.class.getClassLoader();
         }
         InputStream in = cl.getResourceAsStream(name);
-        if (in == null && cl != CommandIndexes.class.getClassLoader()) {
+        if (in == null && !Objects.equals(cl, CommandIndexes.class.getClassLoader())) {
             in = CommandIndexes.class.getClassLoader().getResourceAsStream(name);
         }
         return in;

--- a/skills-generator/src/main/java/info/jab/pml/SkillIndexes.java
+++ b/skills-generator/src/main/java/info/jab/pml/SkillIndexes.java
@@ -3,7 +3,10 @@ package info.jab.pml;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.stream.Stream;
+import org.jspecify.annotations.Nullable;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -42,7 +45,7 @@ public final class SkillIndexes {
             validateSkillSummaryExists(numericId, entry.useXml());
             String skillId = entry.requiresSystemPrompt()
                 ? resolveSkillId(entry)
-                : entry.skillId();
+                : requireConfiguredSkillId(entry);
             skillIds.add(skillId);
         }
 
@@ -60,7 +63,7 @@ public final class SkillIndexes {
             validateSkillSummaryExists(numericId, entry.useXml());
             String skillId = entry.requiresSystemPrompt()
                 ? resolveSkillId(entry)
-                : entry.skillId();
+                : requireConfiguredSkillId(entry);
             descriptors.add(new SkillDescriptor(
                 skillId,
                 entry.requiresSystemPrompt(),
@@ -106,6 +109,14 @@ public final class SkillIndexes {
         return entry.references().getFirst();
     }
 
+    private static String requireConfiguredSkillId(InventoryEntry entry) {
+        if (entry.skillId() == null || entry.skillId().isBlank()) {
+            throw new RuntimeException("Entry with id " + entry.numericId()
+                + " has requiresSystemPrompt=false but no skillId specified.");
+        }
+        return entry.skillId();
+    }
+
     /**
      * Loads and parses skills.xml.
      */
@@ -133,7 +144,7 @@ public final class SkillIndexes {
                 if (!(skillNodes.item(i) instanceof Element skillEl)) {
                     continue;
                 }
-                if (skillEl.getParentNode() != root) {
+                if (!skillEl.getParentNode().isSameNode(root)) {
                     continue;
                 }
                 String numericId = skillEl.getAttribute("id");
@@ -183,7 +194,7 @@ public final class SkillIndexes {
         if (!el.hasAttribute(name)) {
             return defaultValue;
         }
-        String v = el.getAttribute(name).trim().toLowerCase();
+        String v = el.getAttribute(name).trim().toLowerCase(Locale.ROOT);
         return "true".equals(v) || "yes".equals(v) || "1".equals(v);
     }
 
@@ -270,7 +281,7 @@ public final class SkillIndexes {
             cl = SkillIndexes.class.getClassLoader();
         }
         InputStream in = cl.getResourceAsStream(name);
-        if (in == null && cl != SkillIndexes.class.getClassLoader()) {
+        if (in == null && !Objects.equals(cl, SkillIndexes.class.getClassLoader())) {
             in = SkillIndexes.class.getClassLoader().getResourceAsStream(name);
         }
         return in;
@@ -287,7 +298,7 @@ public final class SkillIndexes {
     public record InventoryEntry(
         String numericId,
         boolean requiresSystemPrompt,
-        String skillId,
+        @Nullable String skillId,
         boolean useXml,
         List<String> references,
         List<SkillResource> resources

--- a/skills-generator/src/main/java/info/jab/pml/SkillsGenerator.java
+++ b/skills-generator/src/main/java/info/jab/pml/SkillsGenerator.java
@@ -16,6 +16,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
+import org.jspecify.annotations.Nullable;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
@@ -161,7 +162,7 @@ public final class SkillsGenerator {
                 throw new RuntimeException("Skill resource not found: " + resourceName
                     + ". Each skill in SkillIndexes must have a matching file in skill-indexes/.");
             }
-            String content = new String(stream.readAllBytes());
+            String content = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
             return appendProjectTagToDescription(content);
         } catch (Exception e) {
             throw new RuntimeException("Failed to load skill: " + resourceName, e);
@@ -276,7 +277,7 @@ public final class SkillsGenerator {
         return dash > 0 ? skillId.substring(0, dash) : skillId;
     }
 
-    private InputStream getResource(String name) {
+    private @Nullable InputStream getResource(String name) {
         return Optional.ofNullable(getClass().getClassLoader().getResourceAsStream(name))
             .or(() -> Optional.ofNullable(Thread.currentThread().getContextClassLoader().getResourceAsStream(name)))
             .orElse(null);

--- a/skills-generator/src/test/java/info/jab/pml/SkillReferenceGeneratorTest.java
+++ b/skills-generator/src/test/java/info/jab/pml/SkillReferenceGeneratorTest.java
@@ -378,21 +378,6 @@ class SkillReferenceGeneratorTest {
         }
 
         /**
-         * Determines if a rule is a template generation rule rather than a code analysis rule.
-         */
-        private boolean isTemplateGenerationRule(String content, String baseFileName) {
-            // Check for template generation indicators
-            boolean hasTemplateReference = content.contains("embedded template") ||
-                                         content.contains("template EXACTLY") ||
-                                         content.contains("markdown file named");
-
-            boolean isChecklistGuide = baseFileName.contains("checklist-guide");
-            boolean isDocumentationRule = baseFileName.contains("documentation");
-
-            return hasTemplateReference || isChecklistGuide || isDocumentationRule;
-        }
-
-        /**
          * Validates that example numbering is consistent and sequential.
          */
         private void validateExampleNumberingConsistency(String[] lines, String baseFileName) {
@@ -578,10 +563,13 @@ class SkillReferenceGeneratorTest {
         private String getElementText(Element parent, String tagName) {
             NodeList nodes = parent.getElementsByTagName(tagName);
             if (nodes.getLength() == 0) {
-                return null;
+                throw new IllegalStateException("Missing element <" + tagName + ">");
             }
             String text = nodes.item(0).getTextContent();
-            return text != null ? text.trim() : null;
+            if (text == null) {
+                throw new IllegalStateException("Element <" + tagName + "> has no text content");
+            }
+            return text.trim();
         }
     }
 }

--- a/skills-generator/src/test/java/info/jab/pml/SkillsGeneratorTest.java
+++ b/skills-generator/src/test/java/info/jab/pml/SkillsGeneratorTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -288,7 +289,10 @@ class SkillsGeneratorTest {
                     "041-planning-plan-mode",
                     "042-planning-openspec"
                 );
-            assertThat(descriptors.get("034-architecture-design-exploration").references())
+            SkillIndexes.SkillDescriptor descriptor = Objects.requireNonNull(
+                descriptors.get("034-architecture-design-exploration")
+            );
+            assertThat(descriptor.references())
                 .containsExactly("034-architecture-design-exploration");
         }
 
@@ -467,7 +471,10 @@ class SkillsGeneratorTest {
                 throw new IllegalStateException("No <version> element in parent pom.xml");
             }
             String version = versionNodes.item(0).getTextContent();
-            return version != null ? version.trim() : null;
+            if (version == null) {
+                throw new IllegalStateException("Parent pom.xml <version> element has no text content");
+            }
+            return version.trim();
         }
     }
 


### PR DESCRIPTION
## Summary
- add JSpecify dependency management and module dependency
- configure Error Prone and NullAway for the skills generator compiler
- fix baseline nullness and Error Prone findings in generator code/tests

## Validation
- ./mvnw validate
- ./mvnw clean verify