### PR TITLE
ci(openspec): tolerate blocked automated pr creation

### DIFF
--- a/.github/workflows/create-spec-with-codex.yaml
+++ b/.github/workflows/create-spec-with-codex.yaml
@@ -136,7 +136,8 @@ jobs:
         id: create-pr
         if: steps.commit.outputs.committed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.CREATE_PR_TOKEN || github.token }}
+          REPOSITORY: ${{ github.repository }}
           ISSUE_BRANCH: ${{ steps.issue.outputs.branch }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_URL: ${{ steps.issue.outputs.url }}
@@ -162,12 +163,20 @@ jobs:
             --jq '.[0].url // empty')"
 
           if [ -z "${pr_url}" ]; then
-            pr_url="$(gh pr create \
-              --head "${ISSUE_BRANCH}" \
-              --base "${BASE_BRANCH}" \
-              --title "docs(openspec): create spec for issue #${ISSUE_NUMBER}" \
-              --body-file "${body_file}" \
-              --label "/create-spec")"
+            if pr_url="$(gh pr create \
+                --head "${ISSUE_BRANCH}" \
+                --base "${BASE_BRANCH}" \
+                --title "docs(openspec): create spec for issue #${ISSUE_NUMBER}" \
+                --body-file "${body_file}" \
+                --label "/create-spec" 2> pr-create-error.log)"; then
+              echo "created=true" >> "${GITHUB_OUTPUT}"
+            else
+              cat pr-create-error.log
+              pr_url="https://github.com/${REPOSITORY}/pull/new/${ISSUE_BRANCH}"
+              echo "created=false" >> "${GITHUB_OUTPUT}"
+            fi
+          else
+            echo "created=true" >> "${GITHUB_OUTPUT}"
           fi
 
           echo "pull-request-url=${pr_url}" >> "${GITHUB_OUTPUT}"
@@ -182,5 +191,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: `Status: Create a PR with OpenSpec change. ${{ steps.create-pr.outputs.pull-request-url }}`
+              body: `Status: Create a PR with OpenSpec change. ${{ steps.create-pr.outputs.created == 'true' && 'Created' || 'Pending repository permission' }}: ${{ steps.create-pr.outputs.pull-request-url }}`
             })


### PR DESCRIPTION
## Summary
- support an optional CREATE_PR_TOKEN for generated OpenSpec PR creation
- avoid failing the workflow when repository settings block GitHub Actions from opening PRs
- comment the issue with either the created PR URL or a manual PR URL

## Validation
- YAML parser check passed
- commit hooks passed