### PR TITLE
docs(blog): polish 0.16.0 release post

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -162,16 +162,24 @@ jobs:
           pre-commit run conventional-pre-commit --hook-stage commit-msg --commit-msg-filename /tmp/commit-msg.txt
 
   package-agent-artifacts:
-    name: Package Agents and Skills
+    name: Package Commands, Agents, and Skills
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: true
+      - name: Create commands archive
+        run: cd .cursor && zip -r ../commands.zip commands
       - name: Create agents archive
         run: cd .cursor && zip -r ../agents.zip agents
       - name: Create skills archive
         run: zip -r skills.zip skills
+      - name: Upload commands.zip
+        uses: actions/upload-artifact@v7
+        with:
+          name: commands.zip
+          path: commands.zip
+          if-no-files-found: error
       - name: Upload agents.zip
         uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Learn to use this project following the quick guide [Getting Started in 5 minute
 
 ### Migrating from legacy rules
 
-Current `System prompts/rules` are deprecated and will be removed in `v0.16.0`. If you still use them, review the [release 0.14.0 article](https://jabrena.github.io/cursor-rules-java/blog/2026/04/release-0.14.0.html).
+Current `System prompts/rules` are deprecated and will be removed in `v0.17.0`. If you still use them, review the [release 0.14.0 article](https://jabrena.github.io/cursor-rules-java/blog/2026/04/release-0.14.0.html).
 
 ## Choose your path
 

--- a/docs/blog/2026/06/release-0.16.0.html
+++ b/docs/blog/2026/06/release-0.16.0.html
@@ -196,7 +196,7 @@ Operate
 /review-alignment between the issue #xxx and the change #yyy
 /implement-issue based on OpenSpec change #yyy
 </code></pre>
-<p>In coming releases, this model will be enriched in different ways, but its pillars are established in this release.</p>
+<p>In upcoming releases, this model will be enriched in different ways, but its pillars are established in this release.</p>
 <p>In other projects, you can find useful <code>Skills</code>, <code>Agents</code>, or <code>Commands</code>, but not always a fully connected workflow designed with <code>Java</code> in mind.</p>
 <h2>What are the Top 10 Skills from this project in Skills.sh?</h2>
 <p><a id="what-are-the-top-10-skills-from-this-project-in-skillssh"></a></p>
@@ -381,6 +381,7 @@ Implement it using Micronaut, not Spring Boot, as the default requirement.
 <p><a href="https://asciinema.org/a/1258091"><img src="https://asciinema.org/a/1258091.svg" alt="asciicast" /></a></p>
 <p><em>Running the test with Codex CLI for the Micronaut variant</em></p>
 <p><strong>As you can see, one of the unique features of this project is the ability to implement requirements across multiple Java frameworks.</strong> With this idea in mind, you can explore moving from one framework to another during a <code>Spike</code>, evaluate how complex the change is, identify which annotations change, and discover which features are framework-specific. If you have good tests, the journey becomes easier.</p>
+<p>Another benefit discovered through this new testing approach is that by following the test execution, we can find issues with skills and reinforce them after each test run. One example is the lack of support for <code>Mongock</code> in <code>Spring Boot 4.0.x</code>, but now the skill is able to provide a workaround, consistent with the solutions for <code>Quarkus</code> and <code>Micronaut</code>.</p>
 <h2>Improving the way to install Agents and Commands</h2>
 <p><a id="improving-the-way-to-install-agents-and-commands"></a></p>
 <p>With the rise of <code>Skills</code>, there is a need for public registries for them. But what happens to <code>Agents</code>, <code>Commands</code>, or other files? The reality is that <code>Agents</code> and <code>Commands</code> are often treated as second-class citizens.</p>
@@ -393,6 +394,13 @@ Implement it using Micronaut, not Spring Boot, as the default requirement.
 <li><a href="https://www.skills.sh/jabrena/cursor-rules-java/005-agents-installation"><code>@005-agents-installation</code></a></li>
 </ul>
 <p>Then you can use them to install assets or generate the inventory files.</p>
+<p><strong>Example:</strong></p>
+<pre><code class="language-bash">install @004-commands-installation cursor
+install @004-commands-installation claude-code
+install @004-commands-installation codex
+install @004-commands-installation github-copilot
+</code></pre>
+<p><strong>Note:</strong> It is a good practice after releasing a new version to download all <code>Skills</code> and then install the <code>Agents</code> and <code>Commands</code> aligned.</p>
 <h2>New capabilities for Java Enterprise Frameworks</h2>
 <p><a id="new-capabilities-for-java-enterprise-frameworks"></a></p>
 <p>In this new release, we have added a few new Java framework capabilities:</p>
@@ -470,7 +478,7 @@ Implement it using Micronaut, not Spring Boot, as the default requirement.
 <li><a href="https://www.skills.sh/jabrena/cursor-rules-java/807-regulations-eu-digital-services-act"><code>@807-regulations-eu-digital-services-act</code></a></li>
 <li><a href="https://www.skills.sh/jabrena/cursor-rules-java/808-regulations-eu-digital-markets-act"><code>@808-regulations-eu-digital-markets-act</code></a></li>
 </ul>
-<p>These skills are engineering review aids. <em>They do not provide legal advice and they do not replace qualified legal, compliance, privacy, security, risk, product, or governance owners.</em></p>
+<p>These skills are engineering review aids. <strong><em>They do not provide legal advice and they do not replace qualified legal, compliance, privacy, security, risk, product, or governance owners.</em></strong></p>
 <p>For distributed systems using GenAI tools, a practical review set is:</p>
 <ul>
 <li><code>EU AI Act</code> when the system uses AI models, LLMs, RAG, AI agents, tool calling, or generated decision support.</li>
@@ -488,8 +496,9 @@ Implement it using Micronaut, not Spring Boot, as the default requirement.
 <p>Functionally, the next workstreams are:</p>
 <ul>
 <li>Expand executable acceptance coverage for <code>Skills</code>, <code>Agents</code>, and <code>Commands</code>, so important behavior is checked with stable <code>Gherkin</code> scenarios instead of relying only on package shape or manual review.</li>
-<li>Add LLM engineering references such as <code>Karpathy's LLM Wiki</code>, so agent and skill guidance can stay closer to widely used mental models for building with language models.</li>
-<li>Improve analysis methods, including <code>the hamburger method</code> and <code>the two-step method</code>, so discovery work can become more structured before teams generate ADRs, specs, plans, or implementation tasks.</li>
+<li>Improve analysis methods, including <a href="https://gojko.net/2012/01/23/splitting-user-stories-the-hamburger-method/"><code>the hamburger method</code></a> from <a href="https://gojko.net/about/">Gojko Adzic</a> and <a href="https://newsletter.kentbeck.com/p/mastering-programming"><code>the two-step method</code></a> from <a href="https://kentbeck.com/">Kent Beck</a>, so discovery work can become more structured before teams generate ADRs, Specs or implementation tasks.</li>
+<li>Improve a few references with fewer examples and add more triggers to increase auto-discovery.</li>
+<li>Add new capabilities such as <a href="https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f"><code>Karpathy's LLM Wiki</code></a>; when analyzing a particular feature, take into consideration other aspects of the whole distributed system.</li>
 <li>Extend Maven guidance with <code>JavaMoney</code> support in the Maven plugin workflow, improving how teams introduce money and currency handling into enterprise builds.</li>
 <li>Complete the <code>EU regulation</code> review family, so teams can map distributed-system and <code>GenAI</code> decisions against a broader set of engineering evidence patterns.</li>
 </ul>

--- a/docs/blog/2026/06/release-0.16.0.html
+++ b/docs/blog/2026/06/release-0.16.0.html
@@ -202,16 +202,16 @@ Operate
 <p><a id="what-are-the-top-10-skills-from-this-project-in-skillssh"></a></p>
 <p>The project has <code>106 skills</code> and uses <a href="https://www.skills.sh/jabrena/cursor-rules-java">Skills.sh</a> as its main skill registry. It has served <code>11.0K</code> installs in total. These are the current top 10 skills used by users there:</p>
 <ol>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/110-java-maven-best-practices"><code>110-java-maven-best-practices</code></a> - <a href="https://www.skills.sh/search?q=maven">maven</a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/121-java-object-oriented-design"><code>121-java-object-oriented-design</code></a> - <a href="https://www.skills.sh/search?q=java%20object%20oriented">java object oriented</a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/124-java-secure-coding"><code>124-java-secure-coding</code></a> - <a href="https://www.skills.sh/search?q=java%20security">java security</a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/131-java-testing-unit-testing"><code>131-java-testing-unit-testing</code></a> - <a href="https://www.skills.sh/search?q=java%20unit%20testing">java unit testing</a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/142-java-functional-programming"><code>142-java-functional-programming</code></a> - <a href="https://www.skills.sh/search?q=java%20functional%20programming">java functional programming</a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/128-java-generics"><code>128-java-generics</code></a> - <a href="https://www.skills.sh/search?q=java%20generics">java generics</a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/111-java-maven-dependencies"><code>111-java-maven-dependencies</code></a> - <a href="https://www.skills.sh/search?q=maven">maven</a></li>
+<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/110-java-maven-best-practices"><code>110-java-maven-best-practices</code></a> - search query: <a href="https://www.skills.sh/search?q=maven">maven</a></li>
+<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/121-java-object-oriented-design"><code>121-java-object-oriented-design</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20object%20oriented">java object oriented</a></li>
+<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/124-java-secure-coding"><code>124-java-secure-coding</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20security">java security</a></li>
+<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/131-java-testing-unit-testing"><code>131-java-testing-unit-testing</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20unit%20testing">java unit testing</a></li>
+<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/142-java-functional-programming"><code>142-java-functional-programming</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20functional%20programming">java functional programming</a></li>
+<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/128-java-generics"><code>128-java-generics</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20generics">java generics</a></li>
+<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/111-java-maven-dependencies"><code>111-java-maven-dependencies</code></a> - search query: <a href="https://www.skills.sh/search?q=maven">maven</a></li>
 <li><a href="https://www.skills.sh/jabrena/cursor-rules-java/141-java-refactoring-with-modern-features"><code>141-java-refactoring-with-modern-features</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/125-java-concurrency"><code>125-java-concurrency</code></a> - <a href="https://www.skills.sh/search?q=java%20concurrency">java concurrency</a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/143-java-functional-exception-handling"><code>143-java-functional-exception-handling</code></a> - <a href="https://www.skills.sh/search?q=java%20functional%20programming">java functional programming</a></li>
+<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/125-java-concurrency"><code>125-java-concurrency</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20concurrency">java concurrency</a></li>
+<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/143-java-functional-exception-handling"><code>143-java-functional-exception-handling</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20functional%20programming">java functional programming</a></li>
 </ol>
 <p><strong>What is your favorite <code>Skill</code> from this project?</strong> You can share it here: <a href="https://github.com/jabrena/cursor-rules-java/discussions/804">https://github.com/jabrena/cursor-rules-java/discussions/804</a></p>
 <h2>Applying Zero Trust with your Agent skills</h2>
@@ -226,7 +226,7 @@ Operate
 <li><code>Snyk Agent Scan</code> adds supply-chain and prompt-risk signals.</li>
 </ul>
 <p>The point is not to claim that a generated skill is perfect. The point is to make suspicious behavior visible before maintainers or users rely on it.</p>
-<p>Common risks include:</p>
+<p>Common skill risks include:</p>
 <ul>
 <li>Prompt injection patterns</li>
 <li>Data exfiltration instructions</li>
@@ -240,20 +240,21 @@ Operate
 <li>Untrusted content and indirect prompt injection</li>
 <li>Tool poisoning and tool shadowing</li>
 </ul>
+<p><strong>Note:</strong> The project runs an analysis for all skills on every commit using the tools described above. <a href="https://github.com/jabrena/cursor-rules-java/blob/main/.github/workflows/maven.yaml">https://github.com/jabrena/cursor-rules-java/blob/main/.github/workflows/maven.yaml</a></p>
 <p>If you are interested in this kind of validation, I recommend reading the following article: <a href="/cursor-rules-java/blog/2026/06/skill-validators-pipeline.html">How to validate skills?</a></p>
 <h2>Improving the approach to test the behavior of Agent Skills</h2>
 <p><a id="improving-the-approach-to-test-the-behavior-of-an-agent-skills"></a></p>
-<p>All elements in this project change for different reasons, so it is necessary to invest time in the release process to ensure that they continue to add value for software engineers and AI agents running in pipelines.</p>
-<p>During this release, we ran a <code>Spike</code> to validate an improved testing process. We added <code>Gherkin</code> support for all skills created or updated in this release, reducing testing time and generating evidence for specific deterministic behaviors.</p>
+<p>During the evolution of this project, files change over time for different reasons. After each change, it is necessary to validate them again, so the release process includes time to ensure they continue to add value for software engineers and AI agents running in pipelines.</p>
+<p>During this release, we ran a <code>Spike</code> to validate an idea for improving the testing process. We added <code>Gherkin</code> support for all skills created or updated in this release, and the results were successful. Testing time was reduced, and more importantly, the project now generates evidence for specific deterministic behaviors from the skills under test.</p>
 <p>Let's review two examples to show the value of the new tests.</p>
 <h3>Example to validate a skill</h3>
-<p>All skills have an acceptance-test inventory, and it lives in <code>acceptance-tests-prompts-skills.md</code>. When a generated skill changes for any reason, it is now possible to run only the matching prompt for that changed skill. Let's review the scenario for <code>@111-java-maven-dependencies</code>.</p>
+<p>All skills have an acceptance-test inventory file, and it lives in <code>acceptance-tests-prompts-skills.md</code>. When a generated skill changes for any reason, it is now possible to run only the matching prompt for that changed skill. Let's review the scenario for <code>@111-java-maven-dependencies</code>.</p>
 <p><strong>@111-java-maven-dependencies:</strong></p>
 <p>The inventory has a prompt to validate the skill:</p>
 <pre><code class="language-bash">execute @skills-generator/src/test/resources/gherkin/skills/111-java-maven-dependencies.feature
 and verify that acceptance-tests pass.
 </code></pre>
-<p>You can run the following <code>Gherkin</code> file:</p>
+<p>That prompt is linked with the following <code>Gherkin</code> file:</p>
 <pre><code class="language-gherkin">Feature: Validate changes from usage of Maven dependencies skill
 
 Background:
@@ -276,11 +277,17 @@ Scenario: Add JSpecify and Error Prone + NullAway to Maven demo
   And the verification failure is accepted because &quot;-Xlint:all&quot; and &quot;-Werror&quot; convert existing warnings into errors
   And any git changes produced during skill execution and verification are reset
 </code></pre>
-<p>For this particular skill, the scenario fixes the example project, the selected dependency answers, the expected <code>pom.xml</code> changes, the expected <code>.mvn/jvm.config</code> changes, the validation command, the accepted compiler failure, and the cleanup expectation. The goal is not to test every possible conversation. The goal is to prove that the changed skill still follows its intended workflow against a stable fixture.</p>
-<p>Let's review another, more complex scenario.</p>
+<p>For that particular skill, the scenario fixes the example project, the selected dependency answers, the expected <code>pom.xml</code> changes, the expected <code>.mvn/jvm.config</code> changes, the validation command, the accepted compiler failure, and the cleanup expectation. The goal is not to test every possible conversation. The goal is to prove that the changed skill still follows its intended workflow against a stable fixture. A <code>Gherkin</code> file cannot cover every possible use case, so it focuses on the most important ones.</p>
+<blockquote>
+<p>&quot;Program testing can be used to show the presence of bugs, but never to show their absence!&quot;</p>
+<ul>
+<li>Edsger W. Dijkstra</li>
+</ul>
+</blockquote>
+<p>Let's review another, more complex scenario and one of the key features included in this release.</p>
 <h3>Example to validate a command</h3>
-<p>All commands have an acceptance-test inventory, and it lives in <code>acceptance-tests-prompts-skills.md</code>. When a generated command changes for any reason, it is now possible to run only the matching prompt for that changed command. Let's review the scenario for <code>@/implement-issue</code>.</p>
-<p>As an example, let's try to solve the first problem from the project <code>Latency problems</code>: <a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md">https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md</a></p>
+<p>All commands have an acceptance-test inventory file, and it lives in <code>acceptance-tests-prompts-skills.md</code>. When a generated command changes for any reason, it is now possible to run only the matching prompt for that changed command. Let's review the scenario about the command <code>/implement-issue</code>.</p>
+<p>To demonstrate the new capabilities, let's try to solve the first problem from the project <a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md"><code>Latency problems</code></a>:</p>
 <pre><code class="language-bash"># Problem 1
 
 ## User Story Statement
@@ -339,7 +346,7 @@ Scenario: Implement God Analysis API from a validated OpenSpec change
   And the command reports changed files, validation evidence, updated OpenSpec task status, risks, and blockers
   And any git changes produced under &quot;examples/openspec/god-analysis-api/demo&quot; during command execution and verification are reset
 </code></pre>
-<p>Under the hood, this <code>Gherkin</code> file triggers the following set of project elements, which can be located in <code>.agents/**</code> or in other locations depending on your preferred tool and installation method:</p>
+<p>When the prompt is executed, under the hood the <code>Gherkin</code> file triggers the agents and skills:</p>
 <pre><code>Build
   /implement-issue
     @robot-tech-lead
@@ -352,7 +359,7 @@ Scenario: Implement God Analysis API from a validated OpenSpec change
       @robot-java-micronaut-coder
       @robot-no-java
 </code></pre>
-<p>In this case, the command internally uses the agent <code>@robot-tech-lead</code>, which redirects to the specific agent <code>@robot-java-spring-boot-coder</code> based on the analysis of the specification, and this is the result:</p>
+<p>In this case, the command internally uses the agent <code>@robot-tech-lead</code>, which redirects to the specific agent <code>@robot-java-spring-boot-coder</code> based on the analysis of the specification. That agent handles specific <code>Java skills</code> and specific <code>Spring Boot skills</code>. This is the result for a <code>Spring Boot</code> implementation:</p>
 <p><a href="https://asciinema.org/a/1257803"><img src="https://asciinema.org/a/1257803.svg" alt="asciicast" /></a></p>
 <p><em>Running the test with Codex CLI for the Spring Boot variant</em></p>
 <p><img src="/cursor-rules-java/images/2026/6/vscode-codex.png" alt="" /></p>
@@ -362,10 +369,10 @@ Scenario: Implement God Analysis API from a validated OpenSpec change
 and verify that acceptance-tests pass. 
 Implement it using Quarkus, not Spring Boot, as the default requirement.
 </code></pre>
-<p>In this case, the agent <code>@robot-tech-lead</code> redirects the workload to the specific agent <code>@robot-java-quarkus-coder</code>:</p>
+<p>In this case, the agent <code>@robot-tech-lead</code> redirects the workload to the specific agent <code>@robot-java-quarkus-coder</code>, which handles specific <code>Java skills</code> and specific <code>Quarkus skills</code>. This is the result for a <code>Quarkus</code> implementation:</p>
 <p><a href="https://asciinema.org/a/1257861"><img src="https://asciinema.org/a/1257861.svg" alt="asciicast" /></a></p>
 <p><em>Running the test with Codex CLI for the Quarkus variant</em></p>
-<p>Or, if required, the agent <code>@robot-tech-lead</code> redirects to the specific agent <code>@robot-java-micronaut-coder</code>:</p>
+<p>Or, if required, the agent <code>@robot-tech-lead</code> redirects to the specific agent <code>@robot-java-micronaut-coder</code>, which handles specific <code>Java skills</code> and specific <code>Micronaut skills</code>. This is the result for a <code>Micronaut</code> implementation:</p>
 <pre><code class="language-bash">execute @skills-generator/src/test/resources/gherkin/commands/implement-issue.feature
 and verify that acceptance-tests pass. 
 Implement it using Micronaut, not Spring Boot, as the default requirement.
@@ -373,7 +380,7 @@ Implement it using Micronaut, not Spring Boot, as the default requirement.
 <p>And the project will implement the feature without any issues:</p>
 <p><a href="https://asciinema.org/a/1258091"><img src="https://asciinema.org/a/1258091.svg" alt="asciicast" /></a></p>
 <p><em>Running the test with Codex CLI for the Micronaut variant</em></p>
-<p>As you can see, one of the unique features of this project is the ability to implement requirements across multiple Java frameworks.</p>
+<p><strong>As you can see, one of the unique features of this project is the ability to implement requirements across multiple Java frameworks.</strong> With this idea in mind, you can explore moving from one framework to another during a <code>Spike</code>, evaluate how complex the change is, identify which annotations change, and discover which features are framework-specific. If you have good tests, the journey becomes easier.</p>
 <h2>Improving the way to install Agents and Commands</h2>
 <p><a id="improving-the-way-to-install-agents-and-commands"></a></p>
 <p>With the rise of <code>Skills</code>, there is a need for public registries for them. But what happens to <code>Agents</code>, <code>Commands</code>, or other files? The reality is that <code>Agents</code> and <code>Commands</code> are often treated as second-class citizens.</p>

--- a/docs/blog/2026/06/release-0.16.0.html
+++ b/docs/blog/2026/06/release-0.16.0.html
@@ -108,7 +108,7 @@
 <article role="main" class="blog-post">
 <h2>What is the purpose?</h2>
 <p>An opinionated, AI-native development workflow for Java Enterprise: reusable <code>Skills</code>, <code>Agents</code>, <code>Commands</code>, and third-party <code>MCP servers</code> combined with a human-in-the-loop model to modernize real-world SDLC practices.</p>
-<p>Starting with this release, the project provides a way to express any <code>SDLC</code> action through 3 phases: <code>Plan</code>, <code>Build</code>, and <code>Operate</code>. <code>Software engineers</code> can use this model in user interfaces or terminals when they write a <code>User prompt</code>.</p>
+<p>Starting with this release, the project introduces a simple way to describe any <code>SDLC</code> action through three phases: <code>Plan</code>, <code>Build</code>, and <code>Operate</code>. <code>Software engineers</code> can use this structure when writing a <code>User prompt</code> in an AI user interface or terminal.</p>
 <p><strong>Example:</strong></p>
 <pre><code class="language-bash">Build
   /implement-issue
@@ -122,7 +122,7 @@
       @robot-java-micronaut-coder
       @robot-no-java
 </code></pre>
-<p>We will go into more detail later, but first, let's review the features that have evolved since the last release:</p>
+<p>We will go into more detail later, but first, let's review the most interesting features added in this release:</p>
 <ul>
 <li><a href="#enriching-the-workflow-with-commands-and-agents-not-only-skills">Enriching the workflow with Commands and Agents, not only Skills</a></li>
 <li><a href="#what-are-the-top-10-skills-from-this-project-in-skillssh">What are the Top 10 Skills from this project in Skills.sh?</a></li>
@@ -133,16 +133,16 @@
 <li><a href="#increasing-the-engineering-awareness-with-eu-regulations">Increasing engineering awareness with EU regulations</a></li>
 </ul>
 <p>Thanks to our community members in <code>Singapore</code>, <code>Hong Kong</code>, <code>Hanoi</code>, <code>London</code>, and <code>New York</code>. 👋👋👋</p>
+<p>If you have questions about the project, how to customize it for your team, how to use the skills in daily work, or how to solve tooling issues, use <a href="https://github.com/jabrena/cursor-rules-java/discussions"><code>GitHub Discussions</code></a>.</p>
 <p><strong>Help this project grow:</strong> <a href="https://github.com/sponsors/jabrena">If this project helps your team, become a sponsor.</a></p>
 <h2>Enriching the workflow with Commands and Agents, not only Skills</h2>
 <p><a id="enriching-the-workflow-with-commands-and-agents-not-only-skills"></a></p>
-<p>The project started more than a year ago with a set of reusable <code>rules / system prompts</code>. They were useful because teams could point an AI assistant at a consistent body of engineering expectations instead of rewriting the same instructions for every conversation. But as documented in <a href="https://github.com/jabrena/cursor-rules-java/blob/main/documentation/adr/ADR-002-configure-cursor-rules-manual-scope.md"><code>ADR-002</code></a>, automatic activation through broad <code>.java</code> frontmatter did not scale well: multiple rules could enter the context at the same time, increasing latency, consuming context, and making answers less deterministic. In 2026, with the rise of <code>Skills</code> and continued use of system prompts, evolving into <code>Skills</code> was a natural step. Release <code>0.16.0</code> moves further toward connected workflows. <code>Commands</code> become the entry points that a team can run. <code>Agents</code> become the role-specific workers that interpret the task. <code>Skills</code> become the reusable knowledge and procedures each agent applies.</p>
-<p>In practice, the operating model now looks like this:</p>
-<pre><code class="language-text">Command -&gt; Agent -&gt; Skills -&gt; Change in your repository
-</code></pre>
+<p>The project started more than a year ago with a set of reusable <code>rules / system prompts</code>. That approach worked well after removing the restriction that associated rules with particular files, as described in <a href="https://github.com/jabrena/cursor-rules-java/blob/main/documentation/adr/ADR-002-configure-cursor-rules-manual-scope.md"><code>ADR-002</code></a>. With the rise of <code>Skills</code>, it was a good decision to convert that material into skills and use the new capabilities provided by <code>Skill registries</code> like <a href="https://www.skills.sh/">https://www.skills.sh/</a> and other registries.</p>
+<p>In this release, we go further by adding new semantics for expressing the actions a software engineer performs while solving a problem.</p>
 <p>That model is organized around three delivery paths:</p>
 <pre><code class="language-text">Plan
   /create-issue
+  /update-issue
     @robot-business-analyst
       @043-planning-github-issues
       @044-planning-jira
@@ -188,7 +188,15 @@ Operate
       @151-java-performance-jmeter
       @152-java-performance-gatling
 </code></pre>
-<p>In coming releases, this model will be expanded in different ways, but its pillars are established in this release.</p>
+<p>Of course, you can continue using the project in the classic way: add the Java class and a particular skill to the context, or describe the action in natural language and let the <code>AI agent harness tools</code> trigger the right skill. However, combining commands with agents and skills gives you more benefits.</p>
+<p><strong>Example:</strong></p>
+<pre><code class="language-bash">Create AGENTS.md #It will trigger the skill @200-agents-md
+/update-issue from github #xxx and use User Story format.
+/create-spec using ideas from github issue #xxx
+/review-alignment between the issue #xxx and the change #yyy
+/implement-issue based on OpenSpec change #yyy
+</code></pre>
+<p>In coming releases, this model will be enriched in different ways, but its pillars are established in this release.</p>
 <p>In other projects, you can find useful <code>Skills</code>, <code>Agents</code>, or <code>Commands</code>, but not always a fully connected workflow designed with <code>Java</code> in mind.</p>
 <h2>What are the Top 10 Skills from this project in Skills.sh?</h2>
 <p><a id="what-are-the-top-10-skills-from-this-project-in-skillssh"></a></p>
@@ -205,7 +213,7 @@ Operate
 <li><a href="https://www.skills.sh/jabrena/cursor-rules-java/125-java-concurrency"><code>125-java-concurrency</code></a> - <a href="https://www.skills.sh/search?q=java%20concurrency">java concurrency</a></li>
 <li><a href="https://www.skills.sh/jabrena/cursor-rules-java/143-java-functional-exception-handling"><code>143-java-functional-exception-handling</code></a> - <a href="https://www.skills.sh/search?q=java%20functional%20programming">java functional programming</a></li>
 </ol>
-<p><strong>What is your favorite <code>Skill</code> from this project?</strong> You could share it here: <a href="https://github.com/jabrena/cursor-rules-java/discussions/804">https://github.com/jabrena/cursor-rules-java/discussions/804</a></p>
+<p><strong>What is your favorite <code>Skill</code> from this project?</strong> You can share it here: <a href="https://github.com/jabrena/cursor-rules-java/discussions/804">https://github.com/jabrena/cursor-rules-java/discussions/804</a></p>
 <h2>Applying Zero Trust with your Agent skills</h2>
 <p><a id="applying-zero-trust-with-your-agent-skills"></a></p>
 <p><code>Skills</code> are not ordinary Markdown files. They are executable guidance for AI agents. A skill can tell an agent how to read code, run commands, inspect evidence, write files, install tools, or make a technical recommendation.</p>
@@ -235,9 +243,9 @@ Operate
 <p>If you are interested in this kind of validation, I recommend reading the following article: <a href="/cursor-rules-java/blog/2026/06/skill-validators-pipeline.html">How to validate skills?</a></p>
 <h2>Improving the approach to test the behavior of Agent Skills</h2>
 <p><a id="improving-the-approach-to-test-the-behavior-of-an-agent-skills"></a></p>
-<p>All elements in this project change for different reasons, so it is necessary to invest time in the release process to ensure that they continue adding value for software engineers and AI agents running in pipelines.</p>
+<p>All elements in this project change for different reasons, so it is necessary to invest time in the release process to ensure that they continue to add value for software engineers and AI agents running in pipelines.</p>
 <p>During this release, we ran a <code>Spike</code> to validate an improved testing process. We added <code>Gherkin</code> support for all skills created or updated in this release, reducing testing time and generating evidence for specific deterministic behaviors.</p>
-<p>Let's review 2 examples to show the value of the new tests.</p>
+<p>Let's review two examples to show the value of the new tests.</p>
 <h3>Example to validate a skill</h3>
 <p>All skills have an acceptance-test inventory, and it lives in <code>acceptance-tests-prompts-skills.md</code>. When a generated skill changes for any reason, it is now possible to run only the matching prompt for that changed skill. Let's review the scenario for <code>@111-java-maven-dependencies</code>.</p>
 <p><strong>@111-java-maven-dependencies:</strong></p>
@@ -272,7 +280,7 @@ Scenario: Add JSpecify and Error Prone + NullAway to Maven demo
 <p>Let's review another, more complex scenario.</p>
 <h3>Example to validate a command</h3>
 <p>All commands have an acceptance-test inventory, and it lives in <code>acceptance-tests-prompts-skills.md</code>. When a generated command changes for any reason, it is now possible to run only the matching prompt for that changed command. Let's review the scenario for <code>@/implement-issue</code>.</p>
-<p>As example, lets try to solve the first problem from the project <code>Latency problems:</code> <a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md">https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md</a></p>
+<p>As an example, let's try to solve the first problem from the project <code>Latency problems</code>: <a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md">https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md</a></p>
 <pre><code class="language-bash"># Problem 1
 
 ## User Story Statement
@@ -292,7 +300,7 @@ Scenario: Add JSpecify and Error Prone + NullAway to Maven demo
   - Roman API: https://my-json-server.typicode.com/jabrena/latency-problems/roman
   - Nordic API: https://my-json-server.typicode.com/jabrena/latency-problems/nordic
 </code></pre>
-<p>Given this <code>User story</code> and the <code>OpenSpec</code> change defined here: <a href="https://github.com/jabrena/cursor-rules-java/tree/main/examples/openspec">https://github.com/jabrena/cursor-rules-java/tree/main/examples/openspec</a> you could be able to implement using the new command <code>/implement-issue</code>. Lets see how to do it and how to validate it.</p>
+<p>Given this <code>User story</code> and the <code>OpenSpec</code> change defined here: <a href="https://github.com/jabrena/cursor-rules-java/tree/main/examples/openspec">https://github.com/jabrena/cursor-rules-java/tree/main/examples/openspec</a>, you can implement it using the new <code>/implement-issue</code> command. Let's see how to do it and how to validate it.</p>
 <p><strong>/implement-issue:</strong></p>
 <p>Using this prompt:</p>
 <pre><code class="language-bash">execute @skills-generator/src/test/resources/gherkin/commands/implement-issue.feature
@@ -344,12 +352,12 @@ Scenario: Implement God Analysis API from a validated OpenSpec change
       @robot-java-micronaut-coder
       @robot-no-java
 </code></pre>
-<p>In this case, the command internally uses the agent <code>@robot-tech-lead</code>, which redirects to the specific agent <code>@robot-java-spring-boot-coder</code> based on the analysis of the specification and this is the result:</p>
+<p>In this case, the command internally uses the agent <code>@robot-tech-lead</code>, which redirects to the specific agent <code>@robot-java-spring-boot-coder</code> based on the analysis of the specification, and this is the result:</p>
 <p><a href="https://asciinema.org/a/1257803"><img src="https://asciinema.org/a/1257803.svg" alt="asciicast" /></a></p>
 <p><em>Running the test with Codex CLI for the Spring Boot variant</em></p>
 <p><img src="/cursor-rules-java/images/2026/6/vscode-codex.png" alt="" /></p>
 <p><em>Running the test with VS Code + Codex plugin</em></p>
-<p>But if you refine a bit the prompt, you could implement the requirement in <code>Quarkus</code>:</p>
+<p>But if you refine the prompt a bit, you can implement the requirement in <code>Quarkus</code>:</p>
 <pre><code class="language-bash">execute @skills-generator/src/test/resources/gherkin/commands/implement-issue.feature
 and verify that acceptance-tests pass. 
 Implement it using Quarkus, not Spring Boot, as the default requirement.
@@ -362,14 +370,14 @@ Implement it using Quarkus, not Spring Boot, as the default requirement.
 and verify that acceptance-tests pass. 
 Implement it using Micronaut, not Spring Boot, as the default requirement.
 </code></pre>
-<p>And the project will implement the feature without any issue:</p>
+<p>And the project will implement the feature without any issues:</p>
 <p><a href="https://asciinema.org/a/1258091"><img src="https://asciinema.org/a/1258091.svg" alt="asciicast" /></a></p>
 <p><em>Running the test with Codex CLI for the Micronaut variant</em></p>
-<p>So, it you observe one of the unique features from this project is the capacity to implement requirements in multiple Java frameworks.</p>
+<p>As you can see, one of the unique features of this project is the ability to implement requirements across multiple Java frameworks.</p>
 <h2>Improving the way to install Agents and Commands</h2>
 <p><a id="improving-the-way-to-install-agents-and-commands"></a></p>
-<p>With the rise of <code>Skills</code>, there is a need for public registries for them. But what happens with <code>Agents</code>, <code>Commands</code>, or other files? The reality is that <code>Agents</code> and <code>Commands</code> are often treated as second-class citizens.</p>
-<p>To take advantage of the public registry and the process for generating skills from <code>XML</code> sources, it is relatively easy to embed commands and agents in a <code>Meta Skill</code>. Once you have installed the skills, you can see the following inventory and installation workflows:</p>
+<p>With the rise of <code>Skills</code>, there is a need for public registries for them. But what happens to <code>Agents</code>, <code>Commands</code>, or other files? The reality is that <code>Agents</code> and <code>Commands</code> are often treated as second-class citizens.</p>
+<p>To take advantage of the public registry and the process for generating skills from <code>XML</code> sources, it is relatively easy to embed commands and agents in a <code>Meta Skill</code>. Once you have installed the skills, you can use the following inventory and installation workflows:</p>
 <ul>
 <li><a href="https://www.skills.sh/jabrena/cursor-rules-java/001-commands-inventory"><code>@001-commands-inventory</code></a></li>
 <li><a href="https://www.skills.sh/jabrena/cursor-rules-java/002-agents-inventory"><code>@002-agents-inventory</code></a></li>

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/cursor-rules-java/</id>
   <title>Skills & Agents for Java</title>
-  <updated>2026-06-20T10:46:46+0200</updated>
+  <updated>2026-06-20T11:17:16+0200</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/cursor-rules-java/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/cursor-rules-java//feed.xml' />
   <entry>

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/cursor-rules-java/</id>
   <title>Skills & Agents for Java</title>
-  <updated>2026-06-20T10:16:33+0200</updated>
+  <updated>2026-06-20T10:46:46+0200</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/cursor-rules-java/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/cursor-rules-java//feed.xml' />
   <entry>

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/cursor-rules-java/</id>
   <title>Skills & Agents for Java</title>
-  <updated>2026-06-19T19:13:16+0200</updated>
+  <updated>2026-06-20T10:16:33+0200</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/cursor-rules-java/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/cursor-rules-java//feed.xml' />
   <entry>
@@ -13,7 +13,7 @@
     <updated>2026-06-22T00:00:00+0200</updated>
     <summary>What is the purpose?
 An opinionated, AI-native development workflow for Java Enterprise: reusable Skills, Agents, Commands, and third-party MCP servers combined with a human-in-the-loop model to modernize real-world SDLC practices.
-Starting with this release, the project provides a way to express any SDLC action through 3 phases: Plan, Build, and Operate. Software engineers can use this model in us...</summary>
+Starting with this release, the project introduces a simple way to describe any SDLC action through three phases: Plan, Build, and Operate. Software engineers can use th...</summary>
   </entry>
   <entry>
     <id>https://jabrena.github.io/cursor-rules-java//blog/2026/06/skill-validators-pipeline.html</id>

--- a/docs/index.html
+++ b/docs/index.html
@@ -138,7 +138,7 @@
   <div class="post-entry">
     What is the purpose?
 An opinionated, AI-native development workflow for Java Enterprise: reusable Skills, Agents, Commands, and third-party MCP servers combined with a human-in-the-loop model to modernize real-world SDLC practices.
-Starting with this release, the project provides a way to express any SDLC action through 3 phases: Plan, Build, and Operate. Software engineers can use this model in us...
+Starting with this release, the project introduces a simple way to describe any SDLC action through three phases: Plan, Build, and Operate. Software engineers can use th...
     <p></p>
     <a href="blog/2026/06/release-0.16.0.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/agents.html
+++ b/docs/tags/agents.html
@@ -108,7 +108,7 @@
   <div class="post-entry">
     What is the purpose?
 An opinionated, AI-native development workflow for Java Enterprise: reusable Skills, Agents, Commands, and third-party MCP servers combined with a human-in-the-loop model to modernize real-world SDLC practices.
-Starting with this release, the project provides a way to express any SDLC action through 3 phases: Plan, Build, and Operate. Software engineers can use this model in us...
+Starting with this release, the project introduces a simple way to describe any SDLC action through three phases: Plan, Build, and Operate. Software engineers can use th...
     <p></p>
     <a href="../blog/2026/06/release-0.16.0.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/blog.html
+++ b/docs/tags/blog.html
@@ -108,7 +108,7 @@
   <div class="post-entry">
     What is the purpose?
 An opinionated, AI-native development workflow for Java Enterprise: reusable Skills, Agents, Commands, and third-party MCP servers combined with a human-in-the-loop model to modernize real-world SDLC practices.
-Starting with this release, the project provides a way to express any SDLC action through 3 phases: Plan, Build, and Operate. Software engineers can use this model in us...
+Starting with this release, the project introduces a simple way to describe any SDLC action through three phases: Plan, Build, and Operate. Software engineers can use th...
     <p></p>
     <a href="../blog/2026/06/release-0.16.0.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/commands.html
+++ b/docs/tags/commands.html
@@ -108,7 +108,7 @@
   <div class="post-entry">
     What is the purpose?
 An opinionated, AI-native development workflow for Java Enterprise: reusable Skills, Agents, Commands, and third-party MCP servers combined with a human-in-the-loop model to modernize real-world SDLC practices.
-Starting with this release, the project provides a way to express any SDLC action through 3 phases: Plan, Build, and Operate. Software engineers can use this model in us...
+Starting with this release, the project introduces a simple way to describe any SDLC action through three phases: Plan, Build, and Operate. Software engineers can use th...
     <p></p>
     <a href="../blog/2026/06/release-0.16.0.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/java.html
+++ b/docs/tags/java.html
@@ -108,7 +108,7 @@
   <div class="post-entry">
     What is the purpose?
 An opinionated, AI-native development workflow for Java Enterprise: reusable Skills, Agents, Commands, and third-party MCP servers combined with a human-in-the-loop model to modernize real-world SDLC practices.
-Starting with this release, the project provides a way to express any SDLC action through 3 phases: Plan, Build, and Operate. Software engineers can use this model in us...
+Starting with this release, the project introduces a simple way to describe any SDLC action through three phases: Plan, Build, and Operate. Software engineers can use th...
     <p></p>
     <a href="../blog/2026/06/release-0.16.0.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/regulations.html
+++ b/docs/tags/regulations.html
@@ -108,7 +108,7 @@
   <div class="post-entry">
     What is the purpose?
 An opinionated, AI-native development workflow for Java Enterprise: reusable Skills, Agents, Commands, and third-party MCP servers combined with a human-in-the-loop model to modernize real-world SDLC practices.
-Starting with this release, the project provides a way to express any SDLC action through 3 phases: Plan, Build, and Operate. Software engineers can use this model in us...
+Starting with this release, the project introduces a simple way to describe any SDLC action through three phases: Plan, Build, and Operate. Software engineers can use th...
     <p></p>
     <a href="../blog/2026/06/release-0.16.0.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/skills.html
+++ b/docs/tags/skills.html
@@ -108,7 +108,7 @@
   <div class="post-entry">
     What is the purpose?
 An opinionated, AI-native development workflow for Java Enterprise: reusable Skills, Agents, Commands, and third-party MCP servers combined with a human-in-the-loop model to modernize real-world SDLC practices.
-Starting with this release, the project provides a way to express any SDLC action through 3 phases: Plan, Build, and Operate. Software engineers can use this model in us...
+Starting with this release, the project introduces a simple way to describe any SDLC action through three phases: Plan, Build, and Operate. Software engineers can use th...
     <p></p>
     <a href="../blog/2026/06/release-0.16.0.html" class="post-read-more">[Read More]</a>
   </div>

--- a/site-generator/content/blog/2026/06/release-0.16.0.md
+++ b/site-generator/content/blog/2026/06/release-0.16.0.md
@@ -126,16 +126,16 @@ In other projects, you can find useful `Skills`, `Agents`, or `Commands`, but no
 
 The project has `106 skills` and uses [Skills.sh](https://www.skills.sh/jabrena/cursor-rules-java) as its main skill registry. It has served `11.0K` installs in total. These are the current top 10 skills used by users there:
 
-1. [`110-java-maven-best-practices`](https://www.skills.sh/jabrena/cursor-rules-java/110-java-maven-best-practices) - [maven](https://www.skills.sh/search?q=maven)
-2. [`121-java-object-oriented-design`](https://www.skills.sh/jabrena/cursor-rules-java/121-java-object-oriented-design) - [java object oriented](https://www.skills.sh/search?q=java%20object%20oriented)
-3. [`124-java-secure-coding`](https://www.skills.sh/jabrena/cursor-rules-java/124-java-secure-coding) - [java security](https://www.skills.sh/search?q=java%20security)
-4. [`131-java-testing-unit-testing`](https://www.skills.sh/jabrena/cursor-rules-java/131-java-testing-unit-testing) - [java unit testing](https://www.skills.sh/search?q=java%20unit%20testing)
-5. [`142-java-functional-programming`](https://www.skills.sh/jabrena/cursor-rules-java/142-java-functional-programming) - [java functional programming](https://www.skills.sh/search?q=java%20functional%20programming)
-6. [`128-java-generics`](https://www.skills.sh/jabrena/cursor-rules-java/128-java-generics) - [java generics](https://www.skills.sh/search?q=java%20generics)
-7. [`111-java-maven-dependencies`](https://www.skills.sh/jabrena/cursor-rules-java/111-java-maven-dependencies) - [maven](https://www.skills.sh/search?q=maven)
+1. [`110-java-maven-best-practices`](https://www.skills.sh/jabrena/cursor-rules-java/110-java-maven-best-practices) - search query: [maven](https://www.skills.sh/search?q=maven)
+2. [`121-java-object-oriented-design`](https://www.skills.sh/jabrena/cursor-rules-java/121-java-object-oriented-design) - search query: [java object oriented](https://www.skills.sh/search?q=java%20object%20oriented)
+3. [`124-java-secure-coding`](https://www.skills.sh/jabrena/cursor-rules-java/124-java-secure-coding) - search query: [java security](https://www.skills.sh/search?q=java%20security)
+4. [`131-java-testing-unit-testing`](https://www.skills.sh/jabrena/cursor-rules-java/131-java-testing-unit-testing) - search query: [java unit testing](https://www.skills.sh/search?q=java%20unit%20testing)
+5. [`142-java-functional-programming`](https://www.skills.sh/jabrena/cursor-rules-java/142-java-functional-programming) - search query: [java functional programming](https://www.skills.sh/search?q=java%20functional%20programming)
+6. [`128-java-generics`](https://www.skills.sh/jabrena/cursor-rules-java/128-java-generics) - search query: [java generics](https://www.skills.sh/search?q=java%20generics)
+7. [`111-java-maven-dependencies`](https://www.skills.sh/jabrena/cursor-rules-java/111-java-maven-dependencies) - search query: [maven](https://www.skills.sh/search?q=maven)
 8. [`141-java-refactoring-with-modern-features`](https://www.skills.sh/jabrena/cursor-rules-java/141-java-refactoring-with-modern-features)
-9. [`125-java-concurrency`](https://www.skills.sh/jabrena/cursor-rules-java/125-java-concurrency) - [java concurrency](https://www.skills.sh/search?q=java%20concurrency)
-10. [`143-java-functional-exception-handling`](https://www.skills.sh/jabrena/cursor-rules-java/143-java-functional-exception-handling) - [java functional programming](https://www.skills.sh/search?q=java%20functional%20programming)
+9. [`125-java-concurrency`](https://www.skills.sh/jabrena/cursor-rules-java/125-java-concurrency) - search query: [java concurrency](https://www.skills.sh/search?q=java%20concurrency)
+10. [`143-java-functional-exception-handling`](https://www.skills.sh/jabrena/cursor-rules-java/143-java-functional-exception-handling) - search query: [java functional programming](https://www.skills.sh/search?q=java%20functional%20programming)
 
 **What is your favorite `Skill` from this project?** You can share it here: https://github.com/jabrena/cursor-rules-java/discussions/804
 
@@ -155,7 +155,7 @@ That is useful, but it also means generated skills need a `zero trust` review mi
 
 The point is not to claim that a generated skill is perfect. The point is to make suspicious behavior visible before maintainers or users rely on it.
 
-Common risks include:
+Common skill risks include:
 
 - Prompt injection patterns
 - Data exfiltration instructions
@@ -169,21 +169,23 @@ Common risks include:
 - Untrusted content and indirect prompt injection
 - Tool poisoning and tool shadowing
 
+**Note:** The project runs an analysis for all skills on every commit using the tools described above. https://github.com/jabrena/cursor-rules-java/blob/main/.github/workflows/maven.yaml
+
 If you are interested in this kind of validation, I recommend reading the following article: [How to validate skills?](/cursor-rules-java/blog/2026/06/skill-validators-pipeline.html)
 
 ## Improving the approach to test the behavior of Agent Skills
 
 <a id="improving-the-approach-to-test-the-behavior-of-an-agent-skills"></a>
 
-All elements in this project change for different reasons, so it is necessary to invest time in the release process to ensure that they continue to add value for software engineers and AI agents running in pipelines.
+During the evolution of this project, files change over time for different reasons. After each change, it is necessary to validate them again, so the release process includes time to ensure they continue to add value for software engineers and AI agents running in pipelines.
 
-During this release, we ran a `Spike` to validate an improved testing process. We added `Gherkin` support for all skills created or updated in this release, reducing testing time and generating evidence for specific deterministic behaviors.
+During this release, we ran a `Spike` to validate an idea for improving the testing process. We added `Gherkin` support for all skills created or updated in this release, and the results were successful. Testing time was reduced, and more importantly, the project now generates evidence for specific deterministic behaviors from the skills under test.
 
 Let's review two examples to show the value of the new tests.
 
 ### Example to validate a skill
 
-All skills have an acceptance-test inventory, and it lives in `acceptance-tests-prompts-skills.md`. When a generated skill changes for any reason, it is now possible to run only the matching prompt for that changed skill. Let's review the scenario for `@111-java-maven-dependencies`.
+All skills have an acceptance-test inventory file, and it lives in `acceptance-tests-prompts-skills.md`. When a generated skill changes for any reason, it is now possible to run only the matching prompt for that changed skill. Let's review the scenario for `@111-java-maven-dependencies`.
 
 **@111-java-maven-dependencies:**
 
@@ -194,7 +196,7 @@ execute @skills-generator/src/test/resources/gherkin/skills/111-java-maven-depen
 and verify that acceptance-tests pass.
 ```
 
-You can run the following `Gherkin` file:
+That prompt is linked with the following `Gherkin` file:
 
 ```gherkin
 Feature: Validate changes from usage of Maven dependencies skill
@@ -220,15 +222,19 @@ Scenario: Add JSpecify and Error Prone + NullAway to Maven demo
   And any git changes produced during skill execution and verification are reset
 ```
 
-For this particular skill, the scenario fixes the example project, the selected dependency answers, the expected `pom.xml` changes, the expected `.mvn/jvm.config` changes, the validation command, the accepted compiler failure, and the cleanup expectation. The goal is not to test every possible conversation. The goal is to prove that the changed skill still follows its intended workflow against a stable fixture.
+For that particular skill, the scenario fixes the example project, the selected dependency answers, the expected `pom.xml` changes, the expected `.mvn/jvm.config` changes, the validation command, the accepted compiler failure, and the cleanup expectation. The goal is not to test every possible conversation. The goal is to prove that the changed skill still follows its intended workflow against a stable fixture. A `Gherkin` file cannot cover every possible use case, so it focuses on the most important ones.
 
-Let's review another, more complex scenario.
+> "Program testing can be used to show the presence of bugs, but never to show their absence!"
+>
+> - Edsger W. Dijkstra
+
+Let's review another, more complex scenario and one of the key features included in this release.
 
 ### Example to validate a command
 
-All commands have an acceptance-test inventory, and it lives in `acceptance-tests-prompts-skills.md`. When a generated command changes for any reason, it is now possible to run only the matching prompt for that changed command. Let's review the scenario for `@/implement-issue`.
+All commands have an acceptance-test inventory file, and it lives in `acceptance-tests-prompts-skills.md`. When a generated command changes for any reason, it is now possible to run only the matching prompt for that changed command. Let's review the scenario about the command `/implement-issue`.
 
-As an example, let's try to solve the first problem from the project `Latency problems`: https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md
+To demonstrate the new capabilities, let's try to solve the first problem from the project [`Latency problems`](https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md):
 
 ```bash
 # Problem 1
@@ -298,7 +304,7 @@ Scenario: Implement God Analysis API from a validated OpenSpec change
   And any git changes produced under "examples/openspec/god-analysis-api/demo" during command execution and verification are reset
 ```
 
-Under the hood, this `Gherkin` file triggers the following set of project elements, which can be located in `.agents/**` or in other locations depending on your preferred tool and installation method:
+When the prompt is executed, under the hood the `Gherkin` file triggers the agents and skills:
 
 ```
 Build
@@ -314,7 +320,7 @@ Build
       @robot-no-java
 ```
 
-In this case, the command internally uses the agent `@robot-tech-lead`, which redirects to the specific agent `@robot-java-spring-boot-coder` based on the analysis of the specification, and this is the result:
+In this case, the command internally uses the agent `@robot-tech-lead`, which redirects to the specific agent `@robot-java-spring-boot-coder` based on the analysis of the specification. That agent handles specific `Java skills` and specific `Spring Boot skills`. This is the result for a `Spring Boot` implementation:
 
 [![asciicast](https://asciinema.org/a/1257803.svg)](https://asciinema.org/a/1257803)
 
@@ -332,13 +338,13 @@ and verify that acceptance-tests pass.
 Implement it using Quarkus, not Spring Boot, as the default requirement.
 ```
 
-In this case, the agent `@robot-tech-lead` redirects the workload to the specific agent `@robot-java-quarkus-coder`:
+In this case, the agent `@robot-tech-lead` redirects the workload to the specific agent `@robot-java-quarkus-coder`, which handles specific `Java skills` and specific `Quarkus skills`. This is the result for a `Quarkus` implementation:
 
 [![asciicast](https://asciinema.org/a/1257861.svg)](https://asciinema.org/a/1257861)
 
 *Running the test with Codex CLI for the Quarkus variant*
 
-Or, if required, the agent `@robot-tech-lead` redirects to the specific agent `@robot-java-micronaut-coder`:
+Or, if required, the agent `@robot-tech-lead` redirects to the specific agent `@robot-java-micronaut-coder`, which handles specific `Java skills` and specific `Micronaut skills`. This is the result for a `Micronaut` implementation:
 
 ```bash
 execute @skills-generator/src/test/resources/gherkin/commands/implement-issue.feature
@@ -352,7 +358,7 @@ And the project will implement the feature without any issues:
 
 *Running the test with Codex CLI for the Micronaut variant*
 
-As you can see, one of the unique features of this project is the ability to implement requirements across multiple Java frameworks.
+**As you can see, one of the unique features of this project is the ability to implement requirements across multiple Java frameworks.** With this idea in mind, you can explore moving from one framework to another during a `Spike`, evaluate how complex the change is, identify which annotations change, and discover which features are framework-specific. If you have good tests, the journey becomes easier.
 
 ## Improving the way to install Agents and Commands
 

--- a/site-generator/content/blog/2026/06/release-0.16.0.md
+++ b/site-generator/content/blog/2026/06/release-0.16.0.md
@@ -10,7 +10,7 @@ status=published
 
 An opinionated, AI-native development workflow for Java Enterprise: reusable `Skills`, `Agents`, `Commands`, and third-party `MCP servers` combined with a human-in-the-loop model to modernize real-world SDLC practices.
 
-Starting with this release, the project provides a way to express any `SDLC` action through 3 phases: `Plan`, `Build`, and `Operate`. `Software engineers` can use this model in user interfaces or terminals when they write a `User prompt`.
+Starting with this release, the project introduces a simple way to describe any `SDLC` action through three phases: `Plan`, `Build`, and `Operate`. `Software engineers` can use this structure when writing a `User prompt` in an AI user interface or terminal.
 
 **Example:**
 
@@ -28,7 +28,7 @@ Build
       @robot-no-java
 ```
 
-We will go into more detail later, but first, let's review the features that have evolved since the last release:
+We will go into more detail later, but first, let's review the most interesting features added in this release:
 
 - [Enriching the workflow with Commands and Agents, not only Skills](#enriching-the-workflow-with-commands-and-agents-not-only-skills)
 - [What are the Top 10 Skills from this project in Skills.sh?](#what-are-the-top-10-skills-from-this-project-in-skillssh)
@@ -40,25 +40,24 @@ We will go into more detail later, but first, let's review the features that hav
 
 Thanks to our community members in `Singapore`, `Hong Kong`, `Hanoi`, `London`, and `New York`. 👋👋👋
 
+If you have questions about the project, how to customize it for your team, how to use the skills in daily work, or how to solve tooling issues, use [`GitHub Discussions`](https://github.com/jabrena/cursor-rules-java/discussions).
+
 **Help this project grow:** [If this project helps your team, become a sponsor.](https://github.com/sponsors/jabrena)
 
 ## Enriching the workflow with Commands and Agents, not only Skills
 
 <a id="enriching-the-workflow-with-commands-and-agents-not-only-skills"></a>
 
-The project started more than a year ago with a set of reusable `rules / system prompts`. They were useful because teams could point an AI assistant at a consistent body of engineering expectations instead of rewriting the same instructions for every conversation. But as documented in [`ADR-002`](https://github.com/jabrena/cursor-rules-java/blob/main/documentation/adr/ADR-002-configure-cursor-rules-manual-scope.md), automatic activation through broad `.java` frontmatter did not scale well: multiple rules could enter the context at the same time, increasing latency, consuming context, and making answers less deterministic. In 2026, with the rise of `Skills` and continued use of system prompts, evolving into `Skills` was a natural step. Release `0.16.0` moves further toward connected workflows. `Commands` become the entry points that a team can run. `Agents` become the role-specific workers that interpret the task. `Skills` become the reusable knowledge and procedures each agent applies.
+The project started more than a year ago with a set of reusable `rules / system prompts`. That approach worked well after removing the restriction that associated rules with particular files, as described in [`ADR-002`](https://github.com/jabrena/cursor-rules-java/blob/main/documentation/adr/ADR-002-configure-cursor-rules-manual-scope.md). With the rise of `Skills`, it was a good decision to convert that material into skills and use the new capabilities provided by `Skill registries` like [https://www.skills.sh/](https://www.skills.sh/) and other registries.
 
-In practice, the operating model now looks like this:
-
-```text
-Command -> Agent -> Skills -> Change in your repository
-```
+In this release, we go further by adding new semantics for expressing the actions a software engineer performs while solving a problem.
 
 That model is organized around three delivery paths:
 
 ```text
 Plan
   /create-issue
+  /update-issue
     @robot-business-analyst
       @043-planning-github-issues
       @044-planning-jira
@@ -105,7 +104,19 @@ Operate
       @152-java-performance-gatling
 ```
 
-In coming releases, this model will be expanded in different ways, but its pillars are established in this release.
+Of course, you can continue using the project in the classic way: add the Java class and a particular skill to the context, or describe the action in natural language and let the `AI agent harness tools` trigger the right skill. However, combining commands with agents and skills gives you more benefits.
+
+**Example:**
+
+```bash
+Create AGENTS.md #It will trigger the skill @200-agents-md
+/update-issue from github #xxx and use User Story format.
+/create-spec using ideas from github issue #xxx
+/review-alignment between the issue #xxx and the change #yyy
+/implement-issue based on OpenSpec change #yyy
+```
+
+In coming releases, this model will be enriched in different ways, but its pillars are established in this release.
 
 In other projects, you can find useful `Skills`, `Agents`, or `Commands`, but not always a fully connected workflow designed with `Java` in mind.
 
@@ -126,7 +137,7 @@ The project has `106 skills` and uses [Skills.sh](https://www.skills.sh/jabrena/
 9. [`125-java-concurrency`](https://www.skills.sh/jabrena/cursor-rules-java/125-java-concurrency) - [java concurrency](https://www.skills.sh/search?q=java%20concurrency)
 10. [`143-java-functional-exception-handling`](https://www.skills.sh/jabrena/cursor-rules-java/143-java-functional-exception-handling) - [java functional programming](https://www.skills.sh/search?q=java%20functional%20programming)
 
-**What is your favorite `Skill` from this project?** You could share it here: https://github.com/jabrena/cursor-rules-java/discussions/804
+**What is your favorite `Skill` from this project?** You can share it here: https://github.com/jabrena/cursor-rules-java/discussions/804
 
 ## Applying Zero Trust with your Agent skills
 
@@ -164,11 +175,11 @@ If you are interested in this kind of validation, I recommend reading the follow
 
 <a id="improving-the-approach-to-test-the-behavior-of-an-agent-skills"></a>
 
-All elements in this project change for different reasons, so it is necessary to invest time in the release process to ensure that they continue adding value for software engineers and AI agents running in pipelines.
+All elements in this project change for different reasons, so it is necessary to invest time in the release process to ensure that they continue to add value for software engineers and AI agents running in pipelines.
 
 During this release, we ran a `Spike` to validate an improved testing process. We added `Gherkin` support for all skills created or updated in this release, reducing testing time and generating evidence for specific deterministic behaviors.
 
-Let's review 2 examples to show the value of the new tests.
+Let's review two examples to show the value of the new tests.
 
 ### Example to validate a skill
 
@@ -217,7 +228,7 @@ Let's review another, more complex scenario.
 
 All commands have an acceptance-test inventory, and it lives in `acceptance-tests-prompts-skills.md`. When a generated command changes for any reason, it is now possible to run only the matching prompt for that changed command. Let's review the scenario for `@/implement-issue`.
 
-As example, lets try to solve the first problem from the project `Latency problems:` https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md
+As an example, let's try to solve the first problem from the project `Latency problems`: https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md
 
 ```bash
 # Problem 1
@@ -240,7 +251,7 @@ As example, lets try to solve the first problem from the project `Latency proble
   - Nordic API: https://my-json-server.typicode.com/jabrena/latency-problems/nordic
 ```
 
-Given this `User story` and the `OpenSpec` change defined here: https://github.com/jabrena/cursor-rules-java/tree/main/examples/openspec you could be able to implement using the new command `/implement-issue`. Lets see how to do it and how to validate it.
+Given this `User story` and the `OpenSpec` change defined here: https://github.com/jabrena/cursor-rules-java/tree/main/examples/openspec, you can implement it using the new `/implement-issue` command. Let's see how to do it and how to validate it.
 
 **/implement-issue:**
 
@@ -303,7 +314,7 @@ Build
       @robot-no-java
 ```
 
-In this case, the command internally uses the agent `@robot-tech-lead`, which redirects to the specific agent `@robot-java-spring-boot-coder` based on the analysis of the specification and this is the result:
+In this case, the command internally uses the agent `@robot-tech-lead`, which redirects to the specific agent `@robot-java-spring-boot-coder` based on the analysis of the specification, and this is the result:
 
 [![asciicast](https://asciinema.org/a/1257803.svg)](https://asciinema.org/a/1257803)
 
@@ -313,7 +324,7 @@ In this case, the command internally uses the agent `@robot-tech-lead`, which re
 
 *Running the test with VS Code + Codex plugin*
 
-But if you refine a bit the prompt, you could implement the requirement in `Quarkus`:
+But if you refine the prompt a bit, you can implement the requirement in `Quarkus`:
 
 ```bash
 execute @skills-generator/src/test/resources/gherkin/commands/implement-issue.feature
@@ -335,21 +346,21 @@ and verify that acceptance-tests pass.
 Implement it using Micronaut, not Spring Boot, as the default requirement.
 ```
 
-And the project will implement the feature without any issue:
+And the project will implement the feature without any issues:
 
 [![asciicast](https://asciinema.org/a/1258091.svg)](https://asciinema.org/a/1258091)
 
 *Running the test with Codex CLI for the Micronaut variant*
 
-So, it you observe one of the unique features from this project is the capacity to implement requirements in multiple Java frameworks.
+As you can see, one of the unique features of this project is the ability to implement requirements across multiple Java frameworks.
 
 ## Improving the way to install Agents and Commands
 
 <a id="improving-the-way-to-install-agents-and-commands"></a>
 
-With the rise of `Skills`, there is a need for public registries for them. But what happens with `Agents`, `Commands`, or other files? The reality is that `Agents` and `Commands` are often treated as second-class citizens.
+With the rise of `Skills`, there is a need for public registries for them. But what happens to `Agents`, `Commands`, or other files? The reality is that `Agents` and `Commands` are often treated as second-class citizens.
 
-To take advantage of the public registry and the process for generating skills from `XML` sources, it is relatively easy to embed commands and agents in a `Meta Skill`. Once you have installed the skills, you can see the following inventory and installation workflows:
+To take advantage of the public registry and the process for generating skills from `XML` sources, it is relatively easy to embed commands and agents in a `Meta Skill`. Once you have installed the skills, you can use the following inventory and installation workflows:
 
 - [`@001-commands-inventory`](https://www.skills.sh/jabrena/cursor-rules-java/001-commands-inventory)
 - [`@002-agents-inventory`](https://www.skills.sh/jabrena/cursor-rules-java/002-agents-inventory)

--- a/site-generator/content/blog/2026/06/release-0.16.0.md
+++ b/site-generator/content/blog/2026/06/release-0.16.0.md
@@ -116,7 +116,7 @@ Create AGENTS.md #It will trigger the skill @200-agents-md
 /implement-issue based on OpenSpec change #yyy
 ```
 
-In coming releases, this model will be enriched in different ways, but its pillars are established in this release.
+In upcoming releases, this model will be enriched in different ways, but its pillars are established in this release.
 
 In other projects, you can find useful `Skills`, `Agents`, or `Commands`, but not always a fully connected workflow designed with `Java` in mind.
 
@@ -360,6 +360,8 @@ And the project will implement the feature without any issues:
 
 **As you can see, one of the unique features of this project is the ability to implement requirements across multiple Java frameworks.** With this idea in mind, you can explore moving from one framework to another during a `Spike`, evaluate how complex the change is, identify which annotations change, and discover which features are framework-specific. If you have good tests, the journey becomes easier.
 
+Another benefit discovered through this new testing approach is that by following the test execution, we can find issues with skills and reinforce them after each test run. One example is the lack of support for `Mongock` in `Spring Boot 4.0.x`, but now the skill is able to provide a workaround, consistent with the solutions for `Quarkus` and `Micronaut`.
+
 ## Improving the way to install Agents and Commands
 
 <a id="improving-the-way-to-install-agents-and-commands"></a>
@@ -375,6 +377,17 @@ To take advantage of the public registry and the process for generating skills f
 - [`@005-agents-installation`](https://www.skills.sh/jabrena/cursor-rules-java/005-agents-installation)
 
 Then you can use them to install assets or generate the inventory files.
+
+**Example:**
+
+```bash
+install @004-commands-installation cursor
+install @004-commands-installation claude-code
+install @004-commands-installation codex
+install @004-commands-installation github-copilot
+```
+
+**Note:** It is a good practice after releasing a new version to download all `Skills` and then install the `Agents` and `Commands` aligned.
 
 ## New capabilities for Java Enterprise Frameworks
 
@@ -461,7 +474,7 @@ This becomes even more important with GenAI tooling. When prompts, embeddings, g
 - [`@807-regulations-eu-digital-services-act`](https://www.skills.sh/jabrena/cursor-rules-java/807-regulations-eu-digital-services-act)
 - [`@808-regulations-eu-digital-markets-act`](https://www.skills.sh/jabrena/cursor-rules-java/808-regulations-eu-digital-markets-act)
 
-These skills are engineering review aids. _They do not provide legal advice and they do not replace qualified legal, compliance, privacy, security, risk, product, or governance owners._
+These skills are engineering review aids. **_They do not provide legal advice and they do not replace qualified legal, compliance, privacy, security, risk, product, or governance owners._**
 
 For distributed systems using GenAI tools, a practical review set is:
 
@@ -483,8 +496,9 @@ The next phase is already visible in the [`v0.17.0` milestone](https://github.co
 Functionally, the next workstreams are:
 
 - Expand executable acceptance coverage for `Skills`, `Agents`, and `Commands`, so important behavior is checked with stable `Gherkin` scenarios instead of relying only on package shape or manual review.
-- Add LLM engineering references such as `Karpathy's LLM Wiki`, so agent and skill guidance can stay closer to widely used mental models for building with language models.
-- Improve analysis methods, including `the hamburger method` and `the two-step method`, so discovery work can become more structured before teams generate ADRs, specs, plans, or implementation tasks.
+- Improve analysis methods, including [`the hamburger method`](https://gojko.net/2012/01/23/splitting-user-stories-the-hamburger-method/) from [Gojko Adzic](https://gojko.net/about/) and [`the two-step method`](https://newsletter.kentbeck.com/p/mastering-programming) from [Kent Beck](https://kentbeck.com/), so discovery work can become more structured before teams generate ADRs, Specs or implementation tasks.
+- Improve a few references with fewer examples and add more triggers to increase auto-discovery.
+- Add new capabilities such as [`Karpathy's LLM Wiki`](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f); when analyzing a particular feature, take into consideration other aspects of the whole distributed system.
 - Extend Maven guidance with `JavaMoney` support in the Maven plugin workflow, improving how teams introduce money and currency handling into enterprise builds.
 - Complete the `EU regulation` review family, so teams can map distributed-system and `GenAI` decisions against a broader set of engineering evidence patterns.
 


### PR DESCRIPTION
## Summary
- Polish grammar and wording in the 0.16.0 release blog post
- Add GitHub Discussions guidance for project, customization, usage, and tooling questions
- Regenerate the derived GitHub Pages output under docs/

## Validation
- ./mvnw generate-resources -pl site-generator -P site-update

Note: ./mvnw clean generate-resources -pl site-generator -P site-update failed because macOS had site-generator/target/docs-local open, preventing the clean phase from deleting it. The generation-only command completed successfully.