### PR TITLE
feat(skills): add two-step change method skill

### DIFF
--- a/.cursor/agents/robot-tech-lead.md
+++ b/.cursor/agents/robot-tech-lead.md
@@ -16,6 +16,7 @@ You are a **Tech Lead** for Java Enterprise Development. Your primary responsibi
 
 - Translate an issue, approved design, ADR set, OpenSpec change, or valid combination of these sources into executable technical work.
 - Create and refine an implementation plan using `@041-planning-plan-mode`.
+- Use `@051-design-two-steps-methods` for every plan so tasks separate behavior-preserving preparation, validation that behavior stayed unchanged, the intended behavior change, and final verification.
 - Define approach, affected files, dependencies, risks, verification, milestones, and parallel groups.
 - Record source artifacts and unresolved decisions so the plan does not silently override requirements or ADRs.
 - A plan may be created directly from an issue; OpenSpec is not a mandatory prerequisite.
@@ -23,6 +24,7 @@ You are a **Tech Lead** for Java Enterprise Development. Your primary responsibi
 ### Mission 2: Create the specification
 
 - Create or update an OpenSpec change using `@042-planning-openspec`.
+- Use `@051-design-two-steps-methods` for every OpenSpec change so proposal, design, specs, and tasks preserve the two-step sequence.
 - Accept an issue, approved design, ADRs, implementation plan, existing OpenSpec artifacts, or a valid combination as input.
 - Assess whether the scope fits one reviewable change; propose multiple changes and dependencies when outcomes have distinct release, ownership, risk, or deployment boundaries.
 - Record derivation direction and source artifacts. Never silently synchronize a source artifact from a derived artifact.
@@ -42,6 +44,7 @@ You are a **Tech Lead** for Java Enterprise Development. Your primary responsibi
 - **[@robot-java-quarkus-coder](robot-java-quarkus-coder.md):** Quarkus implementation (Jakarta REST resources, CDI, validation, security, Panache/JDBC, Flyway migrations, Kafka messaging, MongoDB, Quarkus tests — `@401`–`@415`, `@421`–`@423`). Use when **Framework identification** yields **Quarkus** as the application framework.
 - **[@robot-java-micronaut-coder](robot-java-micronaut-coder.md):** Micronaut implementation (`@Controller`, validation, security, programmatic JDBC, Micronaut Data, Flyway migrations, Kafka messaging, MongoDB, `Micronaut.run`, CDI-style beans, Micronaut tests — `@501`–`@515`, `@521`–`@523`). Use when **Framework identification** yields **Micronaut** as the application framework.
 - **[@robot-no-java](robot-no-java.md):** Default implementation for non-Java work. Use when the issue, plan, or OpenSpec task list names a non-Java stack or has no Java, Maven, or JVM implementation scope.
+- **Two-step change shaping:** Use `@051-design-two-steps-methods` during every plan or OpenSpec creation so preparatory work is validated before behavior-changing work begins.
 - **Shared implementation routing:** In coder handoffs, prefer `@143` for expected domain failures and reserve `@126` for exceptional/system boundaries. Apply design guidance in the order `@121` → `@122` → `@123`, with `@142` inside those boundaries. Include `@124` for general secure coding, prefer framework JDBC plus `@704` for relational persistence, use `@705` for MongoDB modeling, and use `@701` for OpenAPI contracts when those concerns are in scope.
 - **Parallel column drives grouping:** The plan's task list table includes a **Parallel** column (or **Agent** if the plan uses that name). Treat each **distinct value** in that column as a **delegation group** identifier (e.g. `A1`, `A2`, `A3-timeout`, `A3-retry`, `A4`).
 - **One logical developer per group:** For each distinct **Parallel** value, assign a **separate** instance of the **same** chosen implementation agent (`robot-java-coder`, `robot-java-spring-boot-coder`, `robot-java-quarkus-coder`, `robot-java-micronaut-coder`, or `robot-no-java`) whose scope is **only** the rows for that value. Label every handoff, e.g. `Developer (Parallel=A3-timeout): tasks 12-16 only; verify milestone before A3-retry starts.`

--- a/.cursor/commands/create-plan.md
+++ b/.cursor/commands/create-plan.md
@@ -18,15 +18,17 @@ Create or refine an executable technical implementation plan from the available 
 ## Owning Agent
 `@robot-tech-lead`
 
-## Associated Skill
-`041-planning-plan-mode`
+## Associated Skills
+- `041-planning-plan-mode`
+- `051-design-two-steps-methods` for every plan so preparatory work, behavior change, and verification remain explicitly sequenced
 
 ## Workflow
 1. Identify the available source artifacts and their authority.
 2. Resolve material implementation questions without inventing requirements.
-3. Define the technical approach, affected areas, ordered tasks, risks, and verification.
-4. Record source links and any assumptions or unresolved blockers.
-5. Present the plan for approval.
+3. Apply the two-step method so the plan orders behavior-preserving preparation, behavior-preservation validation, the intended behavior change, and final verification.
+4. Define the technical approach, affected areas, ordered tasks, risks, and verification.
+5. Record source links and any assumptions or unresolved blockers.
+6. Present the plan for approval.
 
 ## Output
 - Executable implementation plan

