### PR TITLE
ci(openspec): use create-spec label for generated prs

### DIFF
--- a/.github/workflows/create-spec-with-codex.yaml
+++ b/.github/workflows/create-spec-with-codex.yaml
@@ -167,8 +167,7 @@ jobs:
               --base "${BASE_BRANCH}" \
               --title "docs(openspec): create spec for issue #${ISSUE_NUMBER}" \
               --body-file "${body_file}" \
-              --label openspec \
-              --label codex)"
+              --label "/create-spec")"
           fi
 
           echo "pull-request-url=${pr_url}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary
- use the existing /create-spec label on generated OpenSpec PRs
- remove missing openspec/codex labels from the PR creation command

## Validation
- YAML parser check passed
- commit hooks passed