### PR TITLE
feat(commands): add review breaking changes command

### DIFF
--- a/.cursor/commands/review-breaking-changes.md
+++ b/.cursor/commands/review-breaking-changes.md
@@ -1,0 +1,57 @@
+# review-breaking-changes
+
+## Purpose
+
+Review an approved plan or OpenSpec artifact for potential breaking changes before implementation or release work proceeds.
+
+## Usage
+
+```text
+/review-breaking-changes <plan|openspec-change|spec> [scope] [constraints]
+```
+
+## Accepted Inputs
+
+- Approved implementation plan (`*.plan.md`)
+- OpenSpec change directory containing proposal, design, specs, or tasks
+- OpenSpec specification file
+- Optional scope constraints such as command, skill, generated output, public API, data contract, documentation, or release boundary
+
+## Owning Agent
+
+`@robot-tech-lead`
+
+## Associated Capabilities
+
+- Compatibility and migration-risk review
+- Public contract and generated-output impact analysis
+- Command, agent, skill, documentation, and OpenSpec traceability review
+- Validation planning for release or implementation readiness
+
+## Workflow
+
+1. Load the selected plan, OpenSpec change, or spec and identify the authoritative scope.
+2. Inventory affected contracts, generated outputs, commands, skills, agents, documentation, APIs, schemas, configuration, and release artifacts mentioned by the source.
+3. Classify each potential break as `BREAKING`, `POTENTIALLY BREAKING`, `NON-BREAKING`, or `UNKNOWN`.
+4. For each breaking or uncertain item, explain the compatibility risk, affected consumers, migration need, and evidence from the source artifact.
+5. Identify missing validation, release-note, migration-guide, deprecation, or fallback work.
+6. Recommend follow-up changes, tests, OpenSpec updates, or `/review-alignment` when artifact conflicts block a reliable conclusion.
+7. Report readiness as `READY`, `READY WITH BREAKING-CHANGE WARNINGS`, or `NOT READY`.
+
+## Output
+
+- Reviewed artifact and scope
+- Compatibility summary
+- Severity-ranked breaking-change findings
+- Affected contracts, generated outputs, commands, skills, documentation, and consumers
+- Required migration, release-note, fallback, or validation work
+- Open questions and recommended follow-up
+- Readiness result
+
+## Safeguards
+
+- Keep the review read-only.
+- Do not modify plans, specs, source files, generated outputs, or issue descriptions without explicit follow-up approval.
+- Do not infer breaking changes from unrelated repository files when they are not connected to the reviewed artifact.
+- Mark uncertain impact as `UNKNOWN` and request more evidence instead of guessing.
+- Preserve the source artifact's scope; do not add requirements or implementation tasks beyond compatibility review.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ An opinionated AI-native workflow for evolving modern Java Enterprise `SDLC` pra
 
 ## Project at a glance
 
-- 14 Commands
+- 15 Commands
 - 9 Agents
-- 106 Skills
+- 107 Skills
 
 ## Latest Updates
 
@@ -63,38 +63,95 @@ Current `System prompts/rules` are deprecated and will be removed in `v0.17.0`. 
 
 ## Choose your path
 
+Commands compose the workflow by routing work to the right agent and skill set:
+
 ### Plan
 
 Turn an idea into an actionable change with user stories, GitHub Issues or Jira, ADRs, diagrams, AI plan mode, and OpenSpec.
 
-| Resource | Available options |
-| --- | --- |
-| **Commands** | `/create-issue` · [`/update-issue`](./.cursor/commands/update-issue.md) · `/explore-design` · `/create-adr` · `/create-diagram` · `/create-plan` · `/create-spec` · `/review-alignment` |
-| **Agents** | `@robot-business-analyst` · `@robot-architect` · `@robot-tech-lead` |
-| **Skills** | [014-agile-user-story](https://www.skills.sh/jabrena/cursor-rules-java/014-agile-user-story) · [030-architecture-adr-general](https://www.skills.sh/jabrena/cursor-rules-java/030-architecture-adr-general) · [033-architecture-diagrams](https://www.skills.sh/jabrena/cursor-rules-java/033-architecture-diagrams) · [041-planning-plan-mode](https://www.skills.sh/jabrena/cursor-rules-java/041-planning-plan-mode) · [200-agents-md](https://www.skills.sh/jabrena/cursor-rules-java/200-agents-md) |
-| **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) |
+```text
+/create-issue
+/update-issue
+@robot-business-analyst
+    @043-planning-github-issues
+    @044-planning-jira
+    @014-agile-user-story
+/create-adr
+@robot-architect
+    @030-architecture-adr-general
+    @031-architecture-adr-functional-requirements
+    @032-architecture-adr-non-functional-requirements
+/create-diagram
+@robot-architect
+    @033-architecture-diagrams
+/create-plan
+@robot-tech-lead
+    @041-planning-plan-mode
+/create-spec
+@robot-tech-lead
+    @042-planning-openspec
+    @051-design-two-steps-methods
+/explore-design
+@robot-architect
+    @034-architecture-design-exploration
+/review-alignment
+@robot-business-analyst
+/review-breaking-changes
+@robot-tech-lead
+
+MCP Servers
+    Jbang-Quarkus-JDBC
+    MongoDB
+    JavaDocs
+    Serena-LSP
+    Grafana
+```
 
 ### Build
 
 Implement and improve Java applications with Maven, design, coding, testing, security, documentation, Spring Boot, Quarkus, Micronaut, OpenAPI, and WireMock guidance.
 
