### PR TITLE
docs(references): add skill portal links

### DIFF
--- a/documentation/guides/PROJECT-REFERENCES.md
+++ b/documentation/guides/PROJECT-REFERENCES.md
@@ -66,6 +66,11 @@ This page collects talks, articles, reference links, skill portals, and related 
 - [Awesome Cursor Rules Chinese translation](https://github.com/LessUp/awesome-cursorrules-zh)
 - [learn-skills.dev author page](https://www.learn-skills.dev/en/for/jabrena)
 - [SkillsLLM cursor-rules-java](https://skillsllm.com/skill/cursor-rules-java)
+- [911 Fund cursor-rules-java tool page](https://skills.911fund.io/tools/jabrena-cursor-rules-java)
+- [SkillsLLM cursor-rules-java vs superpowers comparison](https://skillsllm.com/compare/cursor-rules-java-vs-superpowers)
+- [Cross AI Tools cursor-rules-java skill page](https://crossaitools.com/skills/jabrena/cursor-rules-java)
+- [77taoletao cursor-rules-java skill page](https://77taoletao.com/skills/83)
+- [Open Claw directory rules](https://open-claw.directory/rules)
 
 ### Java
 

--- a/documentation/guides/PROJECT-REFERENCES_ES.md
+++ b/documentation/guides/PROJECT-REFERENCES_ES.md
@@ -66,6 +66,11 @@ Esta página reúne charlas, artículos, enlaces de referencia, portales de skil
 - [Traducción china de Awesome Cursor Rules](https://github.com/LessUp/awesome-cursorrules-zh)
 - [Página de autor en learn-skills.dev](https://www.learn-skills.dev/en/for/jabrena)
 - [SkillsLLM cursor-rules-java](https://skillsllm.com/skill/cursor-rules-java)
+- [Página de herramienta cursor-rules-java en 911 Fund](https://skills.911fund.io/tools/jabrena-cursor-rules-java)
+- [Comparativa de SkillsLLM entre cursor-rules-java y superpowers](https://skillsllm.com/compare/cursor-rules-java-vs-superpowers)
+- [Página de skill cursor-rules-java en Cross AI Tools](https://crossaitools.com/skills/jabrena/cursor-rules-java)
+- [Página de skill cursor-rules-java en 77taoletao](https://77taoletao.com/skills/83)
+- [Reglas del directorio Open Claw](https://open-claw.directory/rules)
 
 ### Java
 

--- a/documentation/guides/PROJECT-REFERENCES_ZH.md
+++ b/documentation/guides/PROJECT-REFERENCES_ZH.md
@@ -66,6 +66,11 @@
 - [Awesome Cursor Rules 中文翻译](https://github.com/LessUp/awesome-cursorrules-zh)
 - [learn-skills.dev 作者页](https://www.learn-skills.dev/en/for/jabrena)
 - [SkillsLLM cursor-rules-java](https://skillsllm.com/skill/cursor-rules-java)
+- [911 Fund cursor-rules-java 工具页面](https://skills.911fund.io/tools/jabrena-cursor-rules-java)
+- [SkillsLLM cursor-rules-java 与 superpowers 对比](https://skillsllm.com/compare/cursor-rules-java-vs-superpowers)
+- [Cross AI Tools cursor-rules-java skill 页面](https://crossaitools.com/skills/jabrena/cursor-rules-java)
+- [77taoletao cursor-rules-java skill 页面](https://77taoletao.com/skills/83)
+- [Open Claw directory 规则页](https://open-claw.directory/rules)
 
 ### Java
 


### PR DESCRIPTION
## Summary
- Add the five skill directory links from #921 to the Project References guide
- Keep Spanish and Chinese localized reference guides in sync

## Validation
- jbang .github/scripts/MarkdownValidator.java --verbose .

Closes #921