### PR TITLE
ci(openspec): create issue branch before spec generation

### DIFF
--- a/.github/workflows/create-spec-with-codex.yaml
+++ b/.github/workflows/create-spec-with-codex.yaml
@@ -82,6 +82,19 @@ jobs:
           sed -i "s/ISSUE_NUMBER_PLACEHOLDER/${ISSUE_NUMBER}/g" .codex/issue/create-openspec-prompt.md
           sed -i "s#ISSUE_BRANCH_PLACEHOLDER#${ISSUE_BRANCH}#g" .codex/issue/create-openspec-prompt.md
 
+      - name: Create feature branch from issue context
+        env:
+          ISSUE_BRANCH: ${{ steps.issue.outputs.branch }}
+        run: |
+          set -euo pipefail
+
+          if git ls-remote --exit-code --heads origin "${ISSUE_BRANCH}" >/dev/null 2>&1; then
+            git fetch origin "${ISSUE_BRANCH}"
+            git switch -c "${ISSUE_BRANCH}" --track "origin/${ISSUE_BRANCH}"
+          else
+            git switch -c "${ISSUE_BRANCH}"
+          fi
+
       - name: Ask Codex to create OpenSpec artifacts
         id: codex
         uses: openai/codex-action@v1
@@ -90,32 +103,75 @@ jobs:
           sandbox: workspace-write
           prompt-file: .codex/issue/create-openspec-prompt.md
 
+      - name: Commit OpenSpec changes
+        id: commit
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add documentation/openspec
+
+          if git diff --cached --quiet; then
+            echo "committed=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          git commit -m "docs(openspec): create spec for issue ${ISSUE_NUMBER}" \
+            -m "Co-authored-by: Codex <codex@openai.com>"
+          echo "committed=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Push feature branch
+        if: steps.commit.outputs.committed == 'true'
+        env:
+          ISSUE_BRANCH: ${{ steps.issue.outputs.branch }}
+        run: |
+          set -euo pipefail
+
+          git push --set-upstream origin "${ISSUE_BRANCH}"
+
       - name: Create pull request
         id: create-pr
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ github.token }}
-          branch: ${{ steps.issue.outputs.branch }}
-          delete-branch: true
-          commit-message: |
-            docs(openspec): create spec for issue ${{ github.event.issue.number }}
+        if: steps.commit.outputs.committed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_BRANCH: ${{ steps.issue.outputs.branch }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_URL: ${{ steps.issue.outputs.url }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          CODEX_SUMMARY: ${{ steps.codex.outputs.final-message }}
+        run: |
+          set -euo pipefail
 
-            Co-authored-by: Codex <codex@openai.com>
-          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          title: "docs(openspec): create spec for issue #${{ github.event.issue.number }}"
-          body: |
-            Creates OpenSpec artifacts from #${{ github.event.issue.number }} using Codex and the `042-planning-openspec` skill.
+          body_file="$(mktemp)"
+          {
+            echo "Creates OpenSpec artifacts from #${ISSUE_NUMBER} using Codex and the \`042-planning-openspec\` skill."
+            echo
+            echo "Source issue: ${ISSUE_URL}"
+            echo
+            echo "Codex summary:"
+            echo "${CODEX_SUMMARY}"
+          } > "${body_file}"
 
-            Source issue: ${{ steps.issue.outputs.url }}
+          pr_url="$(gh pr list \
+            --head "${ISSUE_BRANCH}" \
+            --state open \
+            --json url \
+            --jq '.[0].url // empty')"
 
-            Codex summary:
-            ${{ steps.codex.outputs.final-message }}
-          labels: |
-            openspec
-            codex
-          add-paths: |
-            documentation/openspec/**
+          if [ -z "${pr_url}" ]; then
+            pr_url="$(gh pr create \
+              --head "${ISSUE_BRANCH}" \
+              --base "${BASE_BRANCH}" \
+              --title "docs(openspec): create spec for issue #${ISSUE_NUMBER}" \
+              --body-file "${body_file}" \
+              --label openspec \
+              --label codex)"
+          fi
+
+          echo "pull-request-url=${pr_url}" >> "${GITHUB_OUTPUT}"
 
       - name: Comment on issue
         if: steps.create-pr.outputs.pull-request-url != ''


### PR DESCRIPTION
## Summary
- create or reuse the context-derived issue branch before running Codex
- commit and push generated OpenSpec artifacts from that branch
- create or reuse the PR with gh and keep the issue status comment

## Validation
- YAML parser check passed
- commit hooks passed