### PR TITLE
chore(maven): bump project version to 0.17.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>info.jab</groupId>
     <artifactId>cursor-rules-java</artifactId>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>cursor-rules-java</name>
     <description>A curated collection of Skills and Agents to be used in modern SDLC workflows for Java Enterprise development.</description>

--- a/site-generator/pom.xml
+++ b/site-generator/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>info.jab</groupId>
         <artifactId>cursor-rules-java</artifactId>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/skills-generator/pom.xml
+++ b/skills-generator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>info.jab</groupId>
         <artifactId>cursor-rules-java</artifactId>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/skills-generator/src/main/resources/skill-indexes/001-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/001-skill.xml
@@ -4,7 +4,7 @@
       id="001-commands-inventory">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to generate a checklist document with embedded commands inventory, following the embedded template exactly and producing INVENTORY-COMMANDS-JAVA.md in the project root. This should trigger for requests such as Create embedded commands inventory checklist; Generate INVENTORY-COMMANDS-JAVA.md; Use @001-commands-inventory.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/002-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/002-skill.xml
@@ -4,7 +4,7 @@
       id="002-agents-inventory">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to generate a checklist document with embedded agents inventory, following the embedded template exactly and producing INVENTORY-AGENTS-JAVA.md in the project root. This should trigger for requests such as Create embedded agents inventory checklist; Generate INVENTORY-AGENTS-JAVA.md; Use @002-agents-inventory.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/003-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/003-skill.xml
@@ -4,7 +4,7 @@
       id="003-skills-inventory">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to generate a checklist document with Java system prompts from skills.xml, following the embedded section template and producing INVENTORY-SKILLS-JAVA.md. This should trigger for requests such as Create Java system prompts checklist; Generate INVENTORY-SKILLS-JAVA.md; Use @003-skills-inventory.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/004-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/004-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to install the embedded project commands into command directories (.github/commands, .claude/commands, .cursor/command, .codex/commands), selecting the destination interactively and copying the embedded command definitions from project assets. This should trigger for requests such as Install embedded commands; Bootstrap .cursor/command; Bootstrap .claude/commands; Copy project commands; Install project command suite.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/005-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/005-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to install the embedded robot agents into either .cursor/agents or .claude/agents, selecting the destination interactively and copying the embedded agent definitions from project assets. This should trigger for requests such as Install embedded agents; Bootstrap .cursor/agents; Bootstrap .claude/agents; Copy robot agents.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/012-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/012-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Guides the creation of agile epics with comprehensive definition including business value, success criteria, and breakdown into user stories. Use when the user wants to create an agile epic, define large bodies of work, break down features into user stories, or document strategic initiatives. This should trigger for requests such as Create an agile epic; Write an epic; I need to create an epic; Define an epic; Epic definition.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/013-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/013-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Guides the creation of detailed agile feature documentation from an existing epic. Use when the user wants to split an epic into feature files, derive features with scope and acceptance criteria, or plan feature documentation for stakeholders or engineering. This should trigger for requests such as Create features from an epic; Split epic into features; Feature files from epic; Derive features from epic.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/014-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/014-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Guides the creation of agile user stories and Gherkin feature files. Use when the user wants to create a user story, write acceptance criteria, define Gherkin scenarios, or author BDD feature files. This should trigger for requests such as Create a user story; Write a user story; I need to write a user story.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/030-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/030-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to generate Architecture Decision Records (ADRs) for a Java project through an interactive, conversational process that systematically gathers context, stakeholders, options, and outcomes to produce well-structured ADR documents. This should trigger for requests such as Generate ADR; Create Architecture Decision Record; Document architecture decision; Architecture Decision Record for Java.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/031-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/031-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Facilitates conversational discovery to create Architectural Decision Records (ADRs) for functional requirements covering CLI, REST/HTTP APIs, or both. Use when the user wants to document command-line or HTTP service architecture, capture functional requirements, create ADRs for CLI or API projects, or design interfaces with documented decisions. This should trigger for requests such as Create ADR for functional requirements; Document functional requirements; Capture functional requirements; Generate functional requirements in an ADR.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/032-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/032-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Facilitates conversational discovery to create Architectural Decision Records (ADRs) for non-functional requirements using the ISO/IEC 25010:2023 quality model. Use when the user wants to document quality attributes, NFR decisions, security/performance/scalability architecture, or design systems with measurable quality criteria. This should trigger for requests such as Create ADR for Non-functional requirements; Document Non-functional requirements; Capture Non-functional requirements; Generate Non-functional requirements in an ADR.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/033-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/033-skill.xml
@@ -6,7 +6,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to generate Java project diagrams — including UML sequence diagrams, UML class diagrams, C4 model diagrams, UML state machine diagrams, UML Deployment Diagrams, ER (Entity Relationship) diagrams, and bounded-context diagrams — through a modular, step-based interactive process that adapts to your specific visualization needs. This should trigger for requests such as Generate UML diagram; Create sequence diagram; Create class diagram; Create state machine diagram; Create deployment diagram; Create C4 diagram; Create bounded-context diagram; Create context-map diagram.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/034-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/034-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when a sanitized issue summary, requirement summary, or design brief needs technical design exploration before creating ADRs, specifications, or implementation plans. This skill inspects repository context, clarifies material ambiguity, compares feasible approaches and trade-offs, recommends a direction, obtains approval, and identifies ADR candidates. This should trigger for requests such as Explore a design; Compare implementation approaches; Recommend an architecture direction; Clarify technical options before planning.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/041-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/041-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when creating or refining a structured Java implementation plan from trusted issue summaries, approved designs, ADRs, OpenSpec changes, existing plans, or a valid combination. The plan records its source artifacts and derivation direction and can remain the execution artifact without requiring OpenSpec. This should trigger for requests such as Create a plan from an issue; Create a plan from OpenSpec; Design an implementation plan; Refine an existing plan.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/042-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/042-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when creating or updating OpenSpec change artifacts from an issue, implementation plan, approved design, ADRs, existing OpenSpec artifacts, or a valid combination. The workflow assesses whether the scope is one change or multiple changes, records sources and derivation direction, and prevents silent synchronization. This should trigger for requests such as Create an OpenSpec change from an issue; Convert a plan into OpenSpec; Update an existing OpenSpec change; Split broad requirements into reviewable OpenSpec changes.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/043-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/043-skill.xml
@@ -4,7 +4,7 @@
       id="043-planning-github-issues">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need GitHub CLI (`gh`) installation/authentication guidance and a sanitized GitHub issue inventory workflow. The agent does not ingest GitHub issue or milestone output directly; it asks the user for sanitized issue summaries before analysis or @014-agile-user-story handoff. This should trigger for requests such as GitHub issue summary workflow; GitHub CLI setup for issues; Prepare sanitized GitHub issue inventory.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/044-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/044-skill.xml
@@ -4,7 +4,7 @@
       id="044-planning-jira">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need the Jira CLI (`jira`) to verify installation, configure Jira Cloud access, list issues (all or by JQL) as markdown tables, and analyze user-provided sanitized Jira summaries. Uses an interactive install gate - if `jira` is missing, ask whether to show installation guidance before any issue commands. This should trigger for requests such as jira issue list; List Jira issues; Jira JQL issue query; Jira CLI issue workflow.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/110-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/110-skill.xml
@@ -4,7 +4,7 @@
       id="110-java-maven-best-practices">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to review, improve, or troubleshoot a Maven pom.xml file — including dependency management with BOMs, plugin configuration, version centralization, multi-module project structure, build profiles, or any situation where you want to align your Maven setup with industry best practices. This should trigger for requests such as Review pom.xml to improve it; Apply Maven best practices to pom.xml; Improve Maven POM configuration.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/111-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/111-skill.xml
@@ -6,7 +6,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or evaluate Maven dependencies that improve code quality — including nullness annotations (JSpecify), static analysis (Error Prone + NullAway), functional programming (VAVR), or architecture testing (ArchUnit) — and want a consultative, question-driven approach that adds only what you actually need. This should trigger for requests such as Add Maven dependencies; Add JSpecify nullness dependencies; Add Error Prone NullAway dependencies; Add VAVR functional dependencies; Add ArchUnit architecture testing dependencies.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/112-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/112-skill.xml
@@ -6,7 +6,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or configure Maven plugins in your pom.xml — including quality tools (enforcer, surefire, failsafe, jacoco, pitest, spotbugs, pmd), security scanning (OWASP), code formatting (Spotless), version management, container image build (Jib), build information tracking, and benchmarking (JMH) — through a consultative, modular step-by-step approach that only adds what you actually need. This should trigger for requests such as Add Maven plugins in pom.xml; Improve Maven plugins in pom.xml.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/113-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/113-skill.xml
@@ -4,7 +4,7 @@
       id="113-java-maven-documentation">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to create a DEVELOPER.md file for a Maven project — combining a fixed base template with dynamic sections derived from the project pom.xml, including a Plugin Goals Reference, Maven Profiles table, and Submodules table for multi-module projects. This should trigger for requests such as Create DEVELOPER.md; Generate DEVELOPER.md; Maven project documentation; Add Maven documentation; Plugin goals reference.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/114-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/114-skill.xml
@@ -4,7 +4,7 @@
       id="114-java-maven-search">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Covers Maven Central search using structured Search API fields and URL construction, plus project-local update report guidance for user-provided Versions Maven Plugin output. Use when finding or verifying coordinates or interpreting update reports for the user’s pom.xml. This should trigger for requests such as Search Maven Central; Find Maven dependency; Maven coordinates; groupId artifactId version.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/121-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/121-skill.xml
@@ -4,7 +4,7 @@
       id="121-java-object-oriented-design">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, improving, or refactoring Java object-oriented design, including applying SOLID, DRY, or YAGNI; improving classes and interfaces; correcting encapsulation, inheritance, or polymorphism; resolving God Class, Feature Envy, or Data Clumps; and improving object creation, methods, or exception contracts. Triggers include review Java OOD, refactor Java OOD, improve Java OOD, fix OOP misuse, and identify Java code smells.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/122-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/122-skill.xml
@@ -4,7 +4,7 @@
       id="122-java-type-design">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to review, improve, or refactor Java code for type design quality — including establishing clear type hierarchies, applying consistent naming conventions, eliminating primitive obsession with domain-specific value objects, leveraging generic type parameters, creating type-safe wrappers, designing fluent interfaces, ensuring precision-appropriate numeric types (BigDecimal for financial calculations), and improving type contrast through interfaces and method signature alignment. This should trigger for requests such as Review Java code for type design; Improve type design in Java code; Fix primitive obsession in Java code; Create value objects in Java code.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/123-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/123-skill.xml
@@ -4,7 +4,7 @@
       id="123-java-design-patterns">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to select, review, or implement Java design and integration patterns — including classic Java design patterns, REST API patterns, Kafka and event-driven patterns, database and persistence patterns, and cross-cutting integration patterns. This should trigger for requests such as Apply Java design patterns; Review REST API patterns; Design Kafka event-driven patterns; Improve database persistence patterns; Add resilient integration patterns.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/124-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/124-skill.xml
@@ -4,7 +4,7 @@
       id="124-java-secure-coding">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to apply Java secure coding best practices — including validating untrusted inputs, defending against injection attacks with parameterized queries, minimizing attack surface via least privilege, applying strong cryptographic algorithms, handling exceptions securely without exposing sensitive data, managing secrets at runtime, avoiding unsafe deserialization, and encoding output to prevent XSS. This should trigger for requests such as Review Java code for secure coding.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/125-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/125-skill.xml
@@ -4,7 +4,7 @@
       id="125-java-concurrency">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to apply Java concurrency best practices — including thread safety fundamentals, ExecutorService thread pool management, concurrent design patterns like Producer-Consumer, asynchronous programming with CompletableFuture, immutability and safe publication, deadlock avoidance, virtual threads, structured concurrency, scoped values, backpressure, cancellation discipline, and observability for concurrent systems. This should trigger for requests such as Review Java code for concurrency.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/126-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/126-skill.xml
@@ -4,7 +4,7 @@
       id="126-java-exception-handling">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to apply Java exception handling best practices — including using specific exception types, managing resources with try-with-resources, securing exception messages, preserving error context via exception chaining, validating inputs early with fail-fast principles, handling thread interruption correctly, documenting exceptions with @throws, enforcing logging policy, translating exceptions at API boundaries, managing retries and idempotency, enforcing timeouts, attaching suppressed exceptions, and propagating failures in async/reactive code. This should trigger for requests such as Exception handling; Use try-with-resources in Java code; Create exception chaining in Java code; Apply fail-fast validation in Java code.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/128-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/128-skill.xml
@@ -4,7 +4,7 @@
       id="128-java-generics">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to review, improve, or refactor Java code for generics quality — including avoiding raw types, applying the PECS (Producer Extends Consumer Super) principle for wildcards, using bounded type parameters, designing effective generic methods, leveraging the diamond operator, understanding type erasure implications, handling generic inheritance correctly, preventing heap pollution with @SafeVarargs, and integrating generics with modern Java features like Records, sealed types, and pattern matching. This should trigger for requests such as Improve the code with Generics; Apply Generics; Refactor the code with Generics.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/130-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/130-skill.xml
@@ -4,7 +4,7 @@
       id="130-java-testing-strategies">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to apply testing strategies for Java code — RIGHT-BICEP to guide test creation, A-TRIP for test quality characteristics, or CORRECT for verifying boundary conditions. This should trigger for requests such as Review Java code for testing strategies; Apply RIGHT-BICEP testing strategies in Java code; Apply A-TRIP testing strategies in Java code; Apply CORRECT boundary condition verification in Java code.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/131-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/131-skill.xml
@@ -4,7 +4,7 @@
       id="131-java-testing-unit-testing">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to review, improve, or write Java unit tests — including migrating from JUnit 4 to JUnit 5, adopting AssertJ for fluent assertions, structuring tests with Given-When-Then, ensuring test independence, applying parameterized tests, mocking dependencies with Mockito, verifying boundary conditions (RIGHT-BICEP, CORRECT, A-TRIP), leveraging JSpecify null-safety annotations, or eliminating testing anti-patterns such as reflection-based tests or shared mutable state. This should trigger for requests such as Review Java code for unit tests; Apply best practices for unit tests in Java code.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/132-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/132-skill.xml
@@ -4,7 +4,7 @@
       id="132-java-testing-integration-testing">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to set up, review, or improve Java integration tests — including generating a BaseIntegrationTest.java with WireMock for HTTP stubs, detecting HTTP client infrastructure from import signals, injecting service coordinates dynamically via System.setProperty(), creating WireMock JSON mapping files with bodyFileName, isolating stubs per test method, verifying HTTP interactions, or eliminating anti-patterns such as Mockito-mocked HTTP clients or globally registered WireMock stubs. This should trigger for requests such as Review Java code for integration tests; Apply best practices for integration tests in Java code.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/133-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/133-skill.xml
@@ -4,7 +4,7 @@
       id="133-java-testing-acceptance-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to implement acceptance tests from maintainer-sanitized Gherkin scenario facts for framework-agnostic Java (no Spring Boot, Quarkus, Micronaut) — finding @acceptance scenarios, happy path with RestAssured, project-local DB/Kafka test fixtures, and WireMock for external REST. This should trigger for requests such as Review Java code for acceptance tests; Apply best practices for acceptance tests in Java code.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/141-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/141-skill.xml
