### PR TITLE
test(generator): add skill inventory reports

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,2 +1,2 @@
-java=26-amzn
+java=25.0.2-graalce
 maven=3.9.14

--- a/skills-generator/src/test/java/info/jab/pml/SkillReferenceExampleInventoryTest.java
+++ b/skills-generator/src/test/java/info/jab/pml/SkillReferenceExampleInventoryTest.java
@@ -1,0 +1,122 @@
+package info.jab.pml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Skill reference example inventory")
+class SkillReferenceExampleInventoryTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(SkillReferenceExampleInventoryTest.class);
+
+    @Test
+    @DisplayName("Should report example counts for every skill reference")
+    void should_reportExampleCountsForEverySkillReference() throws Exception {
+        List<ReferenceExampleCount> counts = SkillIndexes.skillDescriptors()
+            .filter(SkillIndexes.SkillDescriptor::requiresSystemPrompt)
+            .flatMap(descriptor -> descriptor.references().stream()
+                .map(reference -> countExamples(descriptor.skillId(), reference)))
+            .sorted(Comparator
+                .comparing(ReferenceExampleCount::skillId)
+                .thenComparing(ReferenceExampleCount::reference))
+            .toList();
+
+        assertThat(counts).isNotEmpty();
+        assertThat(counts)
+            .allSatisfy(count -> assertThat(count.examples()).isGreaterThanOrEqualTo(0));
+
+        String report = buildReport(counts);
+        Path reportPath = writeReport(report);
+        logger.info("Skill reference example count details:{}", System.lineSeparator() + report);
+
+        assertThat(reportPath)
+            .exists()
+            .isRegularFile();
+    }
+
+    private ReferenceExampleCount countExamples(String skillId, String reference) {
+        String resourceName = "skill-references/" + reference + ".xml";
+        try (InputStream stream = getClass().getClassLoader().getResourceAsStream(resourceName)) {
+            assertThat(stream)
+                .withFailMessage("System-prompt XML not found: %s", resourceName)
+                .isNotNull();
+
+            Document document = parseXml(stream, resourceName);
+            int examples = document.getElementsByTagName("example").getLength();
+            return new ReferenceExampleCount(skillId, reference, examples);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read " + resourceName, e);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to parse " + resourceName, e);
+        }
+    }
+
+    private Document parseXml(InputStream stream, String resourceName) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setXIncludeAware(true);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        InputSource inputSource = new InputSource(stream);
+        inputSource.setSystemId(resolveBaseUri(resourceName));
+        return builder.parse(inputSource);
+    }
+
+    private String resolveBaseUri(String resourceName) {
+        URL resourceUrl = getClass().getClassLoader().getResource(resourceName);
+        if (resourceUrl == null) {
+            return "";
+        }
+        String url = resourceUrl.toString();
+        int lastSlash = url.lastIndexOf('/');
+        return lastSlash > 0 ? url.substring(0, lastSlash + 1) : url;
+    }
+
+    private String buildReport(List<ReferenceExampleCount> counts) {
+        long skillCount = counts.stream()
+            .map(ReferenceExampleCount::skillId)
+            .distinct()
+            .count();
+        String rows = counts.stream()
+            .map(count -> "| " + count.skillId() + " | " + count.reference() + " | " + count.examples() + " |")
+            .collect(Collectors.joining(System.lineSeparator()));
+
+        return """
+            # Skill Reference Example Counts
+
+            Total skills: %d
+            Total references: %d
+
+            | Skill | Reference | Examples |
+            |---|---|---:|
+            %s
+            """.formatted(skillCount, counts.size(), rows);
+    }
+
+    private Path writeReport(String report) throws IOException {
+        Path reportPath = Paths.get("target", "skill-reference-example-counts.md");
+        Files.createDirectories(reportPath.getParent());
+        Files.writeString(reportPath, report);
+        logger.info("Skill reference example count report saved to: {}", reportPath.toAbsolutePath());
+        return reportPath;
+    }
+
+    private record ReferenceExampleCount(String skillId, String reference, int examples) {}
+}

