### PR TITLE
docs(skills): improve flyway boot starter guidance

### DIFF
--- a/skills-generator/src/main/resources/skill-references/313-frameworks-spring-db-migrations-flyway.xml
+++ b/skills-generator/src/main/resources/skill-references/313-frameworks-spring-db-migrations-flyway.xml
@@ -33,18 +33,22 @@
         <example number="1" id="maven-flyway-dependencies">
             <example-header>
                 <example-title>Maven coordinates</example-title>
-                <example-subtitle>Add Flyway on the classpath; use database-specific Flyway modules when required by your Flyway major version</example-subtitle>
+                <example-subtitle>Use Spring Boot Flyway support; add database-specific Flyway modules when required by your dialect</example-subtitle>
             </example-header>
             <example-description>
                 <![CDATA[
-                Spring Boot manages Flyway versions via its BOM. Declare `flyway-core` (often transitively via `spring-boot-starter-jdbc` + explicit Flyway, or a dedicated starter pattern used in your project). For PostgreSQL and recent Flyway releases, add the matching `flyway-database-postgresql` artifact so Flyway can talk to the dialect. Keep JDBC driver and Flyway versions compatible with your Spring Boot BOM.
+                Spring Boot manages Flyway versions via its BOM. For Spring Boot 4.x, prefer `spring-boot-starter-flyway` so Boot contributes Flyway auto-configuration and creates the `Flyway` bean. Pair it with JDBC/DataSource support as needed. For PostgreSQL and recent Flyway releases, add the matching `flyway-database-postgresql` artifact so Flyway can talk to the dialect. Keep JDBC driver and Flyway versions compatible with your Spring Boot BOM.
                 ]]>
             </example-description>
             <code-examples>
                 <good-example>
                     <code-block language="xml"><![CDATA[<dependency>
-    <groupId>org.flywaydb</groupId>
-    <artifactId>flyway-core</artifactId>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-jdbc</artifactId>
+</dependency>
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-flyway</artifactId>
 </dependency>
 <dependency>
     <groupId>org.flywaydb</groupId>
@@ -160,6 +164,56 @@ public class V3__LoadProdData extends BaseJavaMigration {
             </code-examples>
         </example>
 
+        <example number="5" id="migration-smoke-test">
+            <example-header>
+                <example-title>Migration smoke test</example-title>
+                <example-subtitle>Verify Spring Boot wires Flyway and applies the migration chain</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Add or update a Spring Boot test that proves Flyway auto-configuration is active. The test should load the application context, inject `Flyway`, assert that expected migrations are applied, and verify the migrated schema through JDBC. Prefer Testcontainers with the production database dialect when production does not use an embedded database.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="java"><![CDATA[@SpringBootTest
+class FlywayMigrationTest {
+
+    @Autowired
+    Flyway flyway;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @Test
+    void appliesCustomerMigration() {
+        assertThat(flyway.info().applied()).hasSize(1);
+
+        Integer customerTableCount = jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_NAME = 'CUSTOMERS'
+            """,
+            Integer.class);
+
+        assertThat(customerTableCount).isEqualTo(1);
+    }
+}]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="java"><![CDATA[// Bad: only checks that the web context starts; it never proves Flyway ran.
+@SpringBootTest
+class ApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
     </examples>
 
     <output-format>
@@ -169,7 +223,7 @@ public class V3__LoadProdData extends BaseJavaMigration {
             <output-format-item>**APPLY** Spring Boot–aligned fixes: correct artifacts, script layout, `spring.flyway.*` tuning, and forward-only migration discipline</output-format-item>
             <output-format-item>**COORDINATE** with `@311-frameworks-spring-jdbc` / `@312-frameworks-spring-data-jdbc` so entities and SQL match applied migrations</output-format-item>
             <output-format-item>**SAFEGUARD DATA** by checking renames, type changes, defaults, enum/status changes, timezone changes, repeatable migrations, broad updates, and unique/index changes for preservation risks</output-format-item>
-            <output-format-item>**TEST** with integration tests hitting a real database (e.g. Testcontainers) after migration changes</output-format-item>
+            <output-format-item>**TEST** with integration tests hitting a real database (e.g. Testcontainers) after migration changes; include a Spring Boot migration smoke test that injects `Flyway` and asserts applied migrations</output-format-item>
             <output-format-item>**CHECK ORDERING** for duplicate versions, branch-dependent migrations, and unsafe `outOfOrder=true` assumptions</output-format-item>
             <output-format-item>**VALIDATE** with `./mvnw compile` before and `./mvnw clean verify` after changes</output-format-item>
         </output-format-list>

--- a/skills-generator/src/main/resources/skill-references/413-frameworks-quarkus-db-migrations-flyway.xml
+++ b/skills-generator/src/main/resources/skill-references/413-frameworks-quarkus-db-migrations-flyway.xml
@@ -139,16 +139,57 @@ quarkus.flyway.locations=classpath:db/migration]]></code-block>
             </code-examples>
         </example>
 
+        <example number="5" id="quarkus-first-flyway-migration">
+            <example-header>
+                <example-title>First Flyway migration in a Quarkus project</example-title>
+                <example-subtitle>Bootstrap the datasource, Flyway extension, migration folder, and production-dialect verification together</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                When a Quarkus project has no datasource, no JDBC or Panache persistence layer, and no Flyway setup yet, treat the request as a bootstrap plus migration change. Add `quarkus-flyway` together with the matching `quarkus-jdbc-*` driver, configure `quarkus.flyway.migrate-at-start=true` and `classpath:db/migration`, then create a versioned migration under `src/main/resources/db/migration`. For data-sensitive changes such as `status` to `status_v2`, keep the first migration in the expand phase: add the new nullable column, backfill from the old value, keep the old column available, and defer `NOT NULL` plus dropping the old column to later deployable contract migrations.
+
+                Verify the migration with the production database dialect when feasible. In Quarkus tests, Dev Services or Testcontainers can start PostgreSQL, MySQL, or another matching database without hardcoded datasource URLs. For semantic changes, add or recommend a previous-release fixture test that loads representative old rows, runs Flyway, and asserts the business meaning is preserved after migration.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="sql"><![CDATA[-- src/main/resources/db/migration/V1__expand_order_status_v2.sql
+ALTER TABLE orders ADD COLUMN status_v2 VARCHAR(40);
+
+UPDATE orders
+SET status_v2 = CASE status
+    WHEN 'P' THEN 'PENDING'
+    WHEN 'S' THEN 'SHIPPED'
+    WHEN 'C' THEN 'CANCELLED'
+    ELSE 'UNKNOWN'
+END
+WHERE status_v2 IS NULL;
+
+-- Later deployable steps:
+-- 1. Release code that writes both status and status_v2 and reads status_v2 with fallback.
+-- 2. Verify previous-release data snapshots keep the same business meaning.
+-- 3. Contract only after rollout: SET NOT NULL on status_v2, then DROP status.]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="sql"><![CDATA[-- Bad: combines expand, semantic rewrite, and contract in one migration
+UPDATE orders SET status = 'PENDING' WHERE status = 'P';
+ALTER TABLE orders ADD COLUMN status_v2 VARCHAR(40) NOT NULL DEFAULT 'PENDING';
+ALTER TABLE orders DROP COLUMN status;]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
     </examples>
 
     <output-format>
         <output-format-list>
             <output-format-item>**ANALYZE** Quarkus Flyway setup: extensions, datasource config, migration locations, migrate-at-start, and test profile behavior</output-format-item>
             <output-format-item>**CATEGORIZE** issues (EXTENSION, CONFIG, SCRIPT, ENTITY MISMATCH) by impact</output-format-item>
+            <output-format-item>**BOOTSTRAP** first-time Flyway projects by adding `quarkus-flyway`, the matching `quarkus-jdbc-*` driver, `quarkus.flyway.*` configuration, and `src/main/resources/db/migration` together</output-format-item>
             <output-format-item>**APPLY** Quarkus-aligned fixes: correct `pom.xml`, `application.properties`, and forward-only SQL</output-format-item>
             <output-format-item>**ALIGN** with `@412-frameworks-quarkus-panache` entities or `@411-frameworks-quarkus-jdbc` SQL</output-format-item>
             <output-format-item>**SAFEGUARD DATA** by checking renames, type changes, defaults, enum/status changes, timezone changes, repeatable migrations, broad updates, and unique/index changes for preservation risks</output-format-item>
-            <output-format-item>**TEST** with `@QuarkusTest` and a real database (Dev Services or Testcontainers) after migration changes</output-format-item>
+            <output-format-item>**TEST** with `@QuarkusTest` and a real production-dialect database using Dev Services or Testcontainers after migration changes; for semantic changes, include previous-release fixture data that proves business meaning is preserved</output-format-item>
             <output-format-item>**CHECK ORDERING** for duplicate versions, branch-dependent migrations, and unsafe `outOfOrder=true` assumptions</output-format-item>
             <output-format-item>**VALIDATE** with `./mvnw compile` before and `./mvnw clean verify` after changes</output-format-item>
         </output-format-list>
@@ -159,7 +200,8 @@ quarkus.flyway.locations=classpath:db/migration]]></code-block>
             <safeguards-item>**FORWARD ONLY**: Never rewrite migrations that already applied in shared environments</safeguards-item>
             <safeguards-item>**PANACHE SYNC**: Adding `@Version` or columns requires matching DDL in Flyway before rollout</safeguards-item>
             <safeguards-item>**DEV SERVICES**: Dev databases are ephemeral — do not treat them as migration history sources of truth</safeguards-item>
-            <safeguards-item>**PARALLEL CHANGE**: Expand, migrate, and contract across separate deployable steps for renames, type changes, backfills, and relationship-table changes</safeguards-item>
+            <safeguards-item>**PARALLEL CHANGE**: Expand, migrate, and contract across separate deployable steps for renames, type changes, backfills, relationship-table changes, and enum/status meaning changes</safeguards-item>
+            <safeguards-item>**FIRST SETUP**: If no datasource or migration chain exists, add Flyway, the JDBC driver, configuration, and versioned migration layout as one coherent bootstrap; avoid hardcoded test datasource URLs when Dev Services or Testcontainers can provide the production dialect</safeguards-item>
             <safeguards-item>**BRANCH ORDERING**: Detect duplicate versions and branch-only dependencies in CI; treat `outOfOrder=true` as an exceptional operational choice</safeguards-item>
             <safeguards-item>**BLOCKING SAFETY CHECK**: Run `./mvnw compile` before recommending schema or build changes</safeguards-item>
         </safeguards-list>

--- a/skills-generator/src/main/resources/skill-references/513-frameworks-micronaut-db-migrations-flyway-antipatterns.xml
+++ b/skills-generator/src/main/resources/skill-references/513-frameworks-micronaut-db-migrations-flyway-antipatterns.xml
@@ -21,6 +21,7 @@
             <constraint>**BRANCH ORDERING**: Detect duplicate version numbers and migrations that assume another branch migration already ran</constraint>
             <constraint>**OUT OF ORDER**: Treat `outOfOrder=true` as an exceptional operational decision, not a default fix for branch conflicts</constraint>
             <constraint>**REPEATABLE MIGRATIONS**: Review repeatable scripts for destructive operations because checksum changes make them rerun</constraint>
+            <constraint>**TESTCONTAINERS REQUIRED**: Require `@MicronautTest` migration verification with Testcontainers for the target production database dialect; reject H2 or hand-written DDL substitutes for migration safety checks</constraint>
         </constraint-list>
     </constraints>
 
@@ -161,20 +162,21 @@ flyway.datasources.default.out-of-order=true]]></code-block>
             </example-header>
             <example-description>
                 <![CDATA[
-                A passing Micronaut context test is not enough. Migration tests should exercise the real Flyway chain and assert preserved values across renames, backfills, defaults, enum/status changes, timezone changes, repeatable migrations, broad updates, and unique/index changes. Prefer Testcontainers with the production dialect over H2 when production uses PostgreSQL, MySQL, or another specific database.
+                A passing Micronaut context test is not enough. Migration tests should exercise the real Flyway chain and assert preserved values across renames, backfills, defaults, enum/status changes, timezone changes, repeatable migrations, broad updates, and unique/index changes. Always use Testcontainers with the target production dialect instead of H2 or hand-written test DDL.
                 ]]>
             </example-description>
             <code-examples>
                 <good-example>
                     <code-block language="java"><![CDATA[// Micronaut test intent:
-// - Use @MicronautTest with Testcontainers for the production dialect.
+// - Use @MicronautTest with Testcontainers for the target production dialect.
 // - Run Flyway against an empty schema and assert all migrations apply.
 // - Load a previous-release fixture, migrate, then assert preserved business data.
 // - Fail fast on duplicate V* prefixes and unexpected out-of-order migrations.]]></code-block>
                 </good-example>
                 <bad-example last-item="true">
-                    <code-block language="java"><![CDATA[// Bad: @MicronautTest starts against H2 with hand-written DDL
-// while production uses PostgreSQL/MySQL and Flyway migrations are never exercised.]]></code-block>
+                    <code-block language="java"><![CDATA[// Bad: @MicronautTest starts against H2 or hand-written DDL
+// while production uses PostgreSQL/MySQL and Flyway migrations are never exercised
+// against the target dialect.]]></code-block>
                 </bad-example>
             </code-examples>
         </example>

--- a/skills-generator/src/main/resources/skill-references/513-frameworks-micronaut-db-migrations-flyway.xml
+++ b/skills-generator/src/main/resources/skill-references/513-frameworks-micronaut-db-migrations-flyway.xml
@@ -24,6 +24,7 @@
             <constraint>**PREREQUISITE**: Project must compile successfully before Flyway or SQL edits</constraint>
             <constraint>**CRITICAL SAFETY**: If compilation fails, IMMEDIATELY STOP and DO NOT CONTINUE</constraint>
             <constraint>**VERIFY**: Run `./mvnw clean verify` or `mvn clean verify` after applying improvements</constraint>
+            <constraint>**TESTCONTAINERS REQUIRED**: Verify Flyway migration chains with `@MicronautTest` and Testcontainers for the target production database dialect; do not substitute H2 or hand-written test DDL for migration safety checks</constraint>
         </constraint-list>
     </constraints>
 
@@ -135,17 +136,19 @@ flyway:
             </example-header>
             <example-description>
                 <![CDATA[
-                Prefer `@MicronautTest` with a Testcontainers-managed database and the same migration scripts as production. Avoid duplicating schema in hand-written `schema.sql` unless you have a deliberate, documented reason.
+                Always use `@MicronautTest` with a Testcontainers-managed database for the target production database dialect and the same migration scripts as production. Do not substitute H2 or duplicate schema in hand-written `schema.sql` for migration safety checks.
                 ]]>
             </example-description>
             <code-examples>
                 <good-example>
-                    <code-block language="java"><![CDATA[// TestPropertyProvider or test resources: point default datasource to Testcontainers JDBC URL
-// Flyway runs on context start when enabled — exercises real migration chain]]></code-block>
+                    <code-block language="java"><![CDATA[// TestPropertyProvider or test resources: point default datasource to a Testcontainers JDBC URL
+// matching the production dialect, for example PostgreSQL:
+// jdbc:tc:postgresql:16:///app
+// Flyway runs on context start when enabled — exercises the real migration chain.]]></code-block>
                 </good-example>
                 <bad-example last-item="true">
-                    <code-block language="java"><![CDATA[// Bad: @MicronautTest with in-memory H2 and hand-written DDL while production uses PostgreSQL + Flyway
-// — drifts and hides migration failures]]></code-block>
+                    <code-block language="java"><![CDATA[// Bad: @MicronautTest with in-memory H2 or hand-written DDL while production uses PostgreSQL + Flyway
+// — drifts and hides migration failures.]]></code-block>
                 </bad-example>
             </code-examples>
         </example>
@@ -159,7 +162,7 @@ flyway:
             <output-format-item>**APPLY** Micronaut-aligned fixes: coordinates, YAML/properties, and versioned SQL</output-format-item>
             <output-format-item>**ALIGN** with `@512-frameworks-micronaut-data` or `@511-frameworks-micronaut-jdbc` access patterns</output-format-item>
             <output-format-item>**SAFEGUARD DATA** by checking renames, type changes, defaults, enum/status changes, timezone changes, repeatable migrations, broad updates, and unique/index changes for preservation risks</output-format-item>
-            <output-format-item>**TEST** with `@MicronautTest` and a containerized database mirroring production dialect</output-format-item>
+            <output-format-item>**TEST** with `@MicronautTest` and Testcontainers mirroring the target production database dialect</output-format-item>
             <output-format-item>**CHECK ORDERING** for duplicate versions, branch-dependent migrations, and unsafe `outOfOrder=true` assumptions</output-format-item>
             <output-format-item>**VALIDATE** with `./mvnw compile` before and `./mvnw clean verify` after changes</output-format-item>
         </output-format-list>
@@ -169,6 +172,7 @@ flyway:
         <safeguards-list>
             <safeguards-item>**IMMUTABLE APPLIED MIGRATIONS**: Do not modify files after they have run in shared environments</safeguards-item>
             <safeguards-item>**DATASOURCE SCOPE**: Configure Flyway for each datasource that needs independent schema</safeguards-item>
+            <safeguards-item>**TESTCONTAINERS ONLY**: Migration verification must run against a Testcontainers-managed database matching the target production dialect; H2 and hand-written test DDL are not acceptable substitutes</safeguards-item>
             <safeguards-item>**PARALLEL CHANGE**: Expand, migrate, and contract across separate deployable steps for renames, type changes, backfills, and relationship-table changes</safeguards-item>
             <safeguards-item>**BRANCH ORDERING**: Detect duplicate versions and branch-only dependencies in CI; treat `outOfOrder=true` as an exceptional operational choice</safeguards-item>
             <safeguards-item>**BLOCKING SAFETY CHECK**: Run `./mvnw compile` before recommending schema or build changes</safeguards-item>

--- a/skills-generator/src/test/resources/gherkin/skills/513-frameworks-micronaut-db-migrations-flyway.feature
+++ b/skills-generator/src/test/resources/gherkin/skills/513-frameworks-micronaut-db-migrations-flyway.feature
@@ -17,7 +17,7 @@ Scenario: Add safe Flyway migration guidance to the Micronaut example
   And the skill inspects "pom.xml", Micronaut datasource configuration, "flyway.datasources.*" configuration, migration locations, and JDBC or Micronaut Data persistence patterns
   And the skill recommends a versioned Flyway migration under "src/main/resources/db/migration"
   And the skill uses Parallel Change with expand, migrate, and contract steps when the change is data-sensitive
-  And the skill recommends "@MicronautTest" with Testcontainers verification against the production database dialect when feasible
+  And the skill requires "@MicronautTest" with Testcontainers verification against the target production database dialect
   And "./mvnw clean verify" or "mvn clean verify" is run after improvements
   And any git changes produced during skill execution and verification are reset
 
@@ -34,5 +34,5 @@ Scenario: Avoid a breaking Flyway migration in the Micronaut example
   And the skill requires explicit human review before proceeding with the breaking migration
   And the skill rejects "outOfOrder=true" as a default fix for branch-ordering problems
   And the skill recommends a safer forward-only Parallel Change sequence instead
-  And the skill requires migration tests that assert preserved item names from a previous-release data snapshot
+  And the skill requires migration tests that assert preserved item names from a previous-release data snapshot using Testcontainers for the target production database dialect
   And any git changes produced during skill execution and verification are reset


### PR DESCRIPTION
## Summary
- Prefer `spring-boot-starter-flyway` for Spring Boot 4.x Flyway guidance.
- Add a migration smoke-test example that injects `Flyway` and asserts applied migrations.
- Extend testing guidance to verify Flyway auto-configuration.

## Validation
- `xmllint --noout skills-generator/src/main/resources/skill-references/313-frameworks-spring-db-migrations-flyway.xml`
- `./mvnw clean install -pl skills-generator`
- Targeted 313 acceptance prompt: `./mvnw clean verify` from `examples/frameworks/spring-boot` passed with 5 tests.