@@ -4,7 +4,7 @@
       id="141-java-refactoring-with-modern-features">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to refactor Java code to adopt modern Java features (Java 8+) — including migrating anonymous classes to lambdas, replacing Iterator loops with Stream API, adopting Optional for null safety, switching from legacy Date/Calendar to java.time, using collection factory methods, applying text blocks, var inference, or leveraging Java 25 features like flexible constructor bodies and module import declarations. This should trigger for requests such as Review Java code for modern Java development; Apply best practices for modern Java development in Java code.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/142-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/142-skill.xml
@@ -4,7 +4,7 @@
       id="142-java-functional-programming">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to apply functional programming principles in Java — including writing immutable objects and Records, pure functions, functional interfaces, lambda expressions, Stream API pipelines, Optional for null safety, function composition, higher-order functions, pattern matching for instanceof and switch, sealed classes/interfaces for controlled hierarchies, Stream Gatherers for custom operations, currying/partial application, effect boundary separation, and concurrent-safe functional patterns. This should trigger for requests such as Improve the code with Functional Programming; Apply Functional Programming; Refactor the code with Functional Programming.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/143-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/143-skill.xml
@@ -4,7 +4,7 @@
       id="143-java-functional-exception-handling">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to apply functional exception handling best practices in Java — including replacing exception overuse with Optional and VAVR Either types, designing error type hierarchies using sealed classes and enums, implementing monadic error composition pipelines, establishing functional control flow patterns, and reserving exceptions only for truly exceptional system-level failures. This should trigger for requests such as Improve the code with Functional Exception Handling; Apply Functional Exception Handling; Refactor the code with Functional Exception Handling.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/144-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/144-skill.xml
@@ -4,7 +4,7 @@
       id="144-java-data-oriented-programming">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to apply data-oriented programming best practices in Java — including separating code (behavior) from data structures using records, designing immutable data with pure transformation functions, keeping data flat and denormalized with ID-based references, starting with generic data structures converting to specific types when needed, ensuring data integrity through pure validation functions, and creating flexible generic data access layers. This should trigger for requests such as Improve the code with Data-Oriented Programming; Apply Data-Oriented Programming; Refactor the code with Data-Oriented Programming; Apply Data-Oriented Programming; Refactor the code with Data-Oriented Programming.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/145-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/145-skill.xml
@@ -4,7 +4,7 @@
       id="145-java-refactoring-high-performance">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to refactor Java code for high performance — including memory/allocation reduction, CPU hot-path optimization, and syntax/API/control-flow improvements. This should trigger for requests such as Review Java code for high performance; Optimize Java hot path; Reduce Java allocations; Improve Java latency/throughput.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/151-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/151-skill.xml
@@ -4,7 +4,7 @@
       id="151-java-performance-jmeter">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to set up JMeter performance testing for a Java project — including creating the run-jmeter.sh script from the exact template, configuring load tests with loops, threads, and ramp-up, or running performance tests from the project root with custom or default settings. This should trigger for requests such as Improve the code with JMeter performance testing; Apply JMeter performance testing; Refactor the code with JMeter performance testing; Add JMeter support.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/152-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/152-skill.xml
@@ -4,7 +4,7 @@
       id="152-java-performance-gatling">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to set up Gatling performance testing for a Java Maven project — including adding Gatling dependencies and the Gatling Maven plugin, creating Java simulations, running gatling:test, configuring a simulation class, and reviewing generated reports. This should trigger for requests such as Add Gatling performance testing; Apply Gatling performance testing; Create a Gatling simulation; Add Gatling support.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/161-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/161-skill.xml
@@ -4,7 +4,7 @@
       id="161-java-profiling-detect">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to set up Java application profiling to detect and measure performance issues — including trusted preinstalled async-profiler v4.x setup, problem-driven profiling (CPU, memory, threading, GC, I/O), interactive profiling scripts, JFR integration with Java 25 (JEP 518, JEP 520), or collecting profiling data with flamegraphs and JFR recordings. This should trigger for requests such as Improve the code with profiling; Apply Profiling; Refactor the code with profiling; Add profiling support.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/162-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/162-skill.xml
@@ -4,7 +4,7 @@
       id="162-java-profiling-analyze">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to analyze Java profiling data collected during the detection phase — including interpreting flamegraphs, memory allocation patterns, CPU hotspots, threading issues, systematic problem categorization, evidence documentation with profiling-problem-analysis and profiling-solutions markdown files, or prioritizing fixes using Impact/Effort scoring. This should trigger for requests such as Analyze JFR profile; Analyze the profile; Analyze the performance; Analyze the memory.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/163-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/163-skill.xml
@@ -4,7 +4,7 @@
       id="163-java-profiling-refactor">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to refactor Java code based on profiling analysis findings — including reviewing docs/profiling-problem-analysis and docs/profiling-solutions, identifying specific performance bottlenecks, and implementing targeted code changes to address CPU, memory, or threading issues. This should trigger for requests such as Refactor the code with profiling; Apply profiling; Refactor the code with profiling; Optimize hot path.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/164-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/164-skill.xml
@@ -4,7 +4,7 @@
       id="164-java-profiling-verify">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to verify Java performance optimizations by comparing profiling results before and after refactoring — including baseline validation, post-refactoring report generation, quantitative before/after metrics comparison, side-by-side flamegraph analysis, regression detection, or creating profiling-comparison-analysis and profiling-final-results documentation. This should trigger for requests such as Verify performance fix; Verify the performance; Verify the memory; Verify the threading.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/170-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/170-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to generate or improve Java project documentation — including README.md files, package-info.java files, and Javadoc enhancements — through a modular, step-based interactive process that adapts to your specific documentation needs. This should trigger for requests such as Improve the code with documentation; Apply documentation; Refactor the code with documentation.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/181-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/181-skill.xml
@@ -4,7 +4,7 @@
       id="181-java-observability-logging">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to implement or improve Java logging and observability — including selecting SLF4J with Logback/Log4j2, applying proper log levels (ERROR, WARN, INFO, DEBUG, TRACE), parameterized logging, correlation context, secure logging without sensitive data exposure, environment-specific configuration, log aggregation, monitoring, and alerting. This should trigger for requests such as Improve logging; Apply logging; Refactor logging; Add logging support.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/182-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/182-skill.xml
@@ -4,7 +4,7 @@
       id="182-java-observability-metrics-micrometer">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to implement or improve Java metrics observability with Micrometer — including meter design, naming/tag conventions, cardinality control, timers/counters/gauges/distribution summaries, percentiles/histograms, Actuator/Prometheus integration, and metrics validation through tests. This should trigger for requests such as Improve metrics; Apply Micrometer; Add metrics observability; Refactor Micrometer instrumentation.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/183-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/183-skill.xml
@@ -4,7 +4,7 @@
       id="183-java-observability-tracing-opentelemetry">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to implement or improve distributed tracing with OpenTelemetry in Java — including trace/span modeling, context propagation, semantic conventions, span attributes/events/status, sampling strategy, baggage usage, privacy safeguards, and backend integration with OTLP collectors. This should trigger for requests such as Improve tracing; Apply OpenTelemetry tracing; Add distributed tracing; Refactor tracing instrumentation.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/200-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/200-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to generate an AGENTS.md file for a Java repository — covering project conventions, tech stack, file structure, commands, Git workflow, and contributor boundaries — through a modular, step-based interactive process that adapts to your specific project needs. This should trigger for requests such as Create AGENTS.md; Update AGENTS.md file; Add agent instructions.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/300-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/300-skill.xml
@@ -4,7 +4,7 @@
       id="300-frameworks-spring-boot-create-project">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to create a new Maven-based Spring Boot 4.0.x project using SDKMAN-managed Java and Spring Boot CLI tooling. This should trigger for requests such as Create a Spring Boot Maven project; Bootstrap Spring Boot project with SDKMAN; Generate a new Spring Boot service.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/301-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/301-skill.xml
@@ -4,7 +4,7 @@
       id="301-frameworks-spring-boot-core">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to review, improve, or build Spring Boot 4.0.x applications — including proper usage of @SpringBootApplication, component annotations (@Controller, @Service, @Repository), bean definition and scoping, configuration classes and @ConfigurationProperties (with @Validated), component scanning, conditional configuration and profiles, constructor injection, @Primary and @Qualifier for multiple beans of the same type, bean minimization, graceful shutdown, virtual threads, Jakarta EE namespace consistency, and scheduled tasks. This should trigger for requests such as Review Java code for Spring Boot application; Apply best practices for Spring Boot application in Java code.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/302-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/302-skill.xml
@@ -4,7 +4,7 @@
       id="302-frameworks-spring-boot-rest">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve REST APIs with Spring Boot — including HTTP methods, resource URIs, status codes, DTOs, versioning, deprecation and sunset headers, content negotiation (JSON and vendor media types), ISO-8601 instants in DTOs, pagination/sorting/filtering, Bean Validation at the boundary, idempotency, ETag concurrency, HTTP caching, error handling, security, contract-first OpenAPI (OpenAPI Generator), controller advice, and problem details for errors. This should trigger for requests such as Review Java code for Spring Boot REST API; Apply best practices for Spring Boot REST API in Java code.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/303-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/303-skill.xml
@@ -4,7 +4,7 @@
       id="303-frameworks-spring-boot-validation">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve validation in Spring Boot applications — including Bean Validation on request DTOs, @Valid/@Validated at API boundaries, constraint groups, custom constraints, @ConfigurationProperties validation, nested DTO validation, and consistent validation error handling. This should trigger for requests such as Add validation support in Spring Boot; Review Spring Boot validation rules; Improve request validation in Spring Boot REST APIs; Add custom Bean Validation constraints in Spring Boot; Validate configuration properties in Spring Boot.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/304-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/304-skill.xml
@@ -4,7 +4,7 @@
       id="304-frameworks-spring-boot-security">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve security in Spring Boot applications — including SecurityFilterChain, OAuth2/JWT resource server patterns, form login basics, method security (@PreAuthorize), CSRF and CORS for APIs, session fixation, security headers, exception handling, password encoding, and sensitive-data-safe logging. This should trigger for requests such as Add Spring Boot security support; Review Spring Boot security configuration; Improve API authorization in Spring Boot; Add JWT resource server security in Spring Boot; Harden Spring Boot security headers and CSRF settings.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/305-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/305-skill.xml
@@ -4,7 +4,7 @@
       id="305-frameworks-spring-boot-modulith">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve modular monoliths with Spring Modulith in Spring Boot applications - including application module package structure, ApplicationModules verification, named interfaces, allowed dependencies, domain events, @ApplicationModuleTest, Scenario-based module tests, generated documentation, actuator exposure, observability, and event publication registry choices. This should trigger for requests such as Add Spring Modulith to a Spring Boot application; Review Spring Modulith module boundaries; Improve modular monolith architecture in Spring Boot; Add @ApplicationModuleTest tests; Generate Spring Modulith documentation.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/311-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/311-skill.xml
@@ -4,7 +4,7 @@
       id="311-frameworks-spring-jdbc">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to write or review programmatic JDBC with Spring — including JdbcClient (Spring Framework 7+) as the default API, JdbcTemplate only where batch/streaming APIs require JdbcOperations, NamedParameterJdbcTemplate for legacy named-param code, parameterized SQL, RowMapper mapping to records, batch operations, transactions, safe handling of generated keys, DataAccessException handling, read-only transactions, streaming large result sets, and @JdbcTest slice testing. This should trigger for requests such as Review Java code for Spring JDBC (JdbcTemplate, JdbcClient, NamedParameterJdbcTemplate); Apply best practices for Spring JDBC data access in Java code; Detect and fix SQL injection risks in JDBC code; Improve transaction boundaries or exception handling for JDBC operations.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/312-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/312-skill.xml
@@ -4,7 +4,7 @@
       id="312-frameworks-spring-data-jdbc">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to use Spring Data JDBC with Java records — including entity design with records, repository pattern, immutable updates, aggregate relationships, custom queries, transaction management, and avoiding N+1 problems. This should trigger for requests such as Review Java code for Spring Data JDBC; Apply best practices for Spring Data JDBC in Java code.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/313-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/313-skill.xml
@@ -4,7 +4,7 @@
       id="313-frameworks-spring-db-migrations-flyway">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or review Flyway database migrations in a Spring Boot application — Maven dependencies, db/migration scripts, spring.flyway.* configuration, baseline and validation, and alignment with JDBC or Spring Data JDBC. This should trigger for requests such as Add or review Flyway migrations in a Spring Boot project; Configure spring.flyway or db/migration layout.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/314-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/314-skill.xml
@@ -4,7 +4,7 @@
       id="314-frameworks-spring-kafka">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design or implement Kafka messaging in Spring Boot — including topic design, producer/consumer implementation, JSON serialization with Boot factory customizers, Testcontainers `@ServiceConnection` integration tests, retries and dead-letter topics, idempotency, and error handling. This should trigger for requests such as Add Kafka in Spring Boot; Review Spring Kafka consumers; Improve retries and DLT in Spring Kafka.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/315-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/315-skill.xml
@@ -4,7 +4,7 @@
       id="315-frameworks-spring-mongodb">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design or implement MongoDB data access in Spring Boot — including document modeling, Spring Data Mongo repositories/templates, indexing, optimistic concurrency, and error handling. This should trigger for requests such as Add MongoDB in Spring Boot; Review Spring Data Mongo design; Improve error handling for Mongo writes.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/316-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/316-skill.xml
@@ -4,7 +4,7 @@
       id="316-frameworks-spring-mongodb-migrations-mongock">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or review Mongock MongoDB data migrations in a Spring Boot application — including Maven coordinates, Spring Data MongoDB drivers, migration scan packages, @ChangeUnit classes, lock/transaction settings, and Testcontainers verification. This should trigger for requests such as Add Mongock migrations in Spring Boot; Review Spring MongoDB data migrations; Configure Mongock change units for Spring Data MongoDB.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/321-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/321-skill.xml
@@ -4,7 +4,7 @@
       id="321-frameworks-spring-boot-testing-unit-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to write unit tests for Spring Boot applications — including pure unit tests with @ExtendWith(MockitoExtension.class) for @Service/@Component, slice tests with @WebMvcTest and @MockitoBean for controllers, @JsonTest for JSON serialization, parameterized tests with @CsvSource/@MethodSource, test profiles, and @TestConfiguration. For framework-agnostic Java use @131-java-testing-unit-testing. For integration tests use @322-frameworks-spring-boot-testing-integration-tests. This should trigger for requests such as Review Java code for Spring Boot unit tests; Apply best practices for Spring Boot unit tests in Java code.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/322-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/322-skill.xml
@@ -4,7 +4,7 @@
       id="322-frameworks-spring-boot-testing-integration-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to write or improve integration tests — including Testcontainers with @ServiceConnection, @DataJdbcTest persistence slices, TestRestTemplate or MockMvcTester for HTTP, data isolation, and container lifecycle management for Spring Boot 4.0.x. This should trigger for requests such as Review Java code for Spring Boot integration tests; Apply best practices for Spring Boot integration tests in Java code.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/323-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/323-skill.xml
@@ -4,7 +4,7 @@
       id="323-frameworks-spring-boot-testing-acceptance-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to implement acceptance tests from a Gherkin .feature file for Spring Boot applications — including finding scenarios tagged @acceptance, implementing happy path tests with TestRestTemplate, @SpringBootTest, Testcontainers with @ServiceConnection for DB/Kafka, and WireMock for external REST stubs. Requires .feature file in context. This should trigger for requests such as Review Java code for Spring Boot acceptance tests; Apply best practices for Spring Boot acceptance tests in Java code.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/400-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/400-skill.xml