--- a/.cursor/commands/create-spec.md
+++ b/.cursor/commands/create-spec.md
@@ -18,16 +18,18 @@ Create or update one or more OpenSpec changes from the available issue, design, 
 ## Owning Agent
 `@robot-tech-lead`
 
-## Associated Skill
-`042-planning-openspec`
+## Associated Skills
+- `042-planning-openspec`
+- `051-design-two-steps-methods` for every OpenSpec change so preparatory work, behavior change, and verification remain explicitly sequenced
 
 ## Workflow
 1. Identify the available source artifacts and their authority.
 2. Assess whether the scope fits one reviewable change.
-3. For broad scope, propose independently valuable changes and dependencies for approval.
-4. Create or update the approved OpenSpec proposal, design, specifications, and tasks.
-5. Record derivation direction, source links, and unresolved questions.
-6. Validate the resulting OpenSpec changes.
+3. Apply the two-step method so OpenSpec separates behavior-preserving preparation from behavior-changing work and validates each step.
+4. For broad scope, propose independently valuable changes and dependencies for approval.
+5. Create or update the approved OpenSpec proposal, design, specifications, and tasks.
+6. Record derivation direction, source links, and unresolved questions.
+7. Validate the resulting OpenSpec changes.
 
 ## Output
 - One OpenSpec change, or an approved map of multiple changes

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -7,8 +7,63 @@ on:
   pull_request:
 
 jobs:
