### PR TITLE
docs(skills): remove h2 from guidance examples

### DIFF
--- a/skills-generator/src/main/resources/skill-references/110-java-maven-best-practices.xml
+++ b/skills-generator/src/main/resources/skill-references/110-java-maven-best-practices.xml
@@ -274,7 +274,7 @@ my-app/
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <database.url>jdbc:h2:mem:devdb</database.url>
+        <database.url>jdbc:postgresql://localhost:5432/devdb</database.url>
       </properties>
     </profile>
     <profile>

--- a/skills-generator/src/main/resources/skill-references/124-java-secure-coding.xml
+++ b/skills-generator/src/main/resources/skill-references/124-java-secure-coding.xml
@@ -149,7 +149,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class SecureDataAccess {
-    private static final String DB_URL = "jdbc:h2:mem:testdb";
+    private static final String DB_URL = "jdbc:vendor://db-host:5432/appdb";
     private static final String USER = "sa";
     private static final String PASS = "";
 
@@ -200,7 +200,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class VulnerableDataAccess {
-    private static final String DB_URL = "jdbc:h2:mem:testdb";
+    private static final String DB_URL = "jdbc:vendor://db-host:5432/appdb";
     private static final String USER = "sa";
     private static final String PASS = "";
 

--- a/skills-generator/src/main/resources/skill-references/311-frameworks-spring-jdbc.xml
+++ b/skills-generator/src/main/resources/skill-references/311-frameworks-spring-jdbc.xml
@@ -888,25 +888,36 @@ class ReportService {
             </example-header>
             <example-description>
                 <![CDATA[
-                Use `@JdbcTest` to load only `DataSource`, `JdbcTemplate`, `NamedParameterJdbcTemplate`, and `JdbcClient` — no web layer, no full application context. Wire your repository under test with `@Import`. Use `@Sql` to set up and tear down fixture data. Prefer an embedded H2 database or Testcontainers for realistic dialect coverage.
+                Use `@JdbcTest` to load only `DataSource`, `JdbcTemplate`, `NamedParameterJdbcTemplate`, and `JdbcClient` — no web layer, no full application context. Wire your repository under test with `@Import`. Use `@Sql` to set up and tear down fixture data. Prefer Testcontainers with the production database dialect instead of embedded H2 so SQL, schema, and transaction behavior match production. Add `@AutoConfigureTestDatabase(replace = NONE)` so Spring Boot does not replace the container datasource with an embedded database.
                 ]]>
             </example-description>
             <code-examples>
                 <good-example>
                     <code-block language="java"><![CDATA[import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @JdbcTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)  // use real DB, not H2
 @Import(ProductRepository.class)
+@Testcontainers
 @Sql("/sql/products.sql")                          // inserts fixture rows before each test
 @Sql(scripts = "/sql/cleanup.sql",
      executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
-class ProductRepositoryTest {
+class ProductRepositoryIT {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
 
     @Autowired
     ProductRepository productRepository;

--- a/skills-generator/src/test/resources/gherkin/skills/311-frameworks-spring-jdbc.feature
+++ b/skills-generator/src/test/resources/gherkin/skills/311-frameworks-spring-jdbc.feature
@@ -1,0 +1,23 @@
+Feature: Validate changes from usage of Spring JDBC skill
+
+Background:
+  Given the skill "311-frameworks-spring-jdbc"
+
+@acceptance-test
+Scenario: Recommend production-dialect Testcontainers for Spring JDBC slice tests
+  Given the example project "examples/frameworks/spring-boot"
+  And the user request is "Review Spring JDBC repository code and test guidance for a PostgreSQL-backed service"
+  And the local generated skill path ".agents/skills/311-frameworks-spring-jdbc"
+  And the folder "examples/frameworks/spring-boot" has no git changes
+  When the skill ".agents/skills/311-frameworks-spring-jdbc" is applied to the example project
+  Then the skill reads "references/311-frameworks-spring-jdbc.md"
+  And "./mvnw compile" is run from "examples/frameworks/spring-boot" before applying Spring JDBC changes
+  And the skill recommends `JdbcClient` as the default Spring JDBC API for queries and updates
+  And the skill keeps repository tests as `@JdbcTest` slices with `@Import` for the repository under test
+  And the skill recommends `@Sql` fixtures for deterministic setup and cleanup
+  And the skill recommends Testcontainers with the production database dialect for JDBC persistence tests
+  And the skill includes `@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)` so Spring Boot does not replace the datasource with embedded H2
+  And the skill includes a static `@Container` database with `@ServiceConnection` for Spring Boot datasource wiring
+  And the skill does not recommend embedded H2 as an acceptable substitute for production-dialect JDBC verification
+  And "./mvnw clean verify" is run from "examples/frameworks/spring-boot" after improvements when code or build files change
+  And any git changes produced during skill execution and verification are reset

--- a/skills-generator/src/test/resources/gherkin/skills/acceptance-tests-prompts-skills.md
+++ b/skills-generator/src/test/resources/gherkin/skills/acceptance-tests-prompts-skills.md
@@ -134,6 +134,13 @@ execute @skills-generator/src/test/resources/gherkin/skills/305-frameworks-sprin
 and verify that acceptance-tests passes.
 ```
 
+## 311-frameworks-spring-jdbc
+
+```bash
+execute @skills-generator/src/test/resources/gherkin/skills/311-frameworks-spring-jdbc.feature
+and verify that acceptance-tests passes.
+```
+
 ## 313-frameworks-spring-db-migrations-flyway
 
 ```bash


### PR DESCRIPTION
## Summary
- replace incidental H2 JDBC URLs in Maven and secure-coding skill examples
- update Spring JDBC `@JdbcTest` guidance to prefer production-dialect Testcontainers
- add `311-frameworks-spring-jdbc` acceptance prompt coverage

## Validation
- `xmllint --noout` for edited XML files
- `git diff --check`
- `./mvnw clean install -pl skills-generator`
- `jbang .github/scripts/MarkdownValidator.java --verbose .`

## Notes
- `704-skill.xml` was intentionally left unchanged because its H2 mention is a neutral SQL dialect listing, not usage guidance.

Co-authored-by: Codex <codex@openai.com>