--- a/skills-generator/src/test/java/info/jab/pml/SkillTriggerInventoryTest.java
+++ b/skills-generator/src/test/java/info/jab/pml/SkillTriggerInventoryTest.java
@@ -1,0 +1,105 @@
+package info.jab.pml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Skill trigger inventory")
+class SkillTriggerInventoryTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(SkillTriggerInventoryTest.class);
+
+    @Test
+    @DisplayName("Should report trigger counts for every skill")
+    void should_reportTriggerCounts_when_skillIndexesAreLoaded() throws Exception {
+        List<SkillTriggerCount> counts = SkillIndexes.loadInventory().stream()
+            .map(this::countTriggers)
+            .sorted(Comparator.comparing(SkillTriggerCount::skillId))
+            .toList();
+
+        assertThat(counts)
+            .hasSize(SkillIndexes.loadInventory().size())
+            .allSatisfy(count -> assertThat(count.skillName()).isNotBlank());
+
+        String report = buildReport(counts);
+        Path reportPath = writeReport(report);
+        logger.info("Skill trigger count details:{}", System.lineSeparator() + report);
+
+        assertThat(reportPath)
+            .exists()
+            .isRegularFile();
+    }
+
+    private SkillTriggerCount countTriggers(SkillIndexes.InventoryEntry entry) {
+        String resourceName = "skill-indexes/" + entry.numericId() + "-skill.xml";
+        try (InputStream stream = getClass().getClassLoader().getResourceAsStream(resourceName)) {
+            assertThat(stream)
+                .withFailMessage("Skill XML not found: %s", resourceName)
+                .isNotNull();
+
+            Document document = InventoryXmlLoader.parse(stream);
+            Element root = document.getDocumentElement();
+            String skillName = elementText(root, "title");
+            int triggerCount = root.getElementsByTagName("trigger").getLength();
+            String skillId = SkillIndexes.resolveSkillId(entry);
+
+            return new SkillTriggerCount(skillId, skillName, triggerCount);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read " + resourceName, e);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to parse " + resourceName, e);
+        }
+    }
+
+    private String elementText(Element parent, String tagName) {
+        NodeList nodes = parent.getElementsByTagName(tagName);
+        assertThat(nodes.getLength())
+            .withFailMessage("Expected <%s> element in %s", tagName, parent.getAttribute("id"))
+            .isGreaterThan(0);
+
+        String text = nodes.item(0).getTextContent();
+        return text == null ? "" : text.trim();
+    }
+
+    private String buildReport(List<SkillTriggerCount> counts) {
+        String rows = counts.stream()
+            .map(count -> "| " + count.skillId() + " | " + count.skillName() + " | " + count.triggers() + " |")
+            .collect(Collectors.joining(System.lineSeparator()));
+
+        return """
+            # Skill Trigger Counts
+
+            Total skills: %d
+
+            | Skill | Name | Triggers |
+            |---|---|---:|
+            %s
+            """.formatted(counts.size(), rows);
+    }
+
+    private Path writeReport(String report) throws IOException {
+        Path reportPath = Paths.get("target", "skill-trigger-counts.md");
+        Files.createDirectories(reportPath.getParent());
+        Files.writeString(reportPath, report);
+        logger.info("Skill trigger count report saved to: {}", reportPath.toAbsolutePath());
+        return reportPath;
+    }
+
+    private record SkillTriggerCount(String skillId, String skillName, int triggers) {}
+}


### PR DESCRIPTION
## Summary
- add a trigger-count inventory report test for generated skills
- add a reference example-count inventory report test for skill references
- align .sdkmanrc with the Java runtime used by the project

## Validation
- ./mvnw verify -pl skills-generator

Note: I used verify without clean because local site clean can fail while macOS Virtualization is holding site-generator/target/docs-local open.