+  detect-validation-scope:
+    name: Detect Validation Scope
+    runs-on: ubuntu-latest
+    outputs:
+      markdown_changed: ${{ steps.detect.outputs.markdown_changed }}
+      generated_skills_changed: ${{ steps.detect.outputs.generated_skills_changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: true
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'graalvm'
+          java-version: '25'
+      - name: Detect validation scope
+        id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_SHA="${{ github.event.before }}"
+          fi
+
+          if [ -z "$BASE_SHA" ] || [[ "$BASE_SHA" =~ ^0+$ ]]; then
+            BASE_SHA="$(git rev-list --max-parents=0 HEAD)"
+          fi
+
+          HEAD_SHA="$(git rev-parse HEAD)"
+
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qE '(^|/)[^/]+\.md$'; then
+            echo "markdown_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "markdown_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          git checkout "$BASE_SHA"
+          ./mvnw --batch-mode --no-transfer-progress clean install -pl skills-generator
+          cp -R .agents/skills /tmp/base-skills
+
+          git checkout "$HEAD_SHA"
+          ./mvnw --batch-mode --no-transfer-progress clean install -pl skills-generator
+          cp -R .agents/skills /tmp/head-skills
+
+          if diff -qr /tmp/base-skills /tmp/head-skills >/dev/null; then
+            echo "generated_skills_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "generated_skills_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
   validate-markdown:
     name: Validate Markdown Files
+    needs: detect-validation-scope
+    if: needs.detect-validation-scope.outputs.markdown_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -27,6 +82,8 @@ jobs:
 
   validate-skill-check:
     name: Validate Agent Skills with skill-check
+    needs: detect-validation-scope
+    if: needs.detect-validation-scope.outputs.generated_skills_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -45,6 +102,8 @@ jobs:
 
   validate-skill-scanner:
     name: Validate Agent Skills with Skill Scanner
+    needs: detect-validation-scope
+    if: needs.detect-validation-scope.outputs.generated_skills_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -66,6 +125,8 @@ jobs:
 
   validate-skillspector:
     name: Validate Agent Skills with SkillSpector
+    needs: detect-validation-scope
+    if: needs.detect-validation-scope.outputs.generated_skills_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -102,7 +163,10 @@ jobs:
 
   validate-snyk-agent-scan:
     name: Validate Agent Skills with Snyk Agent Scan
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: detect-validation-scope
+    if: >
+      needs.detect-validation-scope.outputs.generated_skills_changed == 'true' &&
+      (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -168,7 +232,10 @@ jobs:
 
   validate-virustotal-skills:
     name: Validate Agent Skills with VirusTotal
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: detect-validation-scope
+    if: >
+      needs.detect-validation-scope.outputs.generated_skills_changed == 'true' &&
+      (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/documentation/openspec/changes/add-design-two-steps-methods-skill/tasks.md
+++ b/documentation/openspec/changes/add-design-two-steps-methods-skill/tasks.md
@@ -7,19 +7,19 @@
 - [x] 1.3 Derive a sanitized maintainer-style planning summary and use it as the OpenSpec planning input.
 - [x] 1.4 Assess change boundaries and keep the request as one OpenSpec change for `051-design-two-steps-methods`.
 - [x] 1.5 Create OpenSpec proposal, design, task, and specification delta artifacts with source URL and derivation direction.
-- [ ] 1.6 Add `skills-generator/src/main/resources/skill-indexes/051-skill.xml`.
-- [ ] 1.7 Add `skills-generator/src/main/resources/skill-references/051-design-two-steps-methods.xml`.
-- [ ] 1.8 Register skill id `051` with explicit `skillId="051-design-two-steps-methods"` and reference `051-design-two-steps-methods` in `skills-generator/src/main/resources/skills.xml`.
-- [ ] 1.9 Ensure the skill guidance separates preparatory behavior-preserving refactoring from the intended behavior change.
-- [ ] 1.10 Ensure the skill guides users to validate behavior preservation after preparatory refactoring and verify the intended behavior change afterward.
-- [ ] 1.11 Add `skills-generator/src/test/resources/gherkin/skills/051-design-two-steps-methods.feature` with the acceptance scenario from issue #877.
-- [ ] 1.12 Add the matching `execute @skills-generator/src/test/resources/gherkin/skills/051-design-two-steps-methods.feature` prompt to `skills-generator/src/test/resources/gherkin/skills/acceptance-tests-prompts-skills.md`.
-- [ ] 1.13 Validate changed XML files with `xmllint --noout`.
-- [ ] 1.14 Run `./mvnw clean install -pl skills-generator`.
-- [ ] 1.15 Inspect generated local `.agents/skills/051-design-two-steps-methods/SKILL.md`.
-- [ ] 1.16 Execute the listed `051-design-two-steps-methods` acceptance prompt and verify it passes.
-- [ ] 1.17 Run `./mvnw clean verify -pl skills-generator`.
-- [ ] 1.18 Run `openspec validate --all` from `documentation/`.
+- [x] 1.6 Add `skills-generator/src/main/resources/skill-indexes/051-skill.xml`.
+- [x] 1.7 Add `skills-generator/src/main/resources/skill-references/051-design-two-steps-methods.xml`.
+- [x] 1.8 Register skill id `051` with explicit `skillId="051-design-two-steps-methods"` and reference `051-design-two-steps-methods` in `skills-generator/src/main/resources/skills.xml`.
+- [x] 1.9 Ensure the skill guidance separates preparatory behavior-preserving refactoring from the intended behavior change.
+- [x] 1.10 Ensure the skill guides users to validate behavior preservation after preparatory refactoring and verify the intended behavior change afterward.
+- [x] 1.11 Add `skills-generator/src/test/resources/gherkin/skills/051-design-two-steps-methods.feature` with the acceptance scenario from issue #877.
+- [x] 1.12 Add the matching `execute @skills-generator/src/test/resources/gherkin/skills/051-design-two-steps-methods.feature` prompt to `skills-generator/src/test/resources/gherkin/skills/acceptance-tests-prompts-skills.md`.
+- [x] 1.13 Validate changed XML files with `xmllint --noout`.
+- [x] 1.14 Run `./mvnw clean install -pl skills-generator`.
+- [x] 1.15 Inspect generated local `.agents/skills/051-design-two-steps-methods/SKILL.md`.
+- [x] 1.16 Execute the listed `051-design-two-steps-methods` acceptance prompt and verify it passes.
+- [x] 1.17 Run `./mvnw clean verify -pl skills-generator`.
+- [x] 1.18 Run `openspec validate --all` from `documentation/`.
 
 ## Source and Derivation
 

--- a/skills-generator/src/main/resources/skill-indexes/051-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/051-skill.xml
@@ -7,7 +7,7 @@
     <author>Juan Antonio Breña Moral</author>
     <version>0.17.0-SNAPSHOT</version>
     <license>Apache-2.0</license>
-    <description>Use when a complex or risky code change should be split into Kent Beck's two-step method: first make the change easy through behavior-preserving preparatory refactoring, then make the intended behavior change once the design supports it. This should trigger for requests such as Apply two-step change; Make this risky change safer; Refactor before changing behavior; Separate preparation from behavior change.</description>
+    <description>Use when a complex or risky code change should be split into Kent Beck's two-step method by first making the change easy through behavior-preserving preparatory refactoring, then making the intended behavior change once the design supports it. This should trigger for requests such as Apply two-step change; Make this risky change safer; Refactor before changing behavior; Separate preparation from behavior change.</description>
   </metadata>
 
   <title>Two-Step Change Method</title>

--- a/skills-generator/src/main/resources/skill-indexes/051-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/051-skill.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="https://jabrena.github.io/pml/schemas/0.7.0/pml.xsd"
+      id="051-design-two-steps-methods"
+      interactive="true">
+  <metadata>
+    <author>Juan Antonio Breña Moral</author>
+    <version>0.17.0-SNAPSHOT</version>
+    <license>Apache-2.0</license>
+    <description>Use when a complex or risky code change should be split into Kent Beck's two-step method: first make the change easy through behavior-preserving preparatory refactoring, then make the intended behavior change once the design supports it. This should trigger for requests such as Apply two-step change; Make this risky change safer; Refactor before changing behavior; Separate preparation from behavior change.</description>
+  </metadata>
+
+  <title>Two-Step Change Method</title>
+  <goal><![CDATA[
+Guide Java developers through complex or risky changes by keeping design preparation separate from behavior modification. **This is an interactive SKILL**.
+
+**What is covered in this Skill?**
+
+- Clarifying the intended behavior change before editing
+- Identifying design obstacles that make the change difficult or risky
+- Step 1: behavior-preserving preparatory refactoring that makes the change easy
+- Validation that Step 1 preserves existing behavior
+- Step 2: the smallest intended behavior change after the design supports it
+- Verification that Step 2 delivers the intended behavior
+- Handoff to focused Java, framework, persistence, messaging, API, or testing skills while preserving the two-step sequence
+]]></goal>
+
+  <constraints>
+    <constraints-description>Separate behavior-preserving preparation from behavior-changing work, and validate after each step.</constraints-description>
+    <constraint-list>
+      <constraint>**MUST**: State the intended behavior change before proposing preparatory refactoring</constraint>
+      <constraint>**MUST**: Keep Step 1 behavior-preserving; do not mix broad refactoring with the intended behavior change</constraint>
+      <constraint>**MUST**: Verify existing behavior after Step 1 using the project-appropriate tests, build, characterization tests, or manual checks</constraint>
+      <constraint>**MUST**: Make Step 2 only after the design has been prepared and validated</constraint>
+      <constraint>**MUST**: Verify the intended behavior after Step 2 with focused tests and relevant build checks</constraint>
+      <constraint>**MUST**: Record assumptions and risks when preparation cannot be fully separated from behavior change</constraint>
+    </constraint-list>
+  </constraints>
+
+  <triggers>
+    <trigger-list>
+      <trigger>Apply two-step change</trigger>
+      <trigger>Make this risky change safer</trigger>
+      <trigger>Refactor before changing behavior</trigger>
+      <trigger>Separate preparation from behavior change</trigger>
+      <trigger>Make the change easy, then make the easy change</trigger>
+    </trigger-list>
+  </triggers>
+
+  <steps>
+    <step number="1">
+      <step-title>Define the intended change</step-title>
+      <step-content>Read `references/051-design-two-steps-methods.md`, inspect the relevant code and tests, and state the exact behavior or capability that must change. Identify why the current design makes the change complex, risky, or hard to verify.</step-content>
+    </step>
+    <step number="2">
+      <step-title>Plan preparatory refactoring</step-title>
+      <step-content>Choose the smallest behavior-preserving refactoring that reduces the obstacle: extract method or class, clarify names, isolate dependencies, add seams for testing, move responsibilities, improve types, or add characterization tests before touching behavior.</step-content>
+    </step>
+    <step number="3">
+      <step-title>Make the change easy</step-title>
+      <step-content>Apply Step 1 as focused preparatory refactoring only. Keep commits, notes, or task boundaries clear enough that reviewers can see no intended behavior change is included.</step-content>
+    </step>
+    <step number="4">
+      <step-title>Validate preserved behavior</step-title>
+      <step-content>Run the relevant existing tests, build checks, characterization tests, or manual verification. If behavior changes unexpectedly, fix or revert the preparation before proceeding.</step-content>
+    </step>
+    <step number="5">
+      <step-title>Make the easy behavior change</step-title>
+      <step-content>Apply the smallest intended behavior change now that the design supports it. Use focused Java, framework, persistence, messaging, API, or testing skills when detailed implementation guidance is needed.</step-content>
+    </step>
+    <step number="6">
+      <step-title>Verify and report the outcome</step-title>
+      <step-content>Verify the intended behavior with targeted tests and relevant project validation. Report what was preparation, what changed behavior, what was verified after each step, and any remaining risks.</step-content>
+    </step>
+  </steps>
+</prompt>

--- a/skills-generator/src/main/resources/skill-references/051-design-two-steps-methods.xml
+++ b/skills-generator/src/main/resources/skill-references/051-design-two-steps-methods.xml
@@ -14,7 +14,7 @@
     <tone>Be deliberate, concrete, and disciplined. Keep the user oriented around what preserves behavior, what changes behavior, and how each step is verified.</tone>
 
     <goal>
-        Apply the two-step change method to make a complex or risky change manageable: first make the change easy through behavior-preserving preparatory refactoring, then make the easy behavior change and verify the result. External reference supplied for this method: https://x.com/KentBeck/status/250733358307500032.
+        Apply the two-step change method to make a complex or risky change manageable by first making the change easy through behavior-preserving preparatory refactoring, then making the easy behavior change and verify the result. External reference supplied for this method is https://x.com/KentBeck/status/250733358307500032.
     </goal>
 
     <steps>

--- a/skills-generator/src/main/resources/skill-references/051-design-two-steps-methods.xml
+++ b/skills-generator/src/main/resources/skill-references/051-design-two-steps-methods.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <metadata>
+        <author>Juan Antonio Breña Moral</author>
+        <version>0.17.0-SNAPSHOT</version>
+        <license>Apache-2.0</license>
+        <title>Two-Step Change Method</title>
+        <description>Use when a complex or risky code change should be split into behavior-preserving preparation followed by the intended behavior change.</description>
+    </metadata>
+
+    <role>You are a senior Java engineer who makes complex changes safer by separating design preparation from behavior change.</role>
+
+    <tone>Be deliberate, concrete, and disciplined. Keep the user oriented around what preserves behavior, what changes behavior, and how each step is verified.</tone>
+
+    <goal>
+        Apply the two-step change method to make a complex or risky change manageable: first make the change easy through behavior-preserving preparatory refactoring, then make the easy behavior change and verify the result. External reference supplied for this method: https://x.com/KentBeck/status/250733358307500032.
+    </goal>
+
+    <steps>
+        <step number="1">
+            <step-title>Clarify the Intended Behavior Change</step-title>
+            <step-content><![CDATA[
+Before editing, state the intended behavior or capability change in plain language:
+
+- What observable behavior must change?
+- Which users, APIs, jobs, persistence flows, messages, or integrations are affected?
+- What code and tests currently describe that behavior?
+- What makes the change complex or risky in the current design?
+
+Do not start by naming a refactoring. Start with the behavior that will eventually change, then inspect why the design resists that change.
+            ]]></step-content>
+            <step-constraints>
+                <step-constraint-list>
+                    <step-constraint>**MUST** distinguish desired behavior from preparatory design work</step-constraint>
+                    <step-constraint>**MUST** identify existing tests or missing characterization coverage before refactoring risky code</step-constraint>
+                    <step-constraint>**MUST NOT** invent requirements beyond the user's request or authoritative project artifacts</step-constraint>
+                </step-constraint-list>
+            </step-constraints>
+        </step>
+
+        <step number="2">
+            <step-title>Make the Change Easy</step-title>
+            <step-content><![CDATA[
+Plan and apply the smallest behavior-preserving preparation that makes the later change simple. Examples include:
+
+- Add characterization tests for current behavior before touching fragile code
+- Extract a method, class, interface, strategy, or adapter around the behavior to be changed
+- Rename unclear concepts so the intended change has an obvious place to live
+- Move responsibilities to the component that already owns the relevant decision
+- Isolate framework, persistence, messaging, clock, network, or filesystem dependencies
+- Replace ad hoc conditionals with clearer types only when the later behavior change needs that shape
+- Split one broad function or transaction path into named steps without changing decisions
+
+Keep Step 1 reviewable as preparation. It should not change the external behavior, public contract, data semantics, emitted events, persistence result, or user-visible output unless the user explicitly approved a known compatibility step.
+            ]]></step-content>
+            <step-constraints>
+                <step-constraint-list>
+                    <step-constraint>**BEHAVIOR PRESERVING**: Step 1 changes structure, names, boundaries, tests, or seams, not intended behavior</step-constraint>
+                    <step-constraint>**SMALLEST USEFUL PREPARATION**: Stop refactoring when the intended change is easy enough to make safely</step-constraint>
+                    <step-constraint>**SEQUENCE DISCIPLINE**: Do not mix speculative cleanup with the behavior-changing step</step-constraint>
+                </step-constraint-list>
+            </step-constraints>
+        </step>
+
+        <step number="3">
+            <step-title>Validate Behavior Preservation</step-title>
+            <step-content><![CDATA[
+After Step 1, verify that behavior is unchanged before making the intended change:
+
+- Run the relevant existing unit, integration, acceptance, or contract tests
+- Add and run characterization tests when existing coverage is weak
+- Compile or run the module build when the refactoring touches shared code
+- Inspect generated APIs, schemas, migrations, events, or configuration output when applicable
+- Record any manual check that substitutes for missing automation
+
+If validation fails, treat the failure as a problem in the preparatory refactoring. Fix the preparation, narrow it, or revert it before Step 2. Do not explain away an accidental behavior change as part of the final feature.
+            ]]></step-content>
+            <step-constraints>
+                <step-constraint-list>
+                    <step-constraint>**MUST** verify behavior preservation before Step 2</step-constraint>
+                    <step-constraint>**MUST** report the validation command, test, or manual check used</step-constraint>
+                    <step-constraint>**MUST NOT** proceed when Step 1 introduced unexplained behavior drift</step-constraint>
+                </step-constraint-list>
+            </step-constraints>
+        </step>
+
+        <step number="4">
+            <step-title>Make the Easy Change</step-title>
+            <step-content><![CDATA[
+Once the design supports the work, apply the smallest behavior change that satisfies the request:
+
+- Modify the now-isolated decision, policy, mapping, validation, query, handler, or adapter
+- Add or update focused tests for the new behavior
+- Keep unrelated cleanup out of this step unless it is required to complete the behavior change
+- Use `121-java-object-oriented-design` for responsibility and class design when needed
+- Use `122-java-type-design` for type boundaries and invariants when needed
+- Use `123-java-design-patterns` only when a concrete design pressure calls for a pattern
+- Use framework, persistence, messaging, API, or testing skills when the change touches those areas
+
+The point of Step 2 is that it should now feel direct. If it is still broad or confusing, return to Step 1 and make one more behavior-preserving preparation.
+            ]]></step-content>
+            <step-constraints>
+                <step-constraint-list>
+                    <step-constraint>**MUST** keep Step 2 focused on the intended behavior change</step-constraint>
+                    <step-constraint>**MUST** update or add tests that demonstrate the new behavior when feasible</step-constraint>
+                    <step-constraint>**MUST** preserve the two-step ordering even when using another implementation skill</step-constraint>
+                </step-constraint-list>
+            </step-constraints>
+        </step>
+
+        <step number="5">
+            <step-title>Verify Intended Behavior and Report</step-title>
+            <step-content><![CDATA[
+After Step 2, verify the requested behavior and provide a concise handoff:
+
+- Tests or commands proving Step 1 preserved behavior
+- Tests or commands proving Step 2 changed the intended behavior
+- Files changed during preparation versus files changed for behavior
+- Assumptions, risks, and any remaining verification gaps
+- Recommended follow-up only when it is directly connected to the change
+
+When automation is unavailable, state the skipped check and reason. Do not claim acceptance coverage that was not executed.
+            ]]></step-content>
+        </step>
+    </steps>
+
+    <output-format>
+        <output-format-list>
+            <output-format-item>State the intended behavior change and the design obstacle</output-format-item>
+            <output-format-item>Separate Step 1 preparatory refactoring from Step 2 behavior change</output-format-item>
+            <output-format-item>List validation performed after Step 1 and after Step 2</output-format-item>
+            <output-format-item>Report supporting skills used and why, when applicable</output-format-item>
+            <output-format-item>Call out risks when preparation and behavior change cannot be fully separated</output-format-item>
+        </output-format-list>
+    </output-format>
+
+    <safeguards>
+        <safeguards-list>
+            <safeguards-item>Do not combine large refactoring and intended behavior change in one unvalidated edit</safeguards-item>
+            <safeguards-item>Do not broaden the refactoring beyond what makes the requested change easy</safeguards-item>
+            <safeguards-item>Do not skip behavior-preservation validation after preparatory refactoring</safeguards-item>
+            <safeguards-item>Do not hide accidental behavior changes inside Step 1</safeguards-item>
+            <safeguards-item>Do not claim a prompt, test, build, or manual check passed unless it was actually executed</safeguards-item>
+        </safeguards-list>
+    </safeguards>
+</prompt>

--- a/skills-generator/src/main/resources/skill-references/assets/agents/robot-tech-lead.md
+++ b/skills-generator/src/main/resources/skill-references/assets/agents/robot-tech-lead.md
@@ -16,6 +16,7 @@ You are a **Tech Lead** for Java Enterprise Development. Your primary responsibi
 
 - Translate an issue, approved design, ADR set, OpenSpec change, or valid combination of these sources into executable technical work.
 - Create and refine an implementation plan using `@041-planning-plan-mode`.
+- Use `@051-design-two-steps-methods` for every plan so tasks separate behavior-preserving preparation, validation that behavior stayed unchanged, the intended behavior change, and final verification.
 - Define approach, affected files, dependencies, risks, verification, milestones, and parallel groups.
 - Record source artifacts and unresolved decisions so the plan does not silently override requirements or ADRs.
 - A plan may be created directly from an issue; OpenSpec is not a mandatory prerequisite.
@@ -23,6 +24,7 @@ You are a **Tech Lead** for Java Enterprise Development. Your primary responsibi
 ### Mission 2: Create the specification
 
 - Create or update an OpenSpec change using `@042-planning-openspec`.
+- Use `@051-design-two-steps-methods` for every OpenSpec change so proposal, design, specs, and tasks preserve the two-step sequence.
 - Accept an issue, approved design, ADRs, implementation plan, existing OpenSpec artifacts, or a valid combination as input.
 - Assess whether the scope fits one reviewable change; propose multiple changes and dependencies when outcomes have distinct release, ownership, risk, or deployment boundaries.
 - Record derivation direction and source artifacts. Never silently synchronize a source artifact from a derived artifact.
@@ -42,6 +44,7 @@ You are a **Tech Lead** for Java Enterprise Development. Your primary responsibi
 - **[@robot-java-quarkus-coder](robot-java-quarkus-coder.md):** Quarkus implementation (Jakarta REST resources, CDI, validation, security, Panache/JDBC, Flyway migrations, Kafka messaging, MongoDB, Quarkus tests — `@401`–`@415`, `@421`–`@423`). Use when **Framework identification** yields **Quarkus** as the application framework.
 - **[@robot-java-micronaut-coder](robot-java-micronaut-coder.md):** Micronaut implementation (`@Controller`, validation, security, programmatic JDBC, Micronaut Data, Flyway migrations, Kafka messaging, MongoDB, `Micronaut.run`, CDI-style beans, Micronaut tests — `@501`–`@515`, `@521`–`@523`). Use when **Framework identification** yields **Micronaut** as the application framework.
 - **[@robot-no-java](robot-no-java.md):** Default implementation for non-Java work. Use when the issue, plan, or OpenSpec task list names a non-Java stack or has no Java, Maven, or JVM implementation scope.
+- **Two-step change shaping:** Use `@051-design-two-steps-methods` during every plan or OpenSpec creation so preparatory work is validated before behavior-changing work begins.
 - **Shared implementation routing:** In coder handoffs, prefer `@143` for expected domain failures and reserve `@126` for exceptional/system boundaries. Apply design guidance in the order `@121` → `@122` → `@123`, with `@142` inside those boundaries. Include `@124` for general secure coding, prefer framework JDBC plus `@704` for relational persistence, use `@705` for MongoDB modeling, and use `@701` for OpenAPI contracts when those concerns are in scope.
 - **Parallel column drives grouping:** The plan's task list table includes a **Parallel** column (or **Agent** if the plan uses that name). Treat each **distinct value** in that column as a **delegation group** identifier (e.g. `A1`, `A2`, `A3-timeout`, `A3-retry`, `A4`).
 - **One logical developer per group:** For each distinct **Parallel** value, assign a **separate** instance of the **same** chosen implementation agent (`robot-java-coder`, `robot-java-spring-boot-coder`, `robot-java-quarkus-coder`, `robot-java-micronaut-coder`, or `robot-no-java`) whose scope is **only** the rows for that value. Label every handoff, e.g. `Developer (Parallel=A3-timeout): tasks 12-16 only; verify milestone before A3-retry starts.`

--- a/skills-generator/src/main/resources/skill-references/assets/commands/create-plan.md
+++ b/skills-generator/src/main/resources/skill-references/assets/commands/create-plan.md
@@ -18,15 +18,17 @@ Create or refine an executable technical implementation plan from the available 
 ## Owning Agent
 `@robot-tech-lead`
 
-## Associated Skill
-`041-planning-plan-mode`
+## Associated Skills
+- `041-planning-plan-mode`
+- `051-design-two-steps-methods` for every plan so preparatory work, behavior change, and verification remain explicitly sequenced
 
 ## Workflow
 1. Identify the available source artifacts and their authority.
 2. Resolve material implementation questions without inventing requirements.
-3. Define the technical approach, affected areas, ordered tasks, risks, and verification.
-4. Record source links and any assumptions or unresolved blockers.
-5. Present the plan for approval.
+3. Apply the two-step method so the plan orders behavior-preserving preparation, behavior-preservation validation, the intended behavior change, and final verification.
+4. Define the technical approach, affected areas, ordered tasks, risks, and verification.
+5. Record source links and any assumptions or unresolved blockers.
+6. Present the plan for approval.
 
 ## Output
 - Executable implementation plan

--- a/skills-generator/src/main/resources/skill-references/assets/commands/create-spec.md
+++ b/skills-generator/src/main/resources/skill-references/assets/commands/create-spec.md
@@ -18,16 +18,18 @@ Create or update one or more OpenSpec changes from the available issue, design, 
 ## Owning Agent
 `@robot-tech-lead`
 
-## Associated Skill
-`042-planning-openspec`
+## Associated Skills
+- `042-planning-openspec`
+- `051-design-two-steps-methods` for every OpenSpec change so preparatory work, behavior change, and verification remain explicitly sequenced
 
 ## Workflow
 1. Identify the available source artifacts and their authority.
 2. Assess whether the scope fits one reviewable change.
-3. For broad scope, propose independently valuable changes and dependencies for approval.
-4. Create or update the approved OpenSpec proposal, design, specifications, and tasks.
-5. Record derivation direction, source links, and unresolved questions.
-6. Validate the resulting OpenSpec changes.
+3. Apply the two-step method so OpenSpec separates behavior-preserving preparation from behavior-changing work and validates each step.
+4. For broad scope, propose independently valuable changes and dependencies for approval.
+5. Create or update the approved OpenSpec proposal, design, specifications, and tasks.
+6. Record derivation direction, source links, and unresolved questions.
+7. Validate the resulting OpenSpec changes.
 
 ## Output
 - One OpenSpec change, or an approved map of multiple changes

--- a/skills-generator/src/main/resources/skills.xml
+++ b/skills-generator/src/main/resources/skills.xml
@@ -91,6 +91,11 @@
             <reference>044-planning-jira</reference>
         </reference-list>
     </skill>
+    <skill id="051" skillId="051-design-two-steps-methods">
+        <reference-list>
+            <reference>051-design-two-steps-methods</reference>
+        </reference-list>
+    </skill>
     <skill id="110">
         <reference-list>
             <reference>110-java-maven-best-practices</reference>

--- a/skills-generator/src/test/resources/gherkin/skills/051-design-two-steps-methods.feature
+++ b/skills-generator/src/test/resources/gherkin/skills/051-design-two-steps-methods.feature
@@ -1,0 +1,24 @@
+Feature: Validate changes from usage of two-step change method skill
+
+Background:
+  Given the skill "051-design-two-steps-methods"
+  And the analysis sandbox folder "examples/skills/analysis" has no git changes
+
+@acceptance-test
+Scenario: Guide a risky code change through preparatory refactoring before behavior change
+  Given the user request is "Use the two-step change method to make a complex or risky Java code change safer"
+  And the local generated skill path ".agents/skills/051-design-two-steps-methods"
+  And the requested analysis output path is "examples/skills/analysis/TWO-STEP-CHANGE-METHOD-PLAN.md"
+  And any existing report at the requested output path must be overwritten
+  When the skill ".agents/skills/051-design-two-steps-methods" is applied to the requested risky change
+  Then the skill reads "references/051-design-two-steps-methods.md"
+  And the skill states the intended behavior change before proposing refactoring
+  And the skill identifies why the current design makes the change complex or risky
+  And the skill guides Step 1 as behavior-preserving preparatory refactoring that makes the change easy
+  And the skill requires validation that Step 1 preserves existing behavior before proceeding
+  And the skill guides Step 2 as the intended behavior change once the design supports it
+  And the skill recommends focused verification for the intended behavior change after Step 2
+  And the skill keeps Java, framework, persistence, messaging, API, or testing skill handoffs inside the two-step sequence when those details are needed
+  And the skill writes the two-step change method outcome to "examples/skills/analysis/TWO-STEP-CHANGE-METHOD-PLAN.md"
+  And the generated analysis file reflects the whole guidance including the intended behavior change, design obstacle, Step 1 preparation, Step 1 behavior-preservation validation, Step 2 behavior change, Step 2 verification, assumptions, and risks
+  And any git changes produced under "examples/skills/analysis" during skill execution and verification are reset

--- a/skills-generator/src/test/resources/gherkin/skills/051-design-two-steps-methods.feature
+++ b/skills-generator/src/test/resources/gherkin/skills/051-design-two-steps-methods.feature
@@ -2,23 +2,26 @@ Feature: Validate changes from usage of two-step change method skill
 
 Background:
   Given the skill "051-design-two-steps-methods"
-  And the analysis sandbox folder "examples/skills/analysis" has no git changes
+  And the OpenSpec example project "examples/openspec/god-analysis-api"
+  And the OpenSpec sandbox folder "examples/openspec/god-analysis-api/openspec" has no git changes
 
 @acceptance-test
-Scenario: Guide a risky code change through preparatory refactoring before behavior change
-  Given the user request is "Use the two-step change method to make a complex or risky Java code change safer"
+Scenario: Create an OpenSpec change that plans a risky Java change with the two-step method
+  Given the user request is "Create an OpenSpec change for a risky Java refactoring using the two-step change method"
   And the local generated skill path ".agents/skills/051-design-two-steps-methods"
-  And the requested analysis output path is "examples/skills/analysis/TWO-STEP-CHANGE-METHOD-PLAN.md"
-  And any existing report at the requested output path must be overwritten
-  When the skill ".agents/skills/051-design-two-steps-methods" is applied to the requested risky change
+  And the requested OpenSpec change id is "acceptance-two-step-change-method"
+  And the requested OpenSpec change path is "examples/openspec/god-analysis-api/openspec/changes/acceptance-two-step-change-method"
+  And any existing OpenSpec change at the requested change path must be overwritten
+  When the skill ".agents/skills/051-design-two-steps-methods" is applied to create the requested OpenSpec change
   Then the skill reads "references/051-design-two-steps-methods.md"
-  And the skill states the intended behavior change before proposing refactoring
-  And the skill identifies why the current design makes the change complex or risky
-  And the skill guides Step 1 as behavior-preserving preparatory refactoring that makes the change easy
-  And the skill requires validation that Step 1 preserves existing behavior before proceeding
-  And the skill guides Step 2 as the intended behavior change once the design supports it
-  And the skill recommends focused verification for the intended behavior change after Step 2
+  And the skill creates or updates "proposal.md", "design.md", and "tasks.md" under the requested OpenSpec change path
+  And the OpenSpec design analysis states the intended behavior change before proposing refactoring
+  And the OpenSpec design analysis identifies why the current design makes the change complex or risky
+  And the OpenSpec design analysis separates Step 1 behavior-preserving preparation from Step 2 behavior change
+  And the OpenSpec tasks require validation that Step 1 preserves existing behavior before proceeding
+  And the OpenSpec tasks schedule Step 2 as the intended behavior change once the design supports it
+  And the OpenSpec tasks include focused verification for the intended behavior change after Step 2
   And the skill keeps Java, framework, persistence, messaging, API, or testing skill handoffs inside the two-step sequence when those details are needed
-  And the skill writes the two-step change method outcome to "examples/skills/analysis/TWO-STEP-CHANGE-METHOD-PLAN.md"
-  And the generated analysis file reflects the whole guidance including the intended behavior change, design obstacle, Step 1 preparation, Step 1 behavior-preservation validation, Step 2 behavior change, Step 2 verification, assumptions, and risks
-  And any git changes produced under "examples/skills/analysis" during skill execution and verification are reset
+  And the generated OpenSpec artifacts reflect the whole guidance including the intended behavior change, design obstacle, Step 1 preparation, Step 1 behavior-preservation validation, Step 2 behavior change, Step 2 verification, assumptions, and risks
+  And "openspec validate --all" is run from "examples/openspec/god-analysis-api" after the OpenSpec change is created
+  And any git changes produced under "examples/openspec/god-analysis-api/openspec" during skill execution and verification are reset

--- a/skills-generator/src/test/resources/gherkin/skills/acceptance-tests-prompts-skills.md
+++ b/skills-generator/src/test/resources/gherkin/skills/acceptance-tests-prompts-skills.md
@@ -71,6 +71,13 @@ execute @skills-generator/src/test/resources/gherkin/skills/042-planning-openspe
 and verify that acceptance-tests passes.
 ```
 
+## 051-design-two-steps-methods
+
+```bash
+execute @skills-generator/src/test/resources/gherkin/skills/051-design-two-steps-methods.feature
+and verify that acceptance-tests passes.
+```
+
 ## 110-java-maven-best-practices
 
 ```bash


### PR DESCRIPTION
## Summary
- Add generated XML source for `051-design-two-steps-methods` and register it in `skills.xml`.
- Add Gherkin acceptance coverage and prompt inventory entry.
- Update create-plan/create-spec command assets and `robot-tech-lead` so every plan/OpenSpec change applies the two-step method sequence.

## Validation
- `xmllint --noout skills-generator/src/main/resources/skill-indexes/051-skill.xml skills-generator/src/main/resources/skill-references/051-design-two-steps-methods.xml skills-generator/src/main/resources/skills.xml`
- `./mvnw clean install -pl skills-generator`
- `./mvnw clean verify -pl skills-generator`
- `cd documentation && openspec validate --all`
- `jbang .github/scripts/MarkdownValidator.java --verbose .`
- Manual acceptance prompt execution for `051-design-two-steps-methods.feature`; sandbox output reset afterward.

Closes #877