@@ -4,7 +4,7 @@
       id="400-frameworks-quarkus-create-project">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to create a new Maven-based Quarkus 3.x project using SDKMAN-managed Java and Quarkus CLI tooling. This should trigger for requests such as Create a Quarkus Maven project; Bootstrap Quarkus project with SDKMAN; Generate a new Quarkus service.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/401-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/401-skill.xml
@@ -4,7 +4,7 @@
       id="401-frameworks-quarkus-core">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description><![CDATA[
         Use when building or reviewing core Quarkus applications with CDI beans and scopes, SmallRye Config and profiles, lifecycle, interceptors and events, virtual threads, and test-friendly design. This should trigger for requests such as Review Java code for Quarkus application structure and CDI; Apply best practices for Quarkus configuration and beans; Improve CDI interceptors, events, or programmatic injection in Quarkus; Add virtual-thread configuration or tune CDI lifecycle.

--- a/skills-generator/src/main/resources/skill-indexes/402-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/402-skill.xml
@@ -4,7 +4,7 @@
       id="402-frameworks-quarkus-rest">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve REST APIs with Quarkus REST (Jakarta REST) — including resource classes, HTTP methods, status codes, request/response DTOs, Bean Validation, exception mappers, optional runtime OpenAPI exposure (SmallRye), contract-first generation from OpenAPI, content negotiation, pagination, sorting and filtering, API versioning, idempotency (Idempotency-Key), optimistic concurrency (ETag / If-Match), HTTP caching (Cache-Control), API deprecation (Sunset / Deprecation headers), RFC 7807 Problem Details, ISO-8601 for time in contracts, and security-aware boundaries. This should trigger for requests such as Review or improve JAX-RS resources in a Quarkus project; Design HTTP APIs with validation and error handling on Quarkus; Add API versioning, idempotency, ETag concurrency, or deprecation headers; Implement pagination, sorting, or RFC 7807 Problem Details error responses.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/403-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/403-skill.xml
@@ -4,7 +4,7 @@
       id="403-frameworks-quarkus-validation">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve validation in Quarkus applications — including Bean Validation on JAX-RS resources, @Valid on parameters and CDI beans, constraint groups, @ConfigMapping validation, custom constraints, nested DTO validation, and ExceptionMapper-based error mapping. This should trigger for requests such as Add validation support in Quarkus; Review Quarkus validation rules; Improve request validation in Quarkus REST APIs; Add custom validation constraints in Quarkus; Validate Quarkus @ConfigMapping properties.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/404-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/404-skill.xml
@@ -4,7 +4,7 @@
       id="404-frameworks-quarkus-security">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve security in Quarkus applications — including Quarkus Security with JWT/OIDC, basic auth, @RolesAllowed / @Authenticated / @PermitAll, SecurityIdentity, permission checks, path-based authorization in configuration, exception mapping for auth failures, and sensitive-data-safe logging. This should trigger for requests such as Add Quarkus security support; Review Quarkus security configuration; Improve API authorization in Quarkus; Add JWT/OIDC security in Quarkus; Harden Quarkus authorization rules.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/411-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/411-skill.xml
@@ -4,7 +4,7 @@
       id="411-frameworks-quarkus-jdbc">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need programmatic JDBC in Quarkus — Agroal DataSource, parameterized SQL, transactions, batching, and Dev Services. This should trigger for requests such as Review JDBC or SQL data access in a Quarkus project; Improve transactions and parameter binding for Quarkus JDBC; Translate SQLException to domain exceptions or stream large result sets; Fix CDI self-invocation bypassing @Transactional in Quarkus.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/412-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/412-skill.xml
@@ -4,7 +4,7 @@
       id="412-frameworks-quarkus-panache">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description><![CDATA[
         Use when you need data access with Quarkus Hibernate ORM Panache — including PanacheEntity / PanacheEntityBase, PanacheRepository, named queries, JPQL, native SQL, DTO projections (project(Class)), pagination (Page.of()), N+1 avoidance (JOIN FETCH), optimistic locking (@Version / OptimisticLockException), @NamedQuery for validated reusable queries, transactions, @TestTransaction for test isolation, and immutable-friendly patterns. This is the Quarkus analogue to Spring Data for relational persistence.

--- a/skills-generator/src/main/resources/skill-indexes/413-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/413-skill.xml
@@ -4,7 +4,7 @@
       id="413-frameworks-quarkus-db-migrations-flyway">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or review Flyway database migrations in a Quarkus application — quarkus-flyway extension, db/migration scripts, quarkus.flyway.* configuration, migrate-at-start, and alignment with JDBC or Panache. This should trigger for requests such as Add or review Flyway migrations in a Quarkus project; Configure quarkus-flyway or db/migration layout.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/414-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/414-skill.xml
@@ -4,7 +4,7 @@
       id="414-frameworks-quarkus-kafka">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need Kafka messaging in Quarkus with SmallRye Reactive Messaging — including channel/topic design, build-time Jackson serialization, typed @Channel/@Incoming, ack/failure strategies, retries/DLQ, idempotency, Dev Services, and Testcontainers integration tests. This should trigger for requests such as Add Kafka in Quarkus; Review Reactive Messaging consumers; Improve failure handling for Quarkus Kafka.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/415-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/415-skill.xml
@@ -4,7 +4,7 @@
       id="415-frameworks-quarkus-mongodb">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need MongoDB persistence in Quarkus — including Panache Mongo entities/repositories, document design, indexes, transactions where applicable, and error handling. This should trigger for requests such as Add MongoDB in Quarkus; Review Quarkus Mongo Panache design; Improve Mongo error handling in Quarkus services.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/416-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/416-skill.xml
@@ -4,7 +4,7 @@
       id="416-frameworks-quarkus-mongodb-migrations-mongock">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or review Mongock MongoDB data migrations in a Quarkus application — including the Quarkiverse Mongock extension, Quarkus MongoDB client configuration, migrate-at-start, @ChangeUnit classes, lock/transaction settings, and Quarkus test verification. This should trigger for requests such as Add Mongock migrations in Quarkus; Configure quarkus-mongock; Review Quarkus MongoDB data migrations.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/421-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/421-skill.xml
@@ -4,7 +4,7 @@
       id="421-frameworks-quarkus-testing-unit-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to write fast unit tests for Quarkus applications — including pure tests with @ExtendWith(MockitoExtension.class), @QuarkusTest with @InjectMock for full CDI mock replacement, @InjectSpy for partial CDI bean mocking, REST Assured for resource-focused tests, @ParameterizedTest with @CsvSource / @MethodSource, QuarkusTestProfile for test-specific configuration overrides, and naming conventions (*Test → Surefire, *IT → Failsafe). For framework-agnostic Java use @131-java-testing-unit-testing. This should trigger for requests such as Add or improve unit tests in a Quarkus project; Reduce slow @QuarkusTest usage with Mockito-first tests; Add @InjectSpy partial mocking or QuarkusTestProfile configuration in Quarkus tests; Convert repeated test methods to @ParameterizedTest with @CsvSource or @MethodSource.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/422-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/422-skill.xml
@@ -4,7 +4,7 @@
       id="422-frameworks-quarkus-testing-integration-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to write or improve integration tests for Quarkus — including @QuarkusTest, Dev Services for automatic container provisioning, Testcontainers via QuarkusTestResourceLifecycleManager, WireMock for external HTTP stubs, @QuarkusIntegrationTest for black-box testing against packaged artifacts, REST Assured, data isolation strategies (@TestTransaction vs @BeforeEach cleanup), and Maven Surefire/Failsafe three-tier split (*Test, *IT, *AT). This should trigger for requests such as Add or improve integration tests in a Quarkus project; Configure Testcontainers or Dev Services for Quarkus tests; Add WireMock stubs for external HTTP dependencies in Quarkus integration tests; Set up @QuarkusIntegrationTest for packaged artifact or native binary testing; Fix test data isolation or configure Maven Surefire/Failsafe split.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/423-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/423-skill.xml
@@ -4,7 +4,7 @@
       id="423-frameworks-quarkus-testing-acceptance-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to implement acceptance tests from a Gherkin .feature file for Quarkus applications — including @acceptance scenarios, @QuarkusTest, BaseAcceptanceTest with QuarkusTestResourceLifecycleManager for Testcontainers and WireMock, REST Assured for full HTTP pipeline testing, WireMock JSON mapping files (classpath:wiremock/mappings/), *AT suffix naming, and Maven Surefire/Failsafe three-tier split. Requires the .feature file in context. This should trigger for requests such as Implement Quarkus acceptance tests from a Gherkin feature file; Set up BaseAcceptanceTest with Testcontainers and WireMock for Quarkus; Create WireMock JSON mapping files for external HTTP stubs in Quarkus acceptance tests; Configure Maven *AT naming convention and Failsafe plugin for Quarkus acceptance tests.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/500-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/500-skill.xml
@@ -4,7 +4,7 @@
       id="500-frameworks-micronaut-create-project">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to create a new Maven-based Micronaut 4.x project using SDKMAN-managed Java and Micronaut CLI tooling. This should trigger for requests such as Create a Micronaut Maven project; Bootstrap Micronaut project with SDKMAN; Generate a new Micronaut service.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/501-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/501-skill.xml
@@ -4,7 +4,7 @@
       id="501-frameworks-micronaut-core">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description><![CDATA[
         Use when building or reviewing Micronaut applications — Micronaut.run bootstrap, @Singleton/@Prototype, @Factory beans, @ConfigurationProperties, environments, @Requires, @Controller vs services, @Scheduled, graceful shutdown, @ExecuteOn for blocking work, and Jakarta-consistent APIs. This should trigger for requests such as Review Java code for Micronaut application structure and beans; Apply best practices for Micronaut configuration, @Requires, and factories; Improve scheduling, shutdown, or threading in Micronaut services.

--- a/skills-generator/src/main/resources/skill-indexes/502-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/502-skill.xml
@@ -4,7 +4,7 @@
       id="502-frameworks-micronaut-rest">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve REST APIs with Micronaut — including @Controller routes, HTTP status codes, DTOs, Bean Validation, exception handlers, pagination, idempotency, ETag/If-Match, caching headers, versioning, contract-first OpenAPI (OpenAPI Generator), optional runtime OpenAPI via micronaut-openapi, and security annotations. This should trigger for requests such as Review or improve Micronaut @Controller REST APIs; Add validation, error handling, or align controllers with the OpenAPI contract on Micronaut HTTP layer.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/503-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/503-skill.xml
@@ -4,7 +4,7 @@
       id="503-frameworks-micronaut-validation">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve validation in Micronaut applications — including Bean Validation on @Controller methods, @Body @Valid, query/path parameter validation, @ConfigurationProperties validation, custom constraints, nested DTO validation, and ExceptionHandler mapping for constraint violations. This should trigger for requests such as Add validation support in Micronaut; Review Micronaut validation rules; Improve request validation in Micronaut REST APIs; Add custom validation constraints in Micronaut; Validate Micronaut configuration properties.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/504-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/504-skill.xml
@@ -4,7 +4,7 @@
       id="504-frameworks-micronaut-security">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve security in Micronaut applications — including micronaut-security authentication, @Secured and intercept-url-map rules, JWT/session strategies, SecurityService checks, CORS, CSRF awareness for browser apps, rejection handlers, and sensitive-data-safe logging. This should trigger for requests such as Add Micronaut security support; Review Micronaut security configuration; Improve API authorization in Micronaut; Add JWT security in Micronaut; Harden Micronaut route authorization rules.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/511-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/511-skill.xml
@@ -4,7 +4,7 @@
       id="511-frameworks-micronaut-jdbc">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need programmatic JDBC in Micronaut — pooled DataSource, parameterized SQL, io.micronaut.transaction.annotation.Transactional, batching, and domain exception translation. This should trigger for requests such as Review JDBC or SQL data access in a Micronaut project; Improve transactions and parameter binding for Micronaut JDBC; Translate SQLException to domain exceptions or stream large result sets; Fix self-invocation bypassing @Transactional in Micronaut.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/512-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/512-skill.xml
@@ -4,7 +4,7 @@
       id="512-frameworks-micronaut-data">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need data access with Micronaut Data — @MappedEntity, CrudRepository/PageableRepository, @Query with parameters, @Transactional services, projections, @Version, and @MicronautTest with TestPropertyProvider and Testcontainers. For raw java.sql access without generated repositories, use @511-frameworks-micronaut-jdbc. This should trigger for requests such as Review or implement Micronaut Data repositories and entities; Add transactions, pagination, or projections in Micronaut persistence layer.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/513-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/513-skill.xml
@@ -4,7 +4,7 @@
       id="513-frameworks-micronaut-db-migrations-flyway">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or review Flyway database migrations in a Micronaut application — micronaut-flyway, db/migration scripts, flyway.datasources.* configuration, and alignment with JDBC or Micronaut Data. This should trigger for requests such as Add or review Flyway migrations in a Micronaut project; Configure micronaut-flyway or db/migration layout.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/514-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/514-skill.xml
@@ -4,7 +4,7 @@
       id="514-frameworks-micronaut-kafka">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need Kafka messaging in Micronaut — including @KafkaClient and @KafkaListener design, @Serdeable serialization, topic/partition strategy, TestPropertyProvider integration tests, retries and dead-letter processing, and error handling. This should trigger for requests such as Add Kafka in Micronaut; Review Micronaut Kafka listeners; Improve retry and failure handling for Micronaut Kafka.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/515-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/515-skill.xml
@@ -4,7 +4,7 @@
       id="515-frameworks-micronaut-mongodb">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need MongoDB persistence in Micronaut — including @MongoRepository design, document modeling, indexes, query patterns, and error handling. This should trigger for requests such as Add MongoDB in Micronaut; Review Micronaut Data Mongo design; Improve error handling for Micronaut Mongo operations.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/516-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/516-skill.xml
@@ -4,7 +4,7 @@
       id="516-frameworks-micronaut-mongodb-migrations-mongock">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or review Mongock MongoDB data migrations in a Micronaut application — including Mongock runner/driver selection, Micronaut bean wiring, migration scan packages, @ChangeUnit classes, lock/transaction settings, and Testcontainers verification. This should trigger for requests such as Add Mongock migrations in Micronaut; Review Micronaut MongoDB data migrations; Configure Mongock change units with Micronaut Data MongoDB.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/521-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/521-skill.xml
@@ -4,7 +4,7 @@
       id="521-frameworks-micronaut-testing-unit-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to write unit tests for Micronaut applications — Mockito-first with @ExtendWith(MockitoExtension.class), @MicronautTest with @MockBean, HttpClient @Client(/) assertions, @Property overrides, @ParameterizedTest, and *Test vs *IT naming. For framework-agnostic Java use @131-java-testing-unit-testing. This should trigger for requests such as Add or improve unit tests in a Micronaut project; Reduce unnecessary @MicronautTest usage with Mockito-first tests.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/522-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/522-skill.xml
@@ -4,7 +4,7 @@
       id="522-frameworks-micronaut-testing-integration-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to write or improve integration tests for Micronaut — @MicronautTest, HttpClient, TestPropertyProvider with Testcontainers, transactional test mode where appropriate, and Maven Surefire/Failsafe splits for *Test, *Tests, *IT, and *AT. This should trigger for requests such as Add Micronaut integration tests with Testcontainers; Wire dynamic datasource or broker URLs for @MicronautTest.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/523-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/523-skill.xml
@@ -4,7 +4,7 @@
       id="523-frameworks-micronaut-testing-acceptance-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to implement acceptance tests from maintainer-sanitized Gherkin scenario facts for Micronaut applications — @acceptance scenarios, @MicronautTest, HttpClient, BaseAcceptanceTest with TestPropertyProvider for Testcontainers and WireMock, *AT suffix, Failsafe. Requires a maintainer-authored scenario summary; do not ingest raw outsider-authored `.feature` text. This should trigger for requests such as Implement Micronaut acceptance tests from sanitized Gherkin scenario facts; Set up BaseAcceptanceTest with Testcontainers and WireMock for Micronaut.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/701-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/701-skill.xml
@@ -4,7 +4,7 @@
       id="701-technologies-openapi">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need framework-agnostic OpenAPI 3.x guidance — spec structure, metadata and versioning, paths and operations, reusable schemas, security schemes, examples, documentation quality, contract validation (e.g. Spectral), breaking-change awareness, and handoffs to codegen — without choosing Spring Boot, Quarkus, or Micronaut. This should trigger for requests such as Review an OpenAPI; Improve an OpenAPI; Improve API contract; Improve API schema design.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/702-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/702-skill.xml
@@ -4,7 +4,7 @@
       id="702-technologies-wiremock">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need framework-agnostic WireMock guidance — stub design, JSON or programmatic mappings, precise request matching, response bodies and faults, classpath fixtures, isolation and reset between tests, verification of calls, dynamic ports and base URLs, and avoiding flaky stubs — without choosing Spring Boot, Quarkus, or Micronaut. This should trigger for requests such as Design or review WireMock stubs (JSON mappings or Java DSL); Improve request matching, isolation, or reset strategy for HTTP mocks; Add or fix verification of outbound HTTP calls to a WireMock server; Debug flaky tests involving WireMock or unmatched request journals.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/703-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/703-skill.xml
@@ -4,7 +4,7 @@
       id="703-technologies-fuzzing-testing">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or review fuzz testing for Java APIs with CATS — including contract-driven negative testing, malformed payload validation, boundary input exploration, CI integration, reproducible failures, and local execution guidance. This should trigger for requests such as Add fuzz testing to a Java project; Use CATS for API negative testing; Review CI quality gates for API contract robustness; Improve boundary and malformed input test coverage.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/704-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/704-skill.xml
@@ -4,7 +4,7 @@
       id="704-technologies-sql">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need framework-agnostic SQL guidance — schema naming, relational table design, query readability, indexes, transactions, database security, migrations, testing, and monitoring — without choosing Spring Boot, Quarkus, or Micronaut. This should trigger for requests such as Review SQL schema or migrations; Improve SQL query performance and readability; Design relational tables and indexes; Review database transaction, security, or monitoring practices.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/705-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/705-skill.xml
@@ -4,7 +4,7 @@
       id="705-technologies-nosql-mongodb">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need framework-agnostic MongoDB and non-relational database query guidance — document schema design, collection modeling, JSON Schema validation, indexes, aggregation pipelines, query performance, consistency trade-offs, transactions, and operational safety — without choosing Spring Boot, Quarkus, or Micronaut. This should trigger for requests such as Design MongoDB document schemas; Review MongoDB queries and indexes; Improve aggregation pipeline performance; Model non-relational data access patterns; Review NoSQL consistency and transaction trade-offs.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/706-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/706-skill.xml
@@ -4,7 +4,7 @@
       id="706-technologies-containers-docker">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when you need framework-agnostic Docker and container image guidance for Java projects - Dockerfile design, multi-stage Maven builds, jlink custom runtimes, micro runtime distributions such as Alpaquita, JVM container ergonomics, non-root execution, image metadata, .dockerignore, reproducible builds, vulnerability scanning, SBOM awareness, and production-safe container defaults. This should trigger for requests such as Review Java Dockerfile; Improve Docker image security; Add jlink runtime to a Java container; Add containerization to a Java project; Optimize Java container image size; Review Docker build reproducibility.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/801-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/801-skill.xml
@@ -4,7 +4,7 @@
       id="801-regulations-eu-ai-act">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise systems that use AI, LLMs, AI agents, RAG, tool calling, workflow automation, or model-based decision support and need EU AI Act regulatory awareness. This should trigger for requests such as Review a Java AI system for EU AI Act controls; Design governance for an AI agent with enterprise tools; Add human oversight and auditability to LLM workflows; Assess RAG or model-driven decision support before production release.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/802-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/802-skill.xml
@@ -4,7 +4,7 @@
       id="802-regulations-dora">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise systems that may support financial entities, critical ICT services, third-party ICT provider integrations, or operational resilience obligations under DORA. This should trigger for requests such as Review a Java platform for DORA ICT risk controls; Design operational resilience evidence for a financial service; Add incident, continuity, backup, recovery, or third-party ICT controls; Assess resilience testing and monitoring before production release.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/803-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/803-skill.xml
@@ -4,7 +4,7 @@
       id="803-regulations-gdpr">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise systems that process personal data and need GDPR-aware engineering controls. This should trigger for requests such as Review a Java service for GDPR privacy controls; Design data-subject rights workflows; Add retention, deletion, pseudonymization, or privacy-safe logging; Assess data transfer, DPIA, breach evidence, or processor/controller boundary concerns before production release.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/804-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/804-skill.xml
@@ -4,7 +4,7 @@
       id="804-regulations-eu-nis2">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise systems that may support essential or important entities, critical-sector services, managed service providers, supply-chain dependencies, or cybersecurity incident escalation obligations under NIS2. This should trigger for requests such as Review a Java platform for NIS2 cybersecurity controls; Design operational evidence for critical-sector services; Add incident detection, escalation, continuity, or supply-chain security controls; Assess cybersecurity risk management before production release.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/805-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/805-skill.xml
@@ -4,7 +4,7 @@
       id="805-regulations-eu-cyber-resilience-act">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise products, services, libraries, agents, plugins, connected components, or platform modules that may qualify as products with digital elements and need EU Cyber Resilience Act secure-by-design, vulnerability handling, security update, SBOM, product documentation, or release-readiness controls.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/806-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/806-skill.xml
@@ -4,7 +4,7 @@
       id="806-regulations-eu-data-act">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise systems that expose, exchange, store, process, export, or port data across users, businesses, connected products, cloud providers, APIs, event streams, AI data pipelines, data spaces, or SaaS platforms and need EU Data Act engineering controls. This should trigger for requests such as Review a Java platform for EU Data Act controls; Design data access and portability evidence; Add data-sharing request workflows, export formats, interoperability, metadata, audit logs, cloud-switching support, non-personal data safeguards, or trade-secret handoffs; Assess Data Act engineering readiness before production release.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/807-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/807-skill.xml
@@ -4,7 +4,7 @@
       id="807-regulations-eu-digital-services-act">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise systems that may support intermediary services, hosting services, online platforms, marketplaces, content moderation, recommender systems, advertising delivery, complaint workflows, transparency reporting, or systemic-risk evidence under the EU Digital Services Act. This should trigger for requests such as Review a Java online platform for DSA controls; Design notice-and-action or appeal workflows; Add recommender, ad transparency, moderation, audit, researcher access, or privacy-safe observability evidence; Assess online-platform transparency controls before production release.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-indexes/808-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/808-skill.xml
@@ -4,7 +4,7 @@
       id="808-regulations-eu-digital-markets-act">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.16.0</version>
+    <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise systems that may support EU Digital Markets Act gatekeeper-platform concerns, core platform services, interoperability, business-user data access, consent-dependent data combination, ranking, self-preferencing, advertising transparency, or anti-circumvention controls. This should trigger for requests such as Review a Java platform for DMA controls; Design interoperability and business-user data access evidence; Add ranking, consent, preference, or anti-circumvention audit controls; Assess gatekeeper-platform engineering evidence before production release.</description>
   </metadata>

--- a/skills-generator/src/main/resources/skill-references/001-commands-inventory.xml
+++ b/skills-generator/src/main/resources/skill-references/001-commands-inventory.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Create a Checklist with embedded commands inventory for Java</title>
         <description>Use when you need to generate a checklist document with embedded commands inventory, following the embedded template exactly and producing INVENTORY-COMMANDS-JAVA.md in the project root.</description>

--- a/skills-generator/src/main/resources/skill-references/002-agents-inventory.xml
+++ b/skills-generator/src/main/resources/skill-references/002-agents-inventory.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Create a Checklist with embedded agents inventory for Java</title>
         <description>Use when you need to generate a checklist document with embedded agents inventory, following the embedded template exactly and producing INVENTORY-AGENTS-JAVA.md in the project root.</description>

--- a/skills-generator/src/main/resources/skill-references/003-skills-inventory.xml
+++ b/skills-generator/src/main/resources/skill-references/003-skills-inventory.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Create a Checklist with all Java steps to use with system prompts for Java</title>
         <description>Use when you need to generate a checklist document with Java system prompts from skills.xml, following the embedded section template and producing INVENTORY-SKILLS-JAVA.md.</description>

--- a/skills-generator/src/main/resources/skill-references/004-commands-installation.xml
+++ b/skills-generator/src/main/resources/skill-references/004-commands-installation.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Embedded commands installer</title>
         <description>Use when you need to install the embedded project commands into command directories (.github/commands, .claude/commands, .cursor/command, .codex/commands), selecting the destination interactively and copying the embedded command definitions from project assets.</description>

--- a/skills-generator/src/main/resources/skill-references/005-agents-installation.xml
+++ b/skills-generator/src/main/resources/skill-references/005-agents-installation.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Embedded agents installer</title>
         <description>Use when you need to install the embedded robot agents into either .cursor/agents or .claude/agents, selecting the destination interactively and copying the embedded agent definitions from project assets.</description>

--- a/skills-generator/src/main/resources/skill-references/012-agile-epic.xml
+++ b/skills-generator/src/main/resources/skill-references/012-agile-epic.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Create Agile Epics</title>
         <description>Use when the user wants to create an agile epic, define large bodies of work, break down features into user stories, or document strategic initiatives.</description>

--- a/skills-generator/src/main/resources/skill-references/013-agile-feature.xml
+++ b/skills-generator/src/main/resources/skill-references/013-agile-feature.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Create Agile Features from an Epic</title>
         <description>Use when the user wants to derive detailed feature documentation from an existing epic, split an epic into feature files, or plan features with scope and acceptance criteria.</description>

--- a/skills-generator/src/main/resources/skill-references/014-agile-user-story.xml
+++ b/skills-generator/src/main/resources/skill-references/014-agile-user-story.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Create Agile User Stories and Gherkin Feature Files</title>
         <description>Use when the user wants to create a user story, write acceptance criteria, define Gherkin scenarios, or author BDD feature files.</description>

--- a/skills-generator/src/main/resources/skill-references/030-architecture-adr-general.xml
+++ b/skills-generator/src/main/resources/skill-references/030-architecture-adr-general.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java ADR Generator with interactive conversational approach</title>
         <description>Use when you need to generate Architecture Decision Records (ADRs) for a Java project through an interactive, conversational process that systematically gathers context, stakeholders, options, and outcomes to produce well-structured ADR documents.</description>

--- a/skills-generator/src/main/resources/skill-references/031-architecture-adr-functional-requirements.xml
+++ b/skills-generator/src/main/resources/skill-references/031-architecture-adr-functional-requirements.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Create ADRs for Functional Requirements (CLI and/or REST API)</title>
         <description>Use when the user wants to document CLI and/or REST API architecture, capture functional requirements in an ADR, create ADRs for command-line tools or HTTP services, or design interfaces with documented decisions.</description>

--- a/skills-generator/src/main/resources/skill-references/032-architecture-adr-non-functional-requirements.xml
+++ b/skills-generator/src/main/resources/skill-references/032-architecture-adr-non-functional-requirements.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Create ADRs for Non-Functional Requirements</title>
         <description>Use when the user wants to document quality attributes, NFR decisions, security/performance/scalability architecture, or design systems with measurable quality criteria using ISO/IEC 25010:2023.</description>

--- a/skills-generator/src/main/resources/skill-references/033-architecture-diagrams-bounded-context.xml
+++ b/skills-generator/src/main/resources/skill-references/033-architecture-diagrams-bounded-context.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Diagrams Generator with modular step-based configuration</title>
         <description>Focused bounded-context PlantUML guidance for the interactive architecture diagrams skill.</description>

--- a/skills-generator/src/main/resources/skill-references/033-architecture-diagrams-c4.xml
+++ b/skills-generator/src/main/resources/skill-references/033-architecture-diagrams-c4.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Diagrams Generator with modular step-based configuration</title>
         <description>Focused C4 Context, Container, and Component diagram guidance for the interactive architecture diagrams skill.</description>

--- a/skills-generator/src/main/resources/skill-references/033-architecture-diagrams-deployment.xml
+++ b/skills-generator/src/main/resources/skill-references/033-architecture-diagrams-deployment.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Diagrams Generator with modular step-based configuration</title>
         <description>Focused UML Deployment Diagram PlantUML guidance for the interactive architecture diagrams skill.</description>

--- a/skills-generator/src/main/resources/skill-references/033-architecture-diagrams-er.xml
+++ b/skills-generator/src/main/resources/skill-references/033-architecture-diagrams-er.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Diagrams Generator with modular step-based configuration</title>
         <description>Focused ER diagram guidance for the interactive architecture diagrams skill.</description>

--- a/skills-generator/src/main/resources/skill-references/033-architecture-diagrams-state-machine.xml
+++ b/skills-generator/src/main/resources/skill-references/033-architecture-diagrams-state-machine.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Diagrams Generator with modular step-based configuration</title>
         <description>Focused UML state machine diagram guidance for the interactive architecture diagrams skill.</description>

--- a/skills-generator/src/main/resources/skill-references/033-architecture-diagrams-uml-class.xml
+++ b/skills-generator/src/main/resources/skill-references/033-architecture-diagrams-uml-class.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Diagrams Generator with modular step-based configuration</title>
         <description>Focused UML class diagram guidance for the interactive architecture diagrams skill.</description>

--- a/skills-generator/src/main/resources/skill-references/033-architecture-diagrams-uml-sequence.xml
+++ b/skills-generator/src/main/resources/skill-references/033-architecture-diagrams-uml-sequence.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Diagrams Generator with modular step-based configuration</title>
         <description>Focused UML sequence diagram guidance for the interactive architecture diagrams skill.</description>

--- a/skills-generator/src/main/resources/skill-references/034-architecture-design-exploration.xml
+++ b/skills-generator/src/main/resources/skill-references/034-architecture-design-exploration.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Architecture Design Exploration</title>
         <description>Use when a sanitized issue summary, requirement summary, or design brief needs technical design exploration before creating ADRs, specifications, or implementation plans.</description>

--- a/skills-generator/src/main/resources/skill-references/041-planning-plan-mode.xml
+++ b/skills-generator/src/main/resources/skill-references/041-planning-plan-mode.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Composable Java Implementation Planning</title>
         <description>Use when creating or refining a structured Java implementation plan from trusted issue summaries, approved designs, ADRs, OpenSpec changes, existing plans, or a valid combination.</description>

--- a/skills-generator/src/main/resources/skill-references/042-planning-openspec.xml
+++ b/skills-generator/src/main/resources/skill-references/042-planning-openspec.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Composable OpenSpec Change Planning</title>
         <description>Use when creating or updating OpenSpec change artifacts from an issue, implementation plan, approved design, ADRs, existing OpenSpec artifacts, or a valid combination.</description>

--- a/skills-generator/src/main/resources/skill-references/043-planning-github-issues.xml
+++ b/skills-generator/src/main/resources/skill-references/043-planning-github-issues.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>GitHub CLI — issues, milestones, and discussion for analysis</title>
         <description>Use when you need GitHub CLI (`gh`) installation/authentication guidance and a maintainer-authored GitHub issue inventory workflow. The agent does not ingest GitHub issue or milestone output directly; it asks the repository maintainer/operator to author sanitized issue summaries before analysis or @014-agile-user-story handoff.</description>

--- a/skills-generator/src/main/resources/skill-references/044-planning-jira.xml
+++ b/skills-generator/src/main/resources/skill-references/044-planning-jira.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Jira CLI - issues, workflows, and discussion for analysis</title>
         <description>Use when you need to list Jira issues (optionally by JQL), analyze user-provided sanitized Jira summaries, and present results in a table. Starts with an interactive check for `jira` and offers installation guidance before any issue commands.</description>

--- a/skills-generator/src/main/resources/skill-references/110-java-maven-best-practices.xml
+++ b/skills-generator/src/main/resources/skill-references/110-java-maven-best-practices.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Best Practices</title>
         <description>Use when you need to improve your Maven pom.xml using best practices.</description>

--- a/skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-archunit.xml
+++ b/skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-archunit.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Add Maven dependencies for improved code quality</title>
         <description>ArchUnit Maven dependency guidance for the interactive Maven dependencies skill.</description>

--- a/skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-jspecify.xml
+++ b/skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-jspecify.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Add Maven dependencies for improved code quality</title>
         <description>JSpecify, Error Prone, and NullAway Maven dependency guidance for the interactive Maven dependencies skill.</description>

--- a/skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-vavr.xml
+++ b/skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-vavr.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Add Maven dependencies for improved code quality</title>
         <description>VAVR Maven dependency guidance for the interactive Maven dependencies skill.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-flatten-maven-plugin.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-flatten-maven-plugin.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Flatten Maven plugin guidance for library publishing POMs.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-git-commit-id-maven-plugin.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-git-commit-id-maven-plugin.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Git Commit ID Maven plugin guidance for build traceability metadata.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-jib-maven-plugin.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-jib-maven-plugin.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Jib Maven plugin guidance for container image builds.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-compiler-plugin.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-compiler-plugin.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Maven Compiler plugin guidance for source and target release configuration.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-dependency-plugin.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-dependency-plugin.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Maven Dependency Plugin guidance for declared and undeclared dependency analysis.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-enforcer-plugin.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-enforcer-plugin.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Maven Enforcer plugin guidance for dependency convergence, Java/Maven requirements, and build safety rules.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-failsafe-plugin.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-failsafe-plugin.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Maven Failsafe plugin guidance for integration test execution.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-jxr-plugin.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-jxr-plugin.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Maven JXR plugin guidance for source cross-reference reports.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-surefire-plugin.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-surefire-plugin.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Maven Surefire plugin guidance for unit test execution.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-surefire-report-plugin.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-surefire-report-plugin.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Maven Surefire Report plugin guidance for HTML unit test reports.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-cyclomatic-complexity.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-cyclomatic-complexity.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Cyclomatic complexity profile guidance using PMD and JXR reports.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-jacoco.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-jacoco.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>JaCoCo profile guidance for coverage reporting and thresholds.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-jmh.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-jmh.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>JMH profile guidance for Java microbenchmark support.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-pitest.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-pitest.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>PiTest profile guidance for mutation testing.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-security.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-security.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Security profile guidance for OWASP Dependency Check.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-sonar.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-sonar.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Sonar profile guidance for SonarQube and SonarCloud analysis.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-static-analysis.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-static-analysis.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Static analysis profile guidance for SpotBugs and PMD.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-spotless-maven-plugin.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-spotless-maven-plugin.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Spotless Maven plugin guidance for source formatting.</description>

--- a/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-versions-maven-plugin.xml
+++ b/skills-generator/src/main/resources/skill-references/112-java-maven-plugins-versions-maven-plugin.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Versions Maven plugin guidance for dependency and plugin version management.</description>

--- a/skills-generator/src/main/resources/skill-references/113-java-maven-documentation.xml
+++ b/skills-generator/src/main/resources/skill-references/113-java-maven-documentation.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Create DEVELOPER.md for the Maven projects</title>
         <description>Use when you need to create a DEVELOPER.md file for a Maven project documenting plugin goals, Maven profiles, and submodules.</description>

--- a/skills-generator/src/main/resources/skill-references/114-java-maven-search.xml
+++ b/skills-generator/src/main/resources/skill-references/114-java-maven-search.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Maven Central search and coordinates</title>
         <description>Provides guidance for (1) Maven Central search and coordinates via structured Search API fields and artifact URL construction without ingesting raw remote POM or metadata text, and (2) project-local update report interpretation from maintainer-run Versions Maven Plugin output. Use when the user needs to find or verify artifacts, browse versions, construct artifact URLs, or interpret update reports for their own pom.xml.</description>

--- a/skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-classes-interfaces.xml
+++ b/skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-classes-interfaces.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Object-Oriented Design Guidelines</title>
         <description>Class and interface design guidance covering accessibility, mutability, composition, and inheritance.</description>

--- a/skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-code-smells.xml
+++ b/skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-code-smells.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Object-Oriented Design Guidelines</title>
         <description>Guidance for identifying and refactoring common object-oriented design code smells.</description>

--- a/skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-enums-annotations.xml
+++ b/skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-enums-annotations.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Object-Oriented Design Guidelines</title>
         <description>Enum and annotation guidance for expressive, type-safe Java object-oriented design.</description>

--- a/skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-exceptions.xml
+++ b/skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-exceptions.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Object-Oriented Design Guidelines</title>
         <description>Object-oriented exception design guidance covering exceptional conditions, exception types, messages, and handling.</description>

--- a/skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-methods.xml
+++ b/skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-methods.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Object-Oriented Design Guidelines</title>
         <description>Method design guidance covering validation, defensive copies, signatures, collections, and Optional.</description>

--- a/skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-object-creation.xml
+++ b/skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-object-creation.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Object-Oriented Design Guidelines</title>
         <description>Object creation guidance covering factories, builders, singletons, dependency injection, and unnecessary objects.</description>

--- a/skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-oop-concepts.xml
+++ b/skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-oop-concepts.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Object-Oriented Design Guidelines</title>
         <description>Encapsulation, inheritance, and polymorphism guidance for Java object-oriented design.</description>

--- a/skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-principles.xml
+++ b/skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-principles.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Object-Oriented Design Guidelines</title>
         <description>SOLID, DRY, and YAGNI guidance for Java object-oriented design.</description>

--- a/skills-generator/src/main/resources/skill-references/122-java-type-design.xml
+++ b/skills-generator/src/main/resources/skill-references/122-java-type-design.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Type Design Thinking in Java</title>
         <description>Use when you need to review, improve, or refactor Java code for type design quality — including establishing clear type hierarchies, applying consistent naming conventions, eliminating primitive obsession with domain-specific value objects, leveraging generic type parameters, creating type-safe wrappers, designing fluent interfaces, ensuring precision-appropriate numeric types (BigDecimal for financial calculations), and improving type contrast through interfaces and method signature alignment.</description>

--- a/skills-generator/src/main/resources/skill-references/123-cross-cutting-integration-patterns.xml
+++ b/skills-generator/src/main/resources/skill-references/123-cross-cutting-integration-patterns.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Design and Integration Patterns</title>
         <description>Use when designing or reviewing cross-cutting integration patterns — anti-corruption layers, strangler fig migration, bulkheads, timeouts, retries, backoff, circuit breakers, correlation ids, trace propagation, inbox, outbox, and reliable service boundaries.</description>

--- a/skills-generator/src/main/resources/skill-references/123-database-persistence-patterns.xml
+++ b/skills-generator/src/main/resources/skill-references/123-database-persistence-patterns.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Design and Integration Patterns</title>
         <description>Use when designing or reviewing database and persistence patterns — repositories, unit of work, data mapper, aggregate boundaries, optimistic locking, migrations, CQRS read models, soft delete, multi-tenancy, sharding, connection pools, and N+1 avoidance.</description>

--- a/skills-generator/src/main/resources/skill-references/123-java-design-patterns.xml
+++ b/skills-generator/src/main/resources/skill-references/123-java-design-patterns.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Design and Integration Patterns</title>
         <description>Use when applying classic Java design patterns in application code — creational, structural, and behavioral patterns with practical Java 25 examples and explicit guidance against over-engineering.</description>

--- a/skills-generator/src/main/resources/skill-references/123-kafka-event-driven-patterns.xml
+++ b/skills-generator/src/main/resources/skill-references/123-kafka-event-driven-patterns.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Design and Integration Patterns</title>
         <description>Use when designing or reviewing Kafka and event-driven patterns — event schemas, partitioning keys, consumer groups, idempotent consumers, retry topics, dead-letter topics, outbox, CDC, sagas, CQRS projections, and event sourcing.</description>

--- a/skills-generator/src/main/resources/skill-references/123-rest-api-patterns.xml
+++ b/skills-generator/src/main/resources/skill-references/123-rest-api-patterns.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Design and Integration Patterns</title>
         <description>Use when designing or reviewing REST API patterns — resource-oriented endpoints, DTO boundaries, idempotency, pagination, optimistic concurrency, Problem Details, API gateways, and resilient client interaction.</description>

--- a/skills-generator/src/main/resources/skill-references/124-java-secure-coding.xml
+++ b/skills-generator/src/main/resources/skill-references/124-java-secure-coding.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Secure coding guidelines</title>
         <description>Use when you need to apply Java secure coding best practices — including validating untrusted inputs, defending against injection attacks with parameterized queries, minimizing attack surface via least privilege, applying strong cryptographic algorithms, handling exceptions securely without exposing sensitive data, managing secrets at runtime, avoiding unsafe deserialization, and encoding output to prevent XSS.</description>

--- a/skills-generator/src/main/resources/skill-references/125-java-concurrency.xml
+++ b/skills-generator/src/main/resources/skill-references/125-java-concurrency.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java rules for Concurrency objects</title>
         <description>Use when you need to apply Java concurrency best practices — including thread safety fundamentals, ExecutorService thread pool management, concurrent design patterns like Producer-Consumer, asynchronous programming with CompletableFuture, immutability and safe publication, deadlock avoidance, virtual threads, structured concurrency, scoped values, backpressure, cancellation discipline, and observability for concurrent systems.</description>

--- a/skills-generator/src/main/resources/skill-references/126-java-exception-handling.xml
+++ b/skills-generator/src/main/resources/skill-references/126-java-exception-handling.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Exception Handling Guidelines</title>
         <description>Use when you need to apply Java exception handling best practices — including using specific exception types, managing resources with try-with-resources, securing exception messages, preserving error context via exception chaining, validating inputs early with fail-fast principles, handling thread interruption correctly, documenting exceptions with @throws, enforcing logging policy, translating exceptions at API boundaries, managing retries and idempotency, enforcing timeouts, attaching suppressed exceptions, and propagating failures in async/reactive code.</description>

--- a/skills-generator/src/main/resources/skill-references/128-java-generics.xml
+++ b/skills-generator/src/main/resources/skill-references/128-java-generics.xml
@@ -2,7 +2,7 @@
 <prompt xmlns:xi="http://www.w3.org/2001/XInclude">
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Generics Best Practices</title>
         <description>Use when you need to review, improve, or refactor Java code for generics quality — including avoiding raw types, applying PECS wildcards, using bounded type parameters, designing effective generic methods, leveraging type inference with the diamond operator, handling type erasure, preventing heap pollution with @SafeVarargs, and integrating generics with Records, sealed types, and pattern matching.</description>

--- a/skills-generator/src/main/resources/skill-references/130-java-testing-strategies.xml
+++ b/skills-generator/src/main/resources/skill-references/130-java-testing-strategies.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java testing strategies</title>
         <description>Use when you need to apply testing strategies for Java code — including RIGHT-BICEP to guide test creation, A-TRIP for test quality characteristics, or CORRECT for verifying boundary conditions. Focused on conceptual frameworks rather than framework-specific annotations.</description>

--- a/skills-generator/src/main/resources/skill-references/131-java-testing-unit-testing.xml
+++ b/skills-generator/src/main/resources/skill-references/131-java-testing-unit-testing.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Unit testing guidelines</title>
         <description>Use when you need to review, improve, or write Java unit tests for framework-agnostic applications (no Spring Boot, Quarkus, Micronaut) — including migrating from JUnit 4 to JUnit 5, adopting AssertJ for fluent assertions, structuring tests with Given-When-Then, ensuring test independence, applying parameterized tests, mocking dependencies with Mockito, verifying boundary conditions (RIGHT-BICEP, CORRECT, A-TRIP), leveraging JSpecify null-safety annotations, or eliminating testing anti-patterns such as reflection-based tests or shared mutable state. For Spring Boot use @321-frameworks-spring-boot-testing-unit-tests. For Quarkus use @421-frameworks-quarkus-testing-unit-tests.</description>

--- a/skills-generator/src/main/resources/skill-references/132-java-testing-integration-testing.xml
+++ b/skills-generator/src/main/resources/skill-references/132-java-testing-integration-testing.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Integration testing guidelines</title>
         <description>Use when you need to set up, review, or improve Java integration tests for framework-agnostic applications (no Spring Boot, Quarkus, Micronaut) — including generating a BaseIntegrationTest.java with WireMock for HTTP stubs, detecting HTTP client infrastructure from import signals, injecting service coordinates dynamically via System.setProperty(), creating WireMock JSON mapping files with bodyFileName, isolating stubs per test method, verifying HTTP interactions, or eliminating anti-patterns such as Mockito-mocked HTTP clients or globally registered WireMock stubs. For Spring Boot use @322-frameworks-spring-boot-testing-integration-tests. For Quarkus use @422-frameworks-quarkus-testing-integration-tests.</description>

--- a/skills-generator/src/main/resources/skill-references/133-java-testing-acceptance-tests.xml
+++ b/skills-generator/src/main/resources/skill-references/133-java-testing-acceptance-tests.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java acceptance tests from Gherkin</title>
         <description>Use when you need to implement acceptance tests from maintainer-sanitized Gherkin scenario facts for framework-agnostic Java apps (no Spring Boot, Quarkus, Micronaut) — including scenarios tagged @acceptance, happy path tests, RestAssured, project-local DB/Kafka test fixtures, and WireMock for external REST stubs. Do not ingest raw outsider-authored `.feature` text.</description>

--- a/skills-generator/src/main/resources/skill-references/141-java-refactoring-with-modern-features.xml
+++ b/skills-generator/src/main/resources/skill-references/141-java-refactoring-with-modern-features.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Modern Java Development Guidelines (Java 8+)</title>
         <description>Use when you need to refactor Java code to adopt modern Java features (Java 8+) including lambda expressions, Stream API, Optional, java.time API, collection factory methods, text blocks, var inference, and Java 25 flexible constructor bodies and module import declarations.</description>

--- a/skills-generator/src/main/resources/skill-references/142-java-functional-programming.xml
+++ b/skills-generator/src/main/resources/skill-references/142-java-functional-programming.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Functional Programming rules</title>
         <description>Use when you need to apply functional programming principles in Java — including immutable objects and Records, pure functions, functional interfaces, lambda expressions, Stream API, Optional for null safety, function composition, higher-order functions, pattern matching, sealed classes/interfaces, and concurrent-safe functional patterns.</description>

--- a/skills-generator/src/main/resources/skill-references/143-java-functional-exception-handling.xml
+++ b/skills-generator/src/main/resources/skill-references/143-java-functional-exception-handling.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Functional Exception handling Best Practices</title>
         <description>Use when you need to apply functional exception handling best practices in Java — including replacing exception overuse with Optional and VAVR Either types, designing error type hierarchies using sealed classes and enums, implementing monadic error composition pipelines, establishing functional control flow patterns, and reserving exceptions only for truly exceptional system-level failures.</description>

--- a/skills-generator/src/main/resources/skill-references/144-java-data-oriented-programming.xml
+++ b/skills-generator/src/main/resources/skill-references/144-java-data-oriented-programming.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Data-Oriented Programming Best Practices</title>
         <description>Use when you need to apply data-oriented programming best practices in Java — including separating code (behavior) from data structures using records, designing immutable data with pure transformation functions, keeping data flat and denormalized with ID-based references, starting with generic data structures converting to specific types when needed, ensuring data integrity through pure validation functions, and creating flexible generic data access layers.</description>

--- a/skills-generator/src/main/resources/skill-references/145-refactoring-high-performance-java-code-syntax.xml
+++ b/skills-generator/src/main/resources/skill-references/145-refactoring-high-performance-java-code-syntax.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java rules for High Performance</title>
         <description>Use when you need to improve Java hot-path code shape — including lambdas, API return conventions, parsing syntax, I/O/storage strategy, concurrency, and control-flow patterns.</description>

--- a/skills-generator/src/main/resources/skill-references/145-refactoring-high-performance-java-cpu.xml
+++ b/skills-generator/src/main/resources/skill-references/145-refactoring-high-performance-java-cpu.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java rules for High Performance</title>
         <description>Use when you need to improve Java CPU hot paths — including bit-level parsing, zero-copy/direct buffers, branchless arithmetic, loop unrolling, Unsafe caution, and SIMD/vectorization patterns.</description>

--- a/skills-generator/src/main/resources/skill-references/145-refactoring-high-performance-java-memory-allocation.xml
+++ b/skills-generator/src/main/resources/skill-references/145-refactoring-high-performance-java-memory-allocation.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java rules for High Performance</title>
         <description>Use when you need to improve Java memory behavior in hot paths — including allocation reduction, primitive data choices, escape analysis, collection sizing, data layout, and deduplication patterns.</description>

--- a/skills-generator/src/main/resources/skill-references/151-java-performance-jmeter.xml
+++ b/skills-generator/src/main/resources/skill-references/151-java-performance-jmeter.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Run performance tests based on JMeter</title>
         <description>Use when you need to set up JMeter performance testing for a Java project — including creating the run-jmeter.sh script from the exact template, configuring load tests with loops, threads, and ramp-up, or running performance tests from the project root.</description>

--- a/skills-generator/src/main/resources/skill-references/152-java-performance-gatling.xml
+++ b/skills-generator/src/main/resources/skill-references/152-java-performance-gatling.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Run performance tests based on Gatling</title>
         <description>Use when you need to set up Gatling performance testing for a Java Maven project — including adding Gatling dependencies and the Gatling Maven plugin, creating Java simulations, running gatling:test, configuring a simulation class, and reviewing generated reports.</description>

--- a/skills-generator/src/main/resources/skill-references/161-java-profiling-detect.xml
+++ b/skills-generator/src/main/resources/skill-references/161-java-profiling-detect.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Profiling Workflow / Step 1 / Collect data to measure potential issues</title>
         <description>Use when you need to set up Java application profiling to detect and measure performance issues — including trusted preinstalled async-profiler v4.x setup, problem-driven profiling (CPU, memory, threading, GC, I/O), interactive profiling scripts, or collecting profiling data with flamegraphs and JFR recordings.</description>

--- a/skills-generator/src/main/resources/skill-references/162-java-profiling-analyze.xml
+++ b/skills-generator/src/main/resources/skill-references/162-java-profiling-analyze.xml
@@ -3,7 +3,7 @@
 
     <metadata>
        <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Profiling Workflow / Step 2 / Analyze profiling data</title>
         <description>Use when you need to analyze Java profiling data collected during the detection phase — including interpreting flamegraphs, memory allocation patterns, CPU hotspots, threading issues, systematic problem categorization, evidence documentation, or prioritizing fixes using Impact/Effort scoring.</description>

--- a/skills-generator/src/main/resources/skill-references/163-java-profiling-refactor.xml
+++ b/skills-generator/src/main/resources/skill-references/163-java-profiling-refactor.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Profiling Workflow / Step 3 / Refactor code to fix issues</title>
         <description>Use when you need to refactor Java code based on profiling analysis findings — including reviewing profiling-problem-analysis and profiling-solutions documents, identifying specific performance bottlenecks, and implementing targeted code changes to address them.</description>

--- a/skills-generator/src/main/resources/skill-references/164-java-profiling-verify.xml
+++ b/skills-generator/src/main/resources/skill-references/164-java-profiling-verify.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Profiling Workflow / Step 4 / Verify results</title>
         <description>Use when you need to verify Java performance optimizations by comparing profiling results before and after refactoring — including baseline validation, post-refactoring report generation, quantitative before/after metrics comparison, side-by-side flamegraph analysis, or creating profiling-comparison-analysis and profiling-final-results documentation.</description>

--- a/skills-generator/src/main/resources/skill-references/170-java-documentation.xml
+++ b/skills-generator/src/main/resources/skill-references/170-java-documentation.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Documentation Generator with modular step-based configuration</title>
         <description>Use when you need to generate or improve Java project documentation — including README.md files, package-info.java files, and Javadoc enhancements — through a modular, step-based interactive process that adapts to your specific documentation needs.</description>

--- a/skills-generator/src/main/resources/skill-references/181-java-observability-logging.xml
+++ b/skills-generator/src/main/resources/skill-references/181-java-observability-logging.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Logging Best Practices</title>
         <description>Use when you need to implement or improve Java logging and observability — including selecting SLF4J with Logback/Log4j2, applying proper log levels, parameterized logging, secure logging without sensitive data exposure, environment-specific configuration, log aggregation, and monitoring.</description>

--- a/skills-generator/src/main/resources/skill-references/182-java-observability-metrics-micrometer.xml
+++ b/skills-generator/src/main/resources/skill-references/182-java-observability-metrics-micrometer.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Metrics Observability with Micrometer</title>
         <description>Use when you need to implement or improve Java metrics observability with Micrometer — including meter design, naming/tag conventions, cardinality control, timers/counters/gauges/distribution summaries, percentiles/histograms, Actuator/Prometheus integration, and metrics validation through tests.</description>

--- a/skills-generator/src/main/resources/skill-references/183-java-observability-tracing-opentelemetry.xml
+++ b/skills-generator/src/main/resources/skill-references/183-java-observability-tracing-opentelemetry.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java Distributed Tracing with OpenTelemetry</title>
         <description>Use when you need to implement or improve distributed tracing with OpenTelemetry in Java — including trace/span modeling, context propagation, semantic conventions, span attributes/events/status, sampling strategy, baggage usage, privacy safeguards, and backend integration with OTLP collectors.</description>

--- a/skills-generator/src/main/resources/skill-references/200-agents-md.xml
+++ b/skills-generator/src/main/resources/skill-references/200-agents-md.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>AGENTS.md Generator for Java repositories</title>
         <description>Use when you need to generate an AGENTS.md file for a Java repository — covering project conventions, tech stack, file structure, commands, Git workflow, and contributor boundaries — through a modular, step-based interactive process that adapts to your specific project needs.</description>

--- a/skills-generator/src/main/resources/skill-references/300-frameworks-spring-boot-create-project.xml
+++ b/skills-generator/src/main/resources/skill-references/300-frameworks-spring-boot-create-project.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Create Spring Boot Maven Project</title>
         <description>Use when creating a new Maven-based Spring Boot 4.0.x project with SDKMAN-managed Java and Spring Boot CLI tooling.</description>

--- a/skills-generator/src/main/resources/skill-references/301-frameworks-spring-boot-core.xml
+++ b/skills-generator/src/main/resources/skill-references/301-frameworks-spring-boot-core.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Spring Boot Core Guidelines</title>
         <description>Use when you need to review, improve, or build Spring Boot 4.0.x applications — including proper usage of @SpringBootApplication, component annotations (@Controller, @Service, @Repository), bean definition and scoping, configuration classes and @ConfigurationProperties (with @Validated), component scanning, conditional configuration and profiles, constructor injection, @Primary and @Qualifier for multiple beans of the same type, bean minimization, graceful shutdown, virtual threads, Jakarta EE namespace consistency, scheduled tasks, and @TestConfiguration.</description>

--- a/skills-generator/src/main/resources/skill-references/302-frameworks-spring-boot-rest.xml
+++ b/skills-generator/src/main/resources/skill-references/302-frameworks-spring-boot-rest.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java REST API Design Principles</title>
         <description>Use when you need to design, review, or improve REST APIs with Spring Boot — including HTTP methods, resource URIs, status codes, DTOs, versioning, deprecation and sunset headers, content negotiation (JSON and vendor media types), ISO-8601 instants in DTOs, pagination/sorting/filtering, Bean Validation at the boundary, idempotency, ETag concurrency, HTTP caching, error handling, security, contract-first OpenAPI (OpenAPI Generator), controller advice, and problem details for errors.</description>

--- a/skills-generator/src/main/resources/skill-references/303-frameworks-spring-boot-validation.xml
+++ b/skills-generator/src/main/resources/skill-references/303-frameworks-spring-boot-validation.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Spring Boot Validation Guidelines</title>
         <description>Use when you need to design, review, or improve validation in Spring Boot applications — including Bean Validation on request DTOs, @Valid/@Validated at API boundaries, constraint groups, custom constraints, @ConfigurationProperties validation, nested DTO validation, and consistent validation error handling.</description>

--- a/skills-generator/src/main/resources/skill-references/304-frameworks-spring-boot-security.xml
+++ b/skills-generator/src/main/resources/skill-references/304-frameworks-spring-boot-security.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Spring Boot Security Guidelines</title>
         <description>Use when you need to design, review, or improve security in Spring Boot applications — including SecurityFilterChain, OAuth2/JWT resource server patterns, form login basics, method security (@PreAuthorize), CSRF and CORS for APIs, session fixation, security headers, exception handling, password encoding, and sensitive-data-safe logging.</description>

--- a/skills-generator/src/main/resources/skill-references/305-frameworks-spring-boot-modulith.xml
+++ b/skills-generator/src/main/resources/skill-references/305-frameworks-spring-boot-modulith.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Spring Boot - Spring Modulith</title>
         <description>Use when you need to design, review, or improve modular monoliths with Spring Modulith in Spring Boot applications - including module package structure, ApplicationModules verification, named interfaces, allowed dependencies, domain events, @ApplicationModuleTest, Scenario-based module tests, generated documentation, actuator exposure, observability, and event publication registry choices.</description>

--- a/skills-generator/src/main/resources/skill-references/311-frameworks-spring-jdbc.xml
+++ b/skills-generator/src/main/resources/skill-references/311-frameworks-spring-jdbc.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Spring JDBC — JdbcClient (Spring Framework 7+)</title>
         <description>Use when you need to write or review programmatic JDBC with Spring — including JdbcClient (Spring Framework 7+) as the default API, JdbcTemplate only where batch/streaming APIs require JdbcOperations, NamedParameterJdbcTemplate for legacy named-param code, parameterized SQL, RowMapper mapping to records, batch operations, transactions, safe handling of generated keys, DataAccessException handling, read-only transactions, streaming large result sets, and @JdbcTest slice testing.</description>

--- a/skills-generator/src/main/resources/skill-references/312-frameworks-spring-data-jdbc.xml
+++ b/skills-generator/src/main/resources/skill-references/312-frameworks-spring-data-jdbc.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Spring Data JDBC with Records</title>
         <description>Use when you need to use Spring Data JDBC with Java records — including entity design with records, repository pattern, immutable updates, aggregate relationships, custom queries, transaction management, and avoiding N+1 problems. For programmatic JDBC (`JdbcTemplate`, `NamedParameterJdbcTemplate`), hand-written SQL, and maximum control without repository abstraction, use `@311-frameworks-spring-jdbc`. For Flyway-backed DDL and versioned schema changes, use `@313-frameworks-spring-db-migrations-flyway`.</description>

--- a/skills-generator/src/main/resources/skill-references/313-frameworks-spring-db-migrations-flyway.xml
+++ b/skills-generator/src/main/resources/skill-references/313-frameworks-spring-db-migrations-flyway.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Spring — Database migrations (Flyway)</title>
         <description>Use when you need to add or review Flyway database migrations in a Spring Boot application — including Maven dependencies, `classpath:db/migration` scripts, versioning (`V{version}__{description}.sql`), configuration via `spring.flyway.*`, baseline and repair for existing databases, validation in CI, and coordination with JDBC (`@311-frameworks-spring-jdbc`) or Spring Data JDBC (`@312-frameworks-spring-data-jdbc`). Focus on Flyway; for ORM schema generation use the stack’s Hibernate integration instead of mixing approaches blindly.</description>

--- a/skills-generator/src/main/resources/skill-references/314-frameworks-spring-kafka.xml
+++ b/skills-generator/src/main/resources/skill-references/314-frameworks-spring-kafka.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Spring Boot — Kafka messaging</title>
         <description>Use when you need Kafka with Spring Boot — including Maven dependencies (`spring-boot-starter-kafka`), typed event records, KafkaTemplate producers, @KafkaListener consumers, JSON serialization with Boot auto-configuration, retries and dead-letter topics, idempotent consumers, and integration testing with Testcontainers `@ServiceConnection` or `@EmbeddedKafka`. This should trigger for requests such as Add Kafka in Spring Boot; Review Spring Kafka consumers; Improve retries and DLT in Spring Kafka.</description>

--- a/skills-generator/src/main/resources/skill-references/315-frameworks-spring-mongodb.xml
+++ b/skills-generator/src/main/resources/skill-references/315-frameworks-spring-mongodb.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Spring Boot — MongoDB</title>
         <description>Use when you need MongoDB with Spring Data MongoDB — including Maven dependencies, document modeling with @Document and @CompoundIndex, MongoRepository, MongoTemplate for complex queries, @Version optimistic locking, and explicit error handling for DuplicateKeyException and OptimisticLockingFailureException. This should trigger for requests such as Add MongoDB in Spring Boot; Review Spring Data Mongo repositories; Improve error handling for Mongo writes.</description>

--- a/skills-generator/src/main/resources/skill-references/316-frameworks-spring-mongodb-migrations-mongock.xml
+++ b/skills-generator/src/main/resources/skill-references/316-frameworks-spring-mongodb-migrations-mongock.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Spring - MongoDB migrations (Mongock)</title>
         <description>Use when you need to add or review Mongock MongoDB data migrations in a Spring Boot application - including runner/driver selection per Spring Boot version, standalone runner wiring, migration scan packages, `@ChangeUnit` classes, lock and transaction behavior, and Testcontainers validation. For general Spring Data MongoDB persistence use `@315-frameworks-spring-mongodb`.</description>

--- a/skills-generator/src/main/resources/skill-references/321-frameworks-spring-boot-testing-unit-tests.xml
+++ b/skills-generator/src/main/resources/skill-references/321-frameworks-spring-boot-testing-unit-tests.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Spring Boot Unit Testing with Mockito</title>
         <description>Use when you need to write unit tests for Spring Boot applications — including pure unit tests with @ExtendWith(MockitoExtension.class) for @Service/@Component, slice tests with @WebMvcTest and @MockBean/@MockitoBean for controllers, @JsonTest for JSON serialization, parameterized tests with @CsvSource/@MethodSource, test profiles, and @TestConfiguration. For framework-agnostic Java use @131-java-testing-unit-testing. For integration tests use @322-frameworks-spring-boot-testing-integration-tests.</description>

--- a/skills-generator/src/main/resources/skill-references/322-frameworks-spring-boot-testing-integration-tests.xml
+++ b/skills-generator/src/main/resources/skill-references/322-frameworks-spring-boot-testing-integration-tests.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Spring Boot Integration Testing</title>
         <description>Use when you need to write or improve integration tests — including Testcontainers with @ServiceConnection, @DataJdbcTest persistence slices, TestRestTemplate or MockMvcTester for HTTP, data isolation, and container lifecycle management for Spring Boot 4.0.x.</description>

--- a/skills-generator/src/main/resources/skill-references/323-frameworks-spring-boot-testing-acceptance-tests.xml
+++ b/skills-generator/src/main/resources/skill-references/323-frameworks-spring-boot-testing-acceptance-tests.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Spring Boot acceptance tests from Gherkin</title>
         <description>Use when you need to implement acceptance tests from a Gherkin .feature file for Spring Boot applications — including finding scenarios tagged @acceptance, implementing happy path tests with TestRestTemplate, @SpringBootTest, Testcontainers for DB/Kafka, and WireMock for external REST stubs.</description>

--- a/skills-generator/src/main/resources/skill-references/400-frameworks-quarkus-create-project.xml
+++ b/skills-generator/src/main/resources/skill-references/400-frameworks-quarkus-create-project.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Create Quarkus Maven Project</title>
         <description>Use when creating a new Maven-based Quarkus 3.x project with SDKMAN-managed Java and Quarkus CLI tooling.</description>

--- a/skills-generator/src/main/resources/skill-references/401-frameworks-quarkus-core.xml
+++ b/skills-generator/src/main/resources/skill-references/401-frameworks-quarkus-core.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Quarkus Core Guidelines</title>
         <description>Use when you need to review, improve, or build Quarkus applications — including mandatory @QuarkusMain entry points with static main methods, CDI scopes (@ApplicationScoped, @Singleton, @Dependent), constructor injection, @ConfigMapping and SmallRye Config, profiles (%dev, %test, %prod), build-time vs runtime configuration, lifecycle (@Startup, @PreDestroy), metrics integration patterns, and test-friendly bean design.</description>

--- a/skills-generator/src/main/resources/skill-references/402-frameworks-quarkus-rest.xml
+++ b/skills-generator/src/main/resources/skill-references/402-frameworks-quarkus-rest.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Quarkus REST API Guidelines</title>
         <description>Use when you need to design, review, or improve REST APIs with Quarkus REST (Jakarta REST) — including resource classes, HTTP methods, status codes, request/response DTOs, ISO-8601 instants in DTOs, Bean Validation, exception mappers, optional runtime OpenAPI exposure (SmallRye), contract-first generation from OpenAPI (Quarkus OpenAPI Generator or OpenAPI Generator `jaxrs-spec`), content negotiation, pagination, and security-aware boundaries.</description>

--- a/skills-generator/src/main/resources/skill-references/403-frameworks-quarkus-validation.xml
+++ b/skills-generator/src/main/resources/skill-references/403-frameworks-quarkus-validation.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Quarkus Validation Guidelines</title>
         <description>Use when you need to design, review, or improve validation in Quarkus applications — including Bean Validation on JAX-RS resources, @Valid on parameters and CDI beans, constraint groups, @ConfigMapping validation, custom constraints, nested DTO validation, and RFC 7807 validation errors via quarkus-http-problem.</description>

--- a/skills-generator/src/main/resources/skill-references/404-frameworks-quarkus-security.xml
+++ b/skills-generator/src/main/resources/skill-references/404-frameworks-quarkus-security.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Quarkus Security Guidelines</title>
         <description>Use when you need to design, review, or improve security in Quarkus applications — including Quarkus Security with JWT/OIDC, basic auth, @RolesAllowed / @Authenticated / @PermitAll, SecurityIdentity, permission checks, path-based authorization in configuration, exception mapping for auth failures, and sensitive-data-safe logging.</description>

--- a/skills-generator/src/main/resources/skill-references/411-frameworks-quarkus-jdbc.xml
+++ b/skills-generator/src/main/resources/skill-references/411-frameworks-quarkus-jdbc.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Quarkus JDBC — programmatic SQL</title>
         <description>Use when you need to write or review programmatic JDBC in Quarkus — including Agroal-backed DataSource injection, PreparedStatement with bind parameters, mapping rows to Java records, transactions (@Transactional), batch updates, SQL text blocks and upserts with domain exception translation, and optional NamedParameterJdbcTemplate when spring-jdbc is on the classpath. Prefer explicit SQL without ORM.</description>

--- a/skills-generator/src/main/resources/skill-references/412-frameworks-quarkus-panache.xml
+++ b/skills-generator/src/main/resources/skill-references/412-frameworks-quarkus-panache.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Hibernate ORM with Panache</title>
         <description>Use when you need data access with Quarkus Hibernate ORM Panache — including PanacheEntity / PanacheEntityBase, PanacheRepository, named queries, JPQL, native SQL, transactions, pagination, and immutable-friendly patterns. This is the Quarkus analogue to Spring Data for relational persistence; prefer Panache APIs over verbose persistence boilerplate. For Flyway-backed DDL and versioned schema changes, use `@413-frameworks-quarkus-db-migrations-flyway`.</description>

--- a/skills-generator/src/main/resources/skill-references/413-frameworks-quarkus-db-migrations-flyway.xml
+++ b/skills-generator/src/main/resources/skill-references/413-frameworks-quarkus-db-migrations-flyway.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Quarkus — Database migrations (Flyway)</title>
         <description>Use when you need to add or review Flyway database migrations in a Quarkus application — including the `quarkus-flyway` extension, `classpath:db/migration` scripts, `V{version}__{description}.sql` naming, `quarkus.flyway.*` configuration, migrate-at-start behavior, and coordination with JDBC (`@411-frameworks-quarkus-jdbc`) or Hibernate ORM with Panache (`@412-frameworks-quarkus-panache`). Focus on Flyway-driven schema evolution, not hand-applied DDL in production.</description>

--- a/skills-generator/src/main/resources/skill-references/414-frameworks-quarkus-kafka.xml
+++ b/skills-generator/src/main/resources/skill-references/414-frameworks-quarkus-kafka.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Quarkus — Kafka messaging</title>
         <description>Use when you need Kafka in Quarkus with SmallRye Reactive Messaging — including Maven extension, channel/topic design, typed @Channel Emitter producers, @Incoming consumers with Uni, build-time Jackson serialization, failure strategies (dead-letter-queue, retry), idempotency, Dev Services, and Testcontainers integration tests. This should trigger for requests such as Add Kafka in Quarkus; Review Reactive Messaging consumers; Improve failure handling for Quarkus Kafka.</description>

--- a/skills-generator/src/main/resources/skill-references/415-frameworks-quarkus-mongodb.xml
+++ b/skills-generator/src/main/resources/skill-references/415-frameworks-quarkus-mongodb.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Quarkus — MongoDB</title>
         <description>Use when you need MongoDB in Quarkus with MongoDB Panache — including Maven extension, entity/repository design with @MongoEntity, PanacheMongoEntity active record vs PanacheMongoRepository, parameterized queries, service-layer persistence boundaries, optional transaction support where infrastructure allows it, and explicit error handling for duplicate key and transient failures. This should trigger for requests such as Add MongoDB in Quarkus; Review Quarkus Mongo Panache entities; Improve Mongo error handling in Quarkus services.</description>

--- a/skills-generator/src/main/resources/skill-references/416-frameworks-quarkus-mongodb-migrations-mongock.xml
+++ b/skills-generator/src/main/resources/skill-references/416-frameworks-quarkus-mongodb-migrations-mongock.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Quarkus - MongoDB migrations (Mongock)</title>
         <description>Use when you need to add or review Mongock MongoDB data migrations in a Quarkus application - including the Quarkiverse Mongock extension, Quarkus MongoDB client configuration, `quarkus.mongock.*` settings, `@ChangeUnit` classes, lock and transaction behavior, and Quarkus test validation. For general Quarkus MongoDB persistence use `@415-frameworks-quarkus-mongodb`.</description>

--- a/skills-generator/src/main/resources/skill-references/421-frameworks-quarkus-testing-unit-tests.xml
+++ b/skills-generator/src/main/resources/skill-references/421-frameworks-quarkus-testing-unit-tests.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Quarkus Unit Testing</title>
         <description>Use when you need to write fast unit tests for Quarkus applications — including pure tests with @ExtendWith(MockitoExtension.class) for CDI @ApplicationScoped beans (instantiated manually), @QuarkusTest with @InjectMock to replace CDI dependencies in focused tests, REST Assured only when HTTP surface is under test, and @ParameterizedTest for data-driven cases. For framework-agnostic Java use @131-java-testing-unit-testing. For full integration use @422-frameworks-quarkus-testing-integration-tests.</description>

--- a/skills-generator/src/main/resources/skill-references/422-frameworks-quarkus-testing-integration-tests.xml
+++ b/skills-generator/src/main/resources/skill-references/422-frameworks-quarkus-testing-integration-tests.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Quarkus Integration Testing</title>
         <description>Use when you need to write or improve integration tests for Quarkus — including @QuarkusTest, Dev Services for databases and messaging, Testcontainers when Dev Services are insufficient, @QuarkusIntegrationTest for black-box tests, REST Assured against @TestHTTPManager, persistence with @Transactional rollback, and clear separation of *IT tests in Failsafe.</description>

--- a/skills-generator/src/main/resources/skill-references/423-frameworks-quarkus-testing-acceptance-tests.xml
+++ b/skills-generator/src/main/resources/skill-references/423-frameworks-quarkus-testing-acceptance-tests.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Quarkus acceptance tests from Gherkin</title>
         <description>Use when you need to implement acceptance tests from a Gherkin .feature file for Quarkus applications — including scenarios tagged @acceptance, @QuarkusTest, REST Assured over the real HTTP port, Testcontainers or Dev Services for databases and Kafka, and WireMock for external REST stubs.</description>

--- a/skills-generator/src/main/resources/skill-references/500-frameworks-micronaut-create-project.xml
+++ b/skills-generator/src/main/resources/skill-references/500-frameworks-micronaut-create-project.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Create Micronaut Maven Project</title>
         <description>Use when creating a new Maven-based Micronaut 4.x project with SDKMAN-managed Java and Micronaut CLI tooling.</description>

--- a/skills-generator/src/main/resources/skill-references/501-frameworks-micronaut-core.xml
+++ b/skills-generator/src/main/resources/skill-references/501-frameworks-micronaut-core.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Micronaut Core Guidelines</title>
         <description>Use when you need to review, improve, or build Micronaut applications — including application bootstrap with Micronaut.run, @Singleton/@Prototype scopes, @Factory bean producers, constructor injection with jakarta.inject, @ConfigurationProperties and @Property, environments and @Requires, @Controller vs application services, AOP interceptors, @Scheduled tasks, graceful shutdown, virtual-thread friendly execution, health endpoints, and test-oriented bean design.</description>

--- a/skills-generator/src/main/resources/skill-references/502-frameworks-micronaut-rest.xml
+++ b/skills-generator/src/main/resources/skill-references/502-frameworks-micronaut-rest.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Micronaut REST API Guidelines</title>
         <description>Use when you need to design, review, or improve REST APIs with Micronaut — including HTTP methods, resource URIs, status codes, DTOs, versioning, deprecation and sunset headers, content negotiation (JSON and vendor media types), ISO-8601 instants in DTOs, pagination/sorting/filtering, Bean Validation at the boundary, idempotency, ETag concurrency, HTTP caching, error handling with `ExceptionHandler`, security annotations, contract-first OpenAPI (OpenAPI Generator `micronaut` server), optional runtime OpenAPI via `micronaut-openapi`, and RFC 7807-style problem details for errors.</description>

--- a/skills-generator/src/main/resources/skill-references/503-frameworks-micronaut-validation.xml
+++ b/skills-generator/src/main/resources/skill-references/503-frameworks-micronaut-validation.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Micronaut Validation Guidelines</title>
         <description>Use when you need to design, review, or improve validation in Micronaut applications — including Bean Validation on @Controller methods, @Body @Valid, query/path parameter validation, @ConfigurationProperties validation, custom constraints, nested DTO validation, and ExceptionHandler mapping for constraint violations.</description>

--- a/skills-generator/src/main/resources/skill-references/504-frameworks-micronaut-security.xml
+++ b/skills-generator/src/main/resources/skill-references/504-frameworks-micronaut-security.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Micronaut Security Guidelines</title>
         <description>Use when you need to design, review, or improve security in Micronaut applications — including micronaut-security authentication, @Secured and intercept-url-map rules, JWT/session strategies, SecurityService checks, CORS, CSRF awareness for browser apps, rejection handlers, and sensitive-data-safe logging.</description>

--- a/skills-generator/src/main/resources/skill-references/511-frameworks-micronaut-jdbc.xml
+++ b/skills-generator/src/main/resources/skill-references/511-frameworks-micronaut-jdbc.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Micronaut JDBC — programmatic SQL</title>
         <description>Use when you need to write or review programmatic JDBC in Micronaut — including Hikari-backed DataSource injection, PreparedStatement with bind parameters, mapping rows to Java records, transactions (io.micronaut.transaction.annotation.Transactional), batch updates, SQL text blocks, and domain-specific exception translation. Prefer explicit SQL without Micronaut Data when you need full control.</description>

--- a/skills-generator/src/main/resources/skill-references/512-frameworks-micronaut-data.xml
+++ b/skills-generator/src/main/resources/skill-references/512-frameworks-micronaut-data.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Micronaut Data Guidelines</title>
         <description>Use when you need data access with Micronaut Data — including JDBC (and JPA where applicable) repositories, @MappedEntity design, CrudRepository and custom @Query methods, pagination with Pageable, transactions with @Transactional, immutable-friendly entities and DTO projections, optimistic locking, compile-time query validation, and test setup with @MicronautTest and TestPropertyProvider. For hand-written java.sql repositories and maximum SQL control, use `@511-frameworks-micronaut-jdbc`. For Flyway-backed DDL and versioned schema changes, use `@513-frameworks-micronaut-db-migrations-flyway`.</description>

--- a/skills-generator/src/main/resources/skill-references/513-frameworks-micronaut-db-migrations-flyway.xml
+++ b/skills-generator/src/main/resources/skill-references/513-frameworks-micronaut-db-migrations-flyway.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Micronaut — Database migrations (Flyway)</title>
         <description>Use when you need to add or review Flyway database migrations in a Micronaut application — including `micronaut-flyway` (or Flyway integration aligned with your Micronaut BOM), `classpath:db/migration` scripts, `V{version}__{description}.sql` naming, per-datasource Flyway configuration, and coordination with JDBC (`@511-frameworks-micronaut-jdbc`) or Micronaut Data (`@512-frameworks-micronaut-data`). Focus on repeatable, versioned schema evolution.</description>

--- a/skills-generator/src/main/resources/skill-references/514-frameworks-micronaut-kafka.xml
+++ b/skills-generator/src/main/resources/skill-references/514-frameworks-micronaut-kafka.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Micronaut — Kafka messaging</title>
         <description>Use when you need Kafka in Micronaut — including Maven dependency and annotation processor, @Serdeable event records, @KafkaClient typed producers, @KafkaListener consumers with OffsetStrategy and ErrorStrategyValue, dead-letter routing, idempotency, and integration testing with @MicronautTest, TestPropertyProvider, and Testcontainers. This should trigger for requests such as Add Kafka in Micronaut; Review Micronaut Kafka listeners; Improve retry and failure handling for Micronaut Kafka.</description>

--- a/skills-generator/src/main/resources/skill-references/515-frameworks-micronaut-mongodb.xml
+++ b/skills-generator/src/main/resources/skill-references/515-frameworks-micronaut-mongodb.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Micronaut — MongoDB</title>
         <description>Use when you need MongoDB persistence in Micronaut — including Maven dependency, @MappedEntity document design, @MongoRepository with typed finders and @MongoFindQuery, @Singleton service boundaries, optional @Transactional use where MongoDB transaction support is configured, and explicit error handling for MongoWriteException and DataAccessException. This should trigger for requests such as Add MongoDB in Micronaut; Review Micronaut Data Mongo entities; Improve error handling for Micronaut Mongo operations.</description>

--- a/skills-generator/src/main/resources/skill-references/516-frameworks-micronaut-mongodb-migrations-mongock.xml
+++ b/skills-generator/src/main/resources/skill-references/516-frameworks-micronaut-mongodb-migrations-mongock.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Micronaut - MongoDB migrations (Mongock)</title>
         <description>Use when you need to add or review Mongock MongoDB data migrations in a Micronaut application - including Mongock runner/driver selection, Micronaut bean wiring, migration scan packages, `@ChangeUnit` classes, lock and transaction behavior, and Testcontainers validation. For general Micronaut MongoDB persistence use `@515-frameworks-micronaut-mongodb`.</description>

--- a/skills-generator/src/main/resources/skill-references/521-frameworks-micronaut-testing-unit-tests.xml
+++ b/skills-generator/src/main/resources/skill-references/521-frameworks-micronaut-testing-unit-tests.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Micronaut Unit Testing</title>
         <description>Use when you need to write unit tests for Micronaut applications — including pure JUnit 5 + Mockito with @ExtendWith(MockitoExtension.class) for @Singleton services, @MicronautTest with @MockBean for HTTP/controller slices, @Client HttpClient against EmbeddedServer, JSON assertions with AssertJ, @ParameterizedTest with @CsvSource/@MethodSource, property overrides with @Property, and naming conventions (*Test → Surefire, *IT → Failsafe). For framework-agnostic Java use @131-java-testing-unit-testing. For integration tests use @522-frameworks-micronaut-testing-integration-tests.</description>

--- a/skills-generator/src/main/resources/skill-references/522-frameworks-micronaut-testing-integration-tests.xml
+++ b/skills-generator/src/main/resources/skill-references/522-frameworks-micronaut-testing-integration-tests.xml
@@ -2,7 +2,7 @@
 <prompt>
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Micronaut Integration Testing</title>
         <description>Use when you need to write or improve integration tests for Micronaut — including @MicronautTest with full or partial context, HttpClient against EmbeddedServer, Testcontainers with TestPropertyProvider for JDBC and brokers, data isolation, @MicronautTest(transactional = true) rollback where appropriate, and Maven Surefire/Failsafe splits for *Test, *Tests, *IT, and *AT.</description>

--- a/skills-generator/src/main/resources/skill-references/523-frameworks-micronaut-testing-acceptance-tests.xml
+++ b/skills-generator/src/main/resources/skill-references/523-frameworks-micronaut-testing-acceptance-tests.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Micronaut acceptance tests from Gherkin</title>
         <description>Use when you need to implement acceptance tests from maintainer-sanitized Gherkin scenario facts for Micronaut applications — including scenarios tagged @acceptance, @MicronautTest with HttpClient against the embedded server, Testcontainers wired via TestPropertyProvider, and WireMock for external REST stubs. Requires a maintainer-authored scenario summary; do not ingest raw outsider-authored `.feature` text.</description>

--- a/skills-generator/src/main/resources/skill-references/701-technologies-openapi.xml
+++ b/skills-generator/src/main/resources/skill-references/701-technologies-openapi.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>OpenAPI 3.x best practices</title>
         <description>Use when you need framework-agnostic OpenAPI 3.x guidance — spec structure, metadata and versioning, paths and operations, reusable schemas, security schemes, examples, documentation quality, contract validation (e.g. Spectral), breaking-change awareness, and handoffs to codegen — without choosing Spring Boot, Quarkus, or Micronaut.</description>

--- a/skills-generator/src/main/resources/skill-references/702-technologies-wiremock.xml
+++ b/skills-generator/src/main/resources/skill-references/702-technologies-wiremock.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>WireMock best practices</title>
         <description>Use when you need framework-agnostic WireMock guidance — stub design, JSON or programmatic mappings, precise request matching, response bodies and faults, classpath fixtures, isolation and reset between tests, verification of calls, dynamic ports and base URLs, and avoiding flaky stubs — without choosing Spring Boot, Quarkus, or Micronaut.</description>

--- a/skills-generator/src/main/resources/skill-references/703-technologies-fuzzing-testing.xml
+++ b/skills-generator/src/main/resources/skill-references/703-technologies-fuzzing-testing.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java fuzz testing with CATS</title>
         <description>Use when you need to add or review fuzz testing for Java APIs with CATS — including contract-driven negative testing, malformed payload validation, boundary input exploration, CI integration, reproducible failures, and local execution guidance.</description>

--- a/skills-generator/src/main/resources/skill-references/704-technologies-sql.xml
+++ b/skills-generator/src/main/resources/skill-references/704-technologies-sql.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>SQL best practices</title>
         <description>Use when you need framework-agnostic SQL guidance — schema naming, relational table design, query readability, indexes, transactions, database security, migrations, testing, and monitoring — without choosing Spring Boot, Quarkus, or Micronaut.</description>

--- a/skills-generator/src/main/resources/skill-references/705-technologies-nosql-mongodb.xml
+++ b/skills-generator/src/main/resources/skill-references/705-technologies-nosql-mongodb.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Non-relational database query best practices</title>
         <description>Use when you need framework-agnostic MongoDB and non-relational database query guidance — document schema design, collection modeling, JSON Schema validation, indexes, aggregation pipelines, query performance, consistency trade-offs, transactions, and operational safety.</description>

--- a/skills-generator/src/main/resources/skill-references/706-technologies-containers-docker.xml
+++ b/skills-generator/src/main/resources/skill-references/706-technologies-containers-docker.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>Java container image best practices with Docker</title>
         <description>Use when you need framework-agnostic Docker and container image guidance for Java projects - Dockerfile design, multi-stage Maven builds, jlink custom runtimes, micro runtime distributions such as Alpaquita, JVM container ergonomics, non-root execution, image metadata, .dockerignore, reproducible builds, vulnerability scanning, SBOM awareness, and production-safe container defaults.</description>

--- a/skills-generator/src/main/resources/skill-references/801-regulations-eu-ai-act-chapters-summary.xml
+++ b/skills-generator/src/main/resources/skill-references/801-regulations-eu-ai-act-chapters-summary.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>EU AI Act Regulation for Java Enterprise Development with AI Systems and AI Agents</title>
         <description>Use as a chapter-by-chapter summary of Regulation (EU) 2024/1689 to enrich Java enterprise AI system and AI agent reviews with EU AI Act context.</description>

--- a/skills-generator/src/main/resources/skill-references/801-regulations-eu-ai-act-engineering-examples.xml
+++ b/skills-generator/src/main/resources/skill-references/801-regulations-eu-ai-act-engineering-examples.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>EU AI Act Regulation for Java Enterprise Development with AI Systems and AI Agents</title>
         <description>Use as Java-focused EU AI Act engineering examples for AI capability classification, agent tool gates, audit evidence, RAG governance, release readiness, and incident routing.</description>

--- a/skills-generator/src/main/resources/skill-references/802-regulations-dora-chapters-summary.xml
+++ b/skills-generator/src/main/resources/skill-references/802-regulations-dora-chapters-summary.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>DORA Regulation for Java Enterprise Digital Operational Resilience</title>
         <description>Use as a chapter-by-chapter and article-by-article summary of Regulation (EU) 2022/2554 to enrich Java enterprise operational-resilience reviews with DORA context.</description>

--- a/skills-generator/src/main/resources/skill-references/802-regulations-dora-engineering-examples.xml
+++ b/skills-generator/src/main/resources/skill-references/802-regulations-dora-engineering-examples.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>DORA Regulation for Java Enterprise Digital Operational Resilience</title>
         <description>Use as Java-focused DORA engineering examples for ICT inventory, incident routing, recovery evidence, third-party ICT provider risk, resilience release gates, and Java release-policy controls.</description>

--- a/skills-generator/src/main/resources/skill-references/803-regulations-gdpr-chapters-summary.xml
+++ b/skills-generator/src/main/resources/skill-references/803-regulations-gdpr-chapters-summary.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>GDPR Regulation for Java Enterprise Personal Data Protection</title>
         <description>Use as a chapter-by-chapter and article-by-article summary of Regulation (EU) 2016/679 to enrich Java enterprise privacy engineering reviews with GDPR context.</description>

--- a/skills-generator/src/main/resources/skill-references/803-regulations-gdpr-engineering-examples.xml
+++ b/skills-generator/src/main/resources/skill-references/803-regulations-gdpr-engineering-examples.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>GDPR Regulation for Java Enterprise Personal Data Protection</title>
         <description>Use as Java-focused GDPR engineering examples for personal-data inventory, DTO minimization, rights workflows, retention and deletion, transfer review, privacy-safe logging, and field-level privacy policy controls.</description>

--- a/skills-generator/src/main/resources/skill-references/804-regulations-eu-nis2-chapters-summary.xml
+++ b/skills-generator/src/main/resources/skill-references/804-regulations-eu-nis2-chapters-summary.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>NIS2 Regulation for Java Enterprise Cybersecurity Risk Management</title>
         <description>Use as a chapter-by-chapter and article-by-article summary of Directive (EU) 2022/2555 to enrich Java enterprise cybersecurity and operational-resilience reviews with NIS2 context.</description>

--- a/skills-generator/src/main/resources/skill-references/804-regulations-eu-nis2-engineering-examples.xml
+++ b/skills-generator/src/main/resources/skill-references/804-regulations-eu-nis2-engineering-examples.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>NIS2 Regulation for Java Enterprise Cybersecurity Risk Management</title>
         <description>Use as Java-focused NIS2 engineering examples for asset inventory, incident escalation, vulnerability evidence, continuity, supply-chain security, and secure release gates.</description>

--- a/skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-chapters-summary.xml
+++ b/skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-chapters-summary.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>EU Cyber Resilience Act Regulation for Java Product Security Engineering</title>
         <description>Use as a chapter-by-chapter, article-by-article, and annex-level summary of Regulation (EU) 2024/2847 to enrich Java product security reviews with Cyber Resilience Act context.</description>

--- a/skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-engineering-examples.xml
+++ b/skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-engineering-examples.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>EU Cyber Resilience Act Regulation for Java Product Security Engineering</title>
         <description>Use as Java-focused Cyber Resilience Act engineering examples for secure-by-design development, vulnerability handling, coordinated disclosure, security updates, SBOM evidence, product security documentation, support-period signaling, and release gates.</description>

--- a/skills-generator/src/main/resources/skill-references/806-regulations-eu-data-act-chapters-summary.xml
+++ b/skills-generator/src/main/resources/skill-references/806-regulations-eu-data-act-chapters-summary.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>EU Data Act Regulation for Java Enterprise Data Access and Portability Engineering</title>
         <description>Use as a chapter-by-chapter and article-by-article summary of Regulation (EU) 2023/2854 to enrich Java enterprise data access, portability, interoperability, and cloud-switching reviews with EU Data Act context.</description>

--- a/skills-generator/src/main/resources/skill-references/806-regulations-eu-data-act-engineering-examples.xml
+++ b/skills-generator/src/main/resources/skill-references/806-regulations-eu-data-act-engineering-examples.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>EU Data Act Regulation for Java Enterprise Data Access and Portability Engineering</title>
         <description>Use as Java-focused EU Data Act engineering examples for data inventory, access authorization, portability APIs, export formats, metadata, audit logs, cloud switching, non-personal data safeguards, trade-secret handoffs, and data-sharing request workflows.</description>

--- a/skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-chapters-summary.xml
+++ b/skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-chapters-summary.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>EU Digital Services Act Regulation for Java Online Platform Engineering</title>
         <description>Use as a chapter-by-chapter and article-by-article summary of Regulation (EU) 2022/2065 to enrich Java online platform, moderation, transparency, recommender, advertising, and systemic-risk engineering reviews with Digital Services Act context.</description>

--- a/skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-engineering-examples.xml
+++ b/skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-engineering-examples.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>EU Digital Services Act Regulation for Java Online Platform Engineering</title>
         <description>Use as Java-focused Digital Services Act engineering examples for content decision audit logs, moderation workflow state, notice tracking, recommender explanation, ad transparency, user controls, appeals, systemic-risk evidence, auditor and researcher access, incident escalation, and privacy-safe observability.</description>

--- a/skills-generator/src/main/resources/skill-references/808-regulations-eu-digital-markets-act-chapters-summary.xml
+++ b/skills-generator/src/main/resources/skill-references/808-regulations-eu-digital-markets-act-chapters-summary.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>EU Digital Markets Act Regulation for Java Enterprise Gatekeeper Platform Controls</title>
         <description>Use as a chapter-by-chapter and article-by-article summary of Regulation (EU) 2022/1925 to enrich Java enterprise platform reviews with Digital Markets Act context.</description>

--- a/skills-generator/src/main/resources/skill-references/808-regulations-eu-digital-markets-act-engineering-examples.xml
+++ b/skills-generator/src/main/resources/skill-references/808-regulations-eu-digital-markets-act-engineering-examples.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <license>Apache-2.0</license>
         <title>EU Digital Markets Act Regulation for Java Enterprise Gatekeeper Platform Controls</title>
         <description>Use as Java-focused Digital Markets Act engineering examples for interoperability interfaces, business-user data access, consent evidence, ranking audit signals, export workflows, anti-circumvention controls, and compliance evidence handoff.</description>

--- a/skills-generator/src/main/resources/skill-references/behaviour-article-writer.xml
+++ b/skills-generator/src/main/resources/skill-references/behaviour-article-writer.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <title>Behaviour Article Writer</title>
     </metadata>
 

--- a/skills-generator/src/main/resources/skill-references/behaviour-consultative-interaction.xml
+++ b/skills-generator/src/main/resources/skill-references/behaviour-consultative-interaction.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <title>Behaviour Consultative Interaction Technique</title>
     </metadata>
 

--- a/skills-generator/src/main/resources/skill-references/behaviour-progressive-learning.xml
+++ b/skills-generator/src/main/resources/skill-references/behaviour-progressive-learning.xml
@@ -3,7 +3,7 @@
 
     <metadata>
         <author>Juan Antonio Breña Moral</author>
-        <version>0.16.0</version>
+        <version>0.17.0-SNAPSHOT</version>
         <title>Behaviour Progressive Learning</title>
     </metadata>
 


### PR DESCRIPTION
## Summary
- Bump root Maven project version to `0.17.0-SNAPSHOT`
- Align reactor module parent versions for `skills-generator` and `site-generator`
- Align generated skill source metadata versions with the Maven project version

## Validation
- `./mvnw validate`
- `xmllint --noout` over edited skill XML sources
- `./mvnw clean verify`
- `git diff --check`

Closes #897