-| Resource | Available options |
-| --- | --- |
-| **Commands** | [`/create-feature-branch`](./.cursor/commands/create-feature-branch.md) · [`/create-worktree`](./.cursor/commands/create-worktree.md) · [`/implement-issue`](./.cursor/commands/implement-issue.md) · [`/kill-port`](./.cursor/commands/kill-port.md) |
-| **Agents** | `@robot-tech-lead` · `@robot-no-java` · `@robot-java-coder` · `@robot-java-spring-boot-coder` · `@robot-java-quarkus-coder` · `@robot-java-micronaut-coder` |
-| **Skills** | [110-java-maven-best-practices](https://www.skills.sh/jabrena/cursor-rules-java/110-java-maven-best-practices) · [111-java-maven-dependencies](https://www.skills.sh/jabrena/cursor-rules-java/111-java-maven-dependencies) · [121-java-object-oriented-design](https://www.skills.sh/jabrena/cursor-rules-java/121-java-object-oriented-design) · [124-java-secure-coding](https://www.skills.sh/jabrena/cursor-rules-java/124-java-secure-coding) · [143-java-functional-exception-handling](https://www.skills.sh/jabrena/cursor-rules-java/143-java-functional-exception-handling) |
-| **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [JavaDocs](https://www.javadocs.dev/mcp) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) |
+```text
+/implement-issue
+@robot-tech-lead
+    /create-feature-branch
+    /create-worktree
+    @robot-java-coder
+    @robot-java-spring-boot-coder
+    @robot-java-quarkus-coder
+    @robot-java-micronaut-coder
+    @robot-no-java
+/kill-port
+
+MCP Servers
+    Jbang-Quarkus-JDBC
+    MongoDB
+    JavaDocs
+    Serena-LSP
+```
 
 ### Operate
 
 Measure and improve production behavior through observability, profiling, benchmarking, and performance testing.
 
-| Resource | Available options |
-| --- | --- |
-| **Commands** | [`/profile`](./.cursor/commands/profile.md) · [`/benchmark`](./.cursor/commands/benchmark.md) |
-| **Agents** | `@robot-java-performance` |
-| **Skills** | [151-java-performance-jmeter](https://www.skills.sh/jabrena/cursor-rules-java/151-java-performance-jmeter) · [161-java-profiling-detect](https://www.skills.sh/jabrena/cursor-rules-java/161-java-profiling-detect) · [162-java-profiling-analyze](https://www.skills.sh/jabrena/cursor-rules-java/162-java-profiling-analyze) · [163-java-profiling-refactor](https://www.skills.sh/jabrena/cursor-rules-java/163-java-profiling-refactor) · [164-java-profiling-verify](https://www.skills.sh/jabrena/cursor-rules-java/164-java-profiling-verify) |
-| **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) · [Grafana](https://grafana.com/docs/grafana/latest/developer-resources/mcp/) |
+```text
+/profile
+@robot-java-performance
+    @161-java-profiling-detect
+    @162-java-profiling-analyze
+    @163-java-profiling-refactor
+    @164-java-profiling-verify
+/benchmark
+@robot-java-performance
+    @151-java-performance-jmeter
+    @152-java-performance-gatling
+
+MCP Servers
+    Jbang-Quarkus-JDBC
+    MongoDB
+    Serena-LSP
+    Grafana
+```
 
 ### Compliance (Alpha)
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -16,9 +16,9 @@ Un flujo de trabajo nativo de IA, con criterio propio, para evolucionar las prá
 
 ## Proyecto de un vistazo
 
-- 14 Commands
+- 15 Commands
 - 9 Agents
-- 106 Skills
+- 107 Skills
 
 ## Últimas actualizaciones
 
@@ -63,15 +63,86 @@ Los `System prompts/rules` actuales están deprecados y se eliminarán en `v0.16
 
 ## Elige tu camino
 
+Los commands componen el flujo de trabajo dirigiendo cada tarea al agente y al conjunto de skills adecuados:
+
+```text
+Plan
+  /create-issue
+  /update-issue
+    @robot-business-analyst
+      @043-planning-github-issues
+      @044-planning-jira
+      @014-agile-user-story
+  /create-adr
+    @robot-architect
+      @030-architecture-adr-general
+      @031-architecture-adr-functional-requirements
+      @032-architecture-adr-non-functional-requirements
+  /create-diagram
+    @robot-architect
+      @033-architecture-diagrams
+  /create-plan
+    @robot-tech-lead
+      @041-planning-plan-mode
+  /create-spec
+    @robot-tech-lead
+      @042-planning-openspec
+  /explore-design
+    @robot-architect
+      @034-architecture-design-exploration
+      @051-design-two-steps-methods
+  /review-alignment
+    @robot-business-analyst
+  /review-breaking-changes
+    @robot-tech-lead
+
+Build
+  /implement-issue
+      @robot-tech-lead
+      /create-feature-branch
+      /create-worktree
+      @robot-java-coder
+      @robot-java-spring-boot-coder
+      @robot-java-quarkus-coder
+      @robot-java-micronaut-coder
+      @robot-no-java
+  /kill-port
+
+  MCP Servers
+    Jbang-Quarkus-JDBC
+    MongoDB
+    JavaDocs
+    Serena-LSP
+
+Operate
+  /profile
+    @robot-java-performance
+      @161-java-profiling-detect
+      @162-java-profiling-analyze
+      @163-java-profiling-refactor
+      @164-java-profiling-verify
+  /benchmark
+    @robot-java-performance
+      @151-java-performance-jmeter
+      @152-java-performance-gatling
+
+MCP Servers
+  Jbang-Quarkus-JDBC
+  MongoDB
+  JavaDocs
+  Serena-LSP
+  Grafana
+```
+
 ### Planificar
 
 Convierte una idea en un cambio accionable mediante user stories, GitHub Issues o Jira, ADRs, diagramas, AI plan mode y OpenSpec.
 
 | Recurso | Opciones disponibles |
 | --- | --- |
-| **Commands** | `/create-issue` · [`/update-issue`](./.cursor/commands/update-issue.md) · `/explore-design` · `/create-adr` · `/create-diagram` · `/create-plan` · `/create-spec` · `/review-alignment` |
+| **Commands** | `/create-issue` · [`/update-issue`](./.cursor/commands/update-issue.md) · `/explore-design` · `/create-adr` · `/create-diagram` · `/create-plan` · `/create-spec` · `/review-alignment` · [`/review-breaking-changes`](./.cursor/commands/review-breaking-changes.md) |
 | **Agents** | `@robot-business-analyst` · `@robot-architect` · `@robot-tech-lead` |
-| **Skills** | [014-agile-user-story](https://www.skills.sh/jabrena/cursor-rules-java/014-agile-user-story) · [030-architecture-adr-general](https://www.skills.sh/jabrena/cursor-rules-java/030-architecture-adr-general) · [033-architecture-diagrams](https://www.skills.sh/jabrena/cursor-rules-java/033-architecture-diagrams) · [041-planning-plan-mode](https://www.skills.sh/jabrena/cursor-rules-java/041-planning-plan-mode) · [200-agents-md](https://www.skills.sh/jabrena/cursor-rules-java/200-agents-md) |
+| **Skills** | [014-agile-user-story](https://www.skills.sh/jabrena/cursor-rules-java/014-agile-user-story) · [030-architecture-adr-general](https://www.skills.sh/jabrena/cursor-rules-java/030-architecture-adr-general) · [031-architecture-adr-functional-requirements](https://www.skills.sh/jabrena/cursor-rules-java/031-architecture-adr-functional-requirements) · [032-architecture-adr-non-functional-requirements](https://www.skills.sh/jabrena/cursor-rules-java/032-architecture-adr-non-functional-requirements) · [033-architecture-diagrams](https://www.skills.sh/jabrena/cursor-rules-java/033-architecture-diagrams) · [034-architecture-design-exploration](https://www.skills.sh/jabrena/cursor-rules-java/034-architecture-design-exploration) · [041-planning-plan-mode](https://www.skills.sh/jabrena/cursor-rules-java/041-planning-plan-mode) · [042-planning-openspec](https://www.skills.sh/jabrena/cursor-rules-java/042-planning-openspec) · [043-planning-github-issues](https://www.skills.sh/jabrena/cursor-rules-java/043-planning-github-issues) · [044-planning-jira](https://www.skills.sh/jabrena/cursor-rules-java/044-planning-jira) · [051-design-two-steps-methods](https://www.skills.sh/jabrena/cursor-rules-java/051-design-two-steps-methods) · [200-agents-md](https://www.skills.sh/jabrena/cursor-rules-java/200-agents-md) |
 | **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) |
 
 ### Construir

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -16,9 +16,9 @@
 
 ## 项目概览
 
-- 14 Commands
+- 15 Commands
 - 9 Agents
-- 106 Skills
+- 107 Skills
 
 ## 最新动态
 
@@ -63,15 +63,86 @@ npx skills add jabrena/cursor-rules-java --skill '*' --agent github-copilot -y
 
 ## 选择你的路径
 
+Commands 通过把工作路由到合适的 agent 与 skill 集合来组合完整工作流：
+
+```text
+Plan
+  /create-issue
+  /update-issue
+    @robot-business-analyst
+      @043-planning-github-issues
+      @044-planning-jira
+      @014-agile-user-story
+  /create-adr
+    @robot-architect
+      @030-architecture-adr-general
+      @031-architecture-adr-functional-requirements
+      @032-architecture-adr-non-functional-requirements
+  /create-diagram
+    @robot-architect
+      @033-architecture-diagrams
+  /create-plan
+    @robot-tech-lead
+      @041-planning-plan-mode
+  /create-spec
+    @robot-tech-lead
+      @042-planning-openspec
+  /explore-design
+    @robot-architect
+      @034-architecture-design-exploration
+      @051-design-two-steps-methods
+  /review-alignment
+    @robot-business-analyst
+  /review-breaking-changes
+    @robot-tech-lead
+
+Build
+  /implement-issue
+      @robot-tech-lead
+      /create-feature-branch
+      /create-worktree
+      @robot-java-coder
+      @robot-java-spring-boot-coder
+      @robot-java-quarkus-coder
+      @robot-java-micronaut-coder
+      @robot-no-java
+  /kill-port
+
+  MCP Servers
+    Jbang-Quarkus-JDBC
+    MongoDB
+    JavaDocs
+    Serena-LSP
+
+Operate
+  /profile
+    @robot-java-performance
+      @161-java-profiling-detect
+      @162-java-profiling-analyze
+      @163-java-profiling-refactor
+      @164-java-profiling-verify
+  /benchmark
+    @robot-java-performance
+      @151-java-performance-jmeter
+      @152-java-performance-gatling
+
+MCP Servers
+  Jbang-Quarkus-JDBC
+  MongoDB
+  JavaDocs
+  Serena-LSP
+  Grafana
+```
+
 ### 规划
 
 通过 user stories、GitHub Issues 或 Jira、ADR、图表、AI plan mode 和 OpenSpec，将想法转化为可执行的变更。
 
 | 资源 | 可用选项 |
 | --- | --- |
-| **Commands** | `/create-issue` · [`/update-issue`](./.cursor/commands/update-issue.md) · `/explore-design` · `/create-adr` · `/create-diagram` · `/create-plan` · `/create-spec` · `/review-alignment` |
+| **Commands** | `/create-issue` · [`/update-issue`](./.cursor/commands/update-issue.md) · `/explore-design` · `/create-adr` · `/create-diagram` · `/create-plan` · `/create-spec` · `/review-alignment` · [`/review-breaking-changes`](./.cursor/commands/review-breaking-changes.md) |
 | **Agents** | `@robot-business-analyst` · `@robot-architect` · `@robot-tech-lead` |
-| **Skills** | [014-agile-user-story](https://www.skills.sh/jabrena/cursor-rules-java/014-agile-user-story) · [030-architecture-adr-general](https://www.skills.sh/jabrena/cursor-rules-java/030-architecture-adr-general) · [033-architecture-diagrams](https://www.skills.sh/jabrena/cursor-rules-java/033-architecture-diagrams) · [041-planning-plan-mode](https://www.skills.sh/jabrena/cursor-rules-java/041-planning-plan-mode) · [200-agents-md](https://www.skills.sh/jabrena/cursor-rules-java/200-agents-md) |
+| **Skills** | [014-agile-user-story](https://www.skills.sh/jabrena/cursor-rules-java/014-agile-user-story) · [030-architecture-adr-general](https://www.skills.sh/jabrena/cursor-rules-java/030-architecture-adr-general) · [031-architecture-adr-functional-requirements](https://www.skills.sh/jabrena/cursor-rules-java/031-architecture-adr-functional-requirements) · [032-architecture-adr-non-functional-requirements](https://www.skills.sh/jabrena/cursor-rules-java/032-architecture-adr-non-functional-requirements) · [033-architecture-diagrams](https://www.skills.sh/jabrena/cursor-rules-java/033-architecture-diagrams) · [034-architecture-design-exploration](https://www.skills.sh/jabrena/cursor-rules-java/034-architecture-design-exploration) · [041-planning-plan-mode](https://www.skills.sh/jabrena/cursor-rules-java/041-planning-plan-mode) · [042-planning-openspec](https://www.skills.sh/jabrena/cursor-rules-java/042-planning-openspec) · [043-planning-github-issues](https://www.skills.sh/jabrena/cursor-rules-java/043-planning-github-issues) · [044-planning-jira](https://www.skills.sh/jabrena/cursor-rules-java/044-planning-jira) · [051-design-two-steps-methods](https://www.skills.sh/jabrena/cursor-rules-java/051-design-two-steps-methods) · [200-agents-md](https://www.skills.sh/jabrena/cursor-rules-java/200-agents-md) |
 | **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) |
 
 ### 构建

--- a/skills-generator/src/main/resources/commands.xml
+++ b/skills-generator/src/main/resources/commands.xml
@@ -10,6 +10,7 @@
     <command file="create-plan.md"/>
     <command file="create-spec.md"/>
     <command file="review-alignment.md"/>
+    <command file="review-breaking-changes.md"/>
     <command file="implement-issue.md"/>
     <command file="profile.md"/>
     <command file="benchmark.md"/>

--- a/skills-generator/src/main/resources/skill-references/004-commands-installation.xml
+++ b/skills-generator/src/main/resources/skill-references/004-commands-installation.xml
@@ -78,6 +78,9 @@
                 <xi:include href="assets/commands/review-alignment.md" parse="text"/>
                 ```
                 ```markdown
+                <xi:include href="assets/commands/review-breaking-changes.md" parse="text"/>
+                ```
+                ```markdown
                 <xi:include href="assets/commands/implement-issue.md" parse="text"/>
                 ```
                 ```markdown
@@ -97,7 +100,7 @@
             <step-constraints>
                 <step-constraint-list>
                     <step-constraint>**MUST** copy from embedded assets, not from external URLs</step-constraint>
-                    <step-constraint>**MUST** install all fourteen commands as one set</step-constraint>
+                    <step-constraint>**MUST** install all fifteen commands as one set</step-constraint>
                     <step-constraint>**MUST** preserve original file names</step-constraint>
                 </step-constraint-list>
             </step-constraints>

--- a/skills-generator/src/main/resources/skill-references/assets/commands/review-breaking-changes.md
+++ b/skills-generator/src/main/resources/skill-references/assets/commands/review-breaking-changes.md
@@ -1,0 +1,57 @@
+# review-breaking-changes
+
+## Purpose
+
+Review an approved plan or OpenSpec artifact for potential breaking changes before implementation or release work proceeds.
+
+## Usage
+
+```text
+/review-breaking-changes <plan|openspec-change|spec> [scope] [constraints]
+```
+
+## Accepted Inputs
+
+- Approved implementation plan (`*.plan.md`)
+- OpenSpec change directory containing proposal, design, specs, or tasks
+- OpenSpec specification file
+- Optional scope constraints such as command, skill, generated output, public API, data contract, documentation, or release boundary
+
+## Owning Agent
+
+`@robot-tech-lead`
+
+## Associated Capabilities
+
+- Compatibility and migration-risk review
+- Public contract and generated-output impact analysis
+- Command, agent, skill, documentation, and OpenSpec traceability review
+- Validation planning for release or implementation readiness
+
+## Workflow
+
+1. Load the selected plan, OpenSpec change, or spec and identify the authoritative scope.
+2. Inventory affected contracts, generated outputs, commands, skills, agents, documentation, APIs, schemas, configuration, and release artifacts mentioned by the source.
+3. Classify each potential break as `BREAKING`, `POTENTIALLY BREAKING`, `NON-BREAKING`, or `UNKNOWN`.
+4. For each breaking or uncertain item, explain the compatibility risk, affected consumers, migration need, and evidence from the source artifact.
+5. Identify missing validation, release-note, migration-guide, deprecation, or fallback work.
+6. Recommend follow-up changes, tests, OpenSpec updates, or `/review-alignment` when artifact conflicts block a reliable conclusion.
+7. Report readiness as `READY`, `READY WITH BREAKING-CHANGE WARNINGS`, or `NOT READY`.
+
+## Output
+
+- Reviewed artifact and scope
+- Compatibility summary
+- Severity-ranked breaking-change findings
+- Affected contracts, generated outputs, commands, skills, documentation, and consumers
+- Required migration, release-note, fallback, or validation work
+- Open questions and recommended follow-up
+- Readiness result
+
+## Safeguards
+
+- Keep the review read-only.
+- Do not modify plans, specs, source files, generated outputs, or issue descriptions without explicit follow-up approval.
+- Do not infer breaking changes from unrelated repository files when they are not connected to the reviewed artifact.
+- Mark uncertain impact as `UNKNOWN` and request more evidence instead of guessing.
+- Preserve the source artifact's scope; do not add requirements or implementation tasks beyond compatibility review.

--- a/skills-generator/src/main/resources/skill-references/assets/java-commands-inventory-template.md
+++ b/skills-generator/src/main/resources/skill-references/assets/java-commands-inventory-template.md
@@ -18,6 +18,7 @@ Provide a quick checklist of the embedded commands available for installation in
 | `/create-plan` | Analysis / Design | Create or refine an executable technical implementation plan. |
 | `/create-spec` | Analysis / Design | Create or update one or more validated OpenSpec changes. |
 | `/review-alignment` | Analysis / Design | Review available artifacts for traceability, consistency, completeness, and readiness. |
+| `/review-breaking-changes` | Analysis / Design | Review a plan or OpenSpec artifact for compatibility and migration risks before implementation or release. |
 | `/implement-issue` | Implementation | Deliver an issue from an approved plan or validated OpenSpec task list through framework-aware delegation. |
 | `/profile` | Operation | Coordinate Java profiling from baseline detection through verified optimization. |
 | `/benchmark` | Operation | Select and coordinate JMeter, Gatling, or JMH performance workflows. |

--- a/skills-generator/src/test/java/info/jab/pml/CommandIndexesTest.java
+++ b/skills-generator/src/test/java/info/jab/pml/CommandIndexesTest.java
@@ -150,6 +150,28 @@ class CommandIndexesTest {
     }
 
     @Test
+    @DisplayName("Breaking change review command must assess plans and specs read-only")
+    void should_reviewBreakingChanges_when_commandIsInstalled() {
+        String command = loadClasspathResource("skill-references/assets/commands/review-breaking-changes.md");
+
+        assertThat(command)
+            .contains("/review-breaking-changes <plan|openspec-change|spec>")
+            .contains("Approved implementation plan")
+            .contains("OpenSpec change directory")
+            .contains("OpenSpec specification file")
+            .contains("Owning Agent")
+            .contains("`@robot-tech-lead`")
+            .contains("affected contracts, generated outputs, commands, skills, agents, documentation")
+            .contains("`BREAKING`")
+            .contains("`POTENTIALLY BREAKING`")
+            .contains("`NON-BREAKING`")
+            .contains("`UNKNOWN`")
+            .contains("READY WITH BREAKING-CHANGE WARNINGS")
+            .contains("Keep the review read-only")
+            .contains("Do not modify plans, specs, source files, generated outputs, or issue descriptions");
+    }
+
+    @Test
     @DisplayName("Performance commands must route to Java performance agent")
     void should_routePerformanceWorkflows_when_profileAndBenchmarkCommandsAreInstalled() {
         String profile = loadClasspathResource("skill-references/assets/commands/profile.md");


### PR DESCRIPTION
## Summary
- Add the /review-breaking-changes command and register it in the command inventory
- Update README workflow documentation and localized READMEs with current commands, skills, and MCP servers
- Add coverage for the new command installation index

## Validation
- xmllint --noout skills-generator/src/main/resources/commands.xml skills-generator/src/main/resources/skill-references/004-commands-installation.xml
- jbang .github/scripts/MarkdownValidator.java --verbose .
- ./mvnw test -pl skills-generator -Dtest=CommandIndexesTest