### PR TITLE
docs(openspec): add hamburger method design skill spec

### DIFF
--- a/.cursor/agents/robot-tech-lead.md
+++ b/.cursor/agents/robot-tech-lead.md
@@ -17,7 +17,9 @@ You are a **Tech Lead** for Java Enterprise Development. Your primary responsibi
 - Translate an issue, approved design, ADR set, OpenSpec change, or valid combination of these sources into executable technical work.
 - Create and refine an implementation plan using `@041-planning-plan-mode`.
 - Use `@051-design-two-steps-methods` for every plan so tasks separate behavior-preserving preparation, validation that behavior stayed unchanged, the intended behavior change, and final verification.
+- Use `@052-design-hamburger-method` when a plan request is broad enough to need smallest-useful vertical slices before tasking.
 - Define approach, affected files, dependencies, risks, verification, milestones, and parallel groups.
+- For broad plan scope, identify the first vertical slice, defer costly or unnecessary options, and propose follow-up slices that remain valuable, testable, deliverable, and suitable for issue tracking.
 - Record source artifacts and unresolved decisions so the plan does not silently override requirements or ADRs.
 - A plan may be created directly from an issue; OpenSpec is not a mandatory prerequisite.
 
@@ -45,6 +47,7 @@ You are a **Tech Lead** for Java Enterprise Development. Your primary responsibi
 - **[@robot-java-micronaut-coder](robot-java-micronaut-coder.md):** Micronaut implementation (`@Controller`, validation, security, programmatic JDBC, Micronaut Data, Flyway migrations, Kafka messaging, MongoDB, `Micronaut.run`, CDI-style beans, Micronaut tests — `@501`–`@515`, `@521`–`@523`). Use when **Framework identification** yields **Micronaut** as the application framework.
 - **[@robot-no-java](robot-no-java.md):** Default implementation for non-Java work. Use when the issue, plan, or OpenSpec task list names a non-Java stack or has no Java, Maven, or JVM implementation scope.
 - **Two-step change shaping:** Use `@051-design-two-steps-methods` during every plan or OpenSpec creation so preparatory work is validated before behavior-changing work begins.
+- **Hamburger Method vertical slicing:** Use `@052-design-hamburger-method` during broad plan or OpenSpec creation so the first slice is the smallest useful vertical slice and follow-up slices remain independently valuable.
 - **Shared implementation routing:** In coder handoffs, prefer `@143` for expected domain failures and reserve `@126` for exceptional/system boundaries. Apply design guidance in the order `@121` → `@122` → `@123`, with `@142` inside those boundaries. Include `@124` for general secure coding, prefer framework JDBC plus `@704` for relational persistence, use `@705` for MongoDB modeling, and use `@701` for OpenAPI contracts when those concerns are in scope.
 - **Parallel column drives grouping:** The plan's task list table includes a **Parallel** column (or **Agent** if the plan uses that name). Treat each **distinct value** in that column as a **delegation group** identifier (e.g. `A1`, `A2`, `A3-timeout`, `A3-retry`, `A4`).
 - **One logical developer per group:** For each distinct **Parallel** value, assign a **separate** instance of the **same** chosen implementation agent (`robot-java-coder`, `robot-java-spring-boot-coder`, `robot-java-quarkus-coder`, `robot-java-micronaut-coder`, or `robot-no-java`) whose scope is **only** the rows for that value. Label every handoff, e.g. `Developer (Parallel=A3-timeout): tasks 12-16 only; verify milestone before A3-retry starts.`

--- a/.cursor/commands/create-plan.md
+++ b/.cursor/commands/create-plan.md
@@ -21,14 +21,16 @@ Create or refine an executable technical implementation plan from the available 
 ## Associated Skills
 - `041-planning-plan-mode`
 - `051-design-two-steps-methods` for every plan so preparatory work, behavior change, and verification remain explicitly sequenced
+- `052-design-hamburger-method` when the requested plan is broad enough to need smallest-useful vertical slices before tasking
 
 ## Workflow
 1. Identify the available source artifacts and their authority.
 2. Resolve material implementation questions without inventing requirements.
 3. Apply the two-step method so the plan orders behavior-preserving preparation, behavior-preservation validation, the intended behavior change, and final verification.
-4. Define the technical approach, affected areas, ordered tasks, risks, and verification.
-5. Record source links and any assumptions or unresolved blockers.
-6. Present the plan for approval.
+4. For broad scope, apply the Hamburger Method to identify the smallest useful vertical slice, defer costly or unnecessary options, and propose follow-up slices.
+5. Define the technical approach, affected areas, ordered tasks, risks, and verification.
+6. Record source links and any assumptions or unresolved blockers.
+7. Present the plan for approval.
 
 ## Output
 - Executable implementation plan

--- a/README.md
+++ b/README.md
@@ -87,10 +87,13 @@ Turn an idea into an actionable change with user stories, GitHub Issues or Jira,
 /create-plan
 @robot-tech-lead
     @041-planning-plan-mode
+    @051-design-two-steps-methods
+    @052-design-hamburger-method
 /create-spec
 @robot-tech-lead
     @042-planning-openspec
     @051-design-two-steps-methods
+    @052-design-hamburger-method
 /explore-design
 @robot-architect
     @034-architecture-design-exploration

--- a/README_ES.md
+++ b/README_ES.md
@@ -84,13 +84,16 @@ Plan
   /create-plan
     @robot-tech-lead
       @041-planning-plan-mode
+      @051-design-two-steps-methods
+      @052-design-hamburger-method
   /create-spec
     @robot-tech-lead
       @042-planning-openspec
+      @051-design-two-steps-methods
+      @052-design-hamburger-method
   /explore-design
     @robot-architect
       @034-architecture-design-exploration
-      @051-design-two-steps-methods
   /review-alignment
     @robot-business-analyst
   /review-breaking-changes

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -84,13 +84,16 @@ Plan
   /create-plan
     @robot-tech-lead
       @041-planning-plan-mode
+      @051-design-two-steps-methods
+      @052-design-hamburger-method
   /create-spec
     @robot-tech-lead
       @042-planning-openspec
+      @051-design-two-steps-methods
+      @052-design-hamburger-method
   /explore-design
     @robot-architect
       @034-architecture-design-exploration
-      @051-design-two-steps-methods
   /review-alignment
     @robot-business-analyst
   /review-breaking-changes

--- a/documentation/openspec/changes/add-hamburger-method-design-skill/design.md
+++ b/documentation/openspec/changes/add-hamburger-method-design-skill/design.md
@@ -1,0 +1,71 @@
+## Context
+
+Issue #874 asks for a new `052-design-hamburger-method` skill that helps agents split large feature ideas into small vertical slices. The requested skill should support planning, OpenSpec/spec refinement, implementation breakdown, and optional tracker issue creation for actionable slices.
+
+The existing `051-design-two-steps-methods` skill provides the closest implementation pattern for a design-method skill: generated from XML sources, registered through `skills.xml`, validated through local skill generation, and covered by Gherkin acceptance tests plus prompt inventory when applicable.
+
+## Decisions
+
+### Skill Identifier
+
+Use `052-design-hamburger-method` for the new Hamburger Method guidance.
+
+This identifier follows the existing `051-design-two-steps-methods` design skill and keeps the new slicing method in the design-method sequence.
+
+### Skill Shape
+
+The skill uses the existing XML source pattern:
+
+- `skills-generator/src/main/resources/skill-indexes/052-skill.xml` defines metadata, title, goal, constraints, triggers, and workflow steps.
+- `skills-generator/src/main/resources/skill-references/052-design-hamburger-method.xml` provides detailed method guidance, examples, output structure, and self-check criteria.
+- `skills-generator/src/main/resources/skills.xml` registers the skill id and reference.
+
+Dedicated report templates are not required for the first version. The initial deliverable is an agent skill that produces slicing analysis and recommendations.
+
+### Hamburger Method Workflow
+
+The skill should guide an agent to:
+
+- Recognize oversized feature, story, plan, or spec work where ordinary story-splitting heuristics are not enough.
+- Identify 3-6 functional or workflow layers that participate in delivering value.
+- Generate 4-5 implementation or quality options per layer, ordered from simplest acceptable option to richer options.
+- Challenge scope with a smallest-useful-version question such as: "If this had to ship tomorrow, what would be the smallest useful version?"
+- Filter choices that are too costly, redundant, irreversible, or unnecessary for early learning.
+- Compose one first vertical slice by selecting one option from each relevant layer.
+- Suggest follow-up vertical slices that incrementally improve quality, automation, robustness, reach, or observability.
+- Verify that each slice remains valuable, small, testable, deliverable, and suitable for issue tracking.
+
+### Tracker and Planning Skill Relationships
+
+The Hamburger Method skill should not create tracker issues directly. When it identifies actionable split candidates, it should ask whether those slices should become tracked work and route issue creation or updates through the appropriate skill:
+
+- Use `043-planning-github-issues` for GitHub issues.
+- Use `044-planning-jira` for Jira issues.
+- Use `041-planning-plan-mode` when slices need to become or update an implementation plan.
+- Use `042-planning-openspec` when a slice introduces a separate spec-level product, workflow, or architectural decision.
+
+Mechanical implementation tasks such as registry updates, acceptance prompt coverage, generated-output inspection, or release validation should remain ordinary task or issue work unless they introduce a separate reviewed capability.
+
+### Two-Step Implementation Sequence
+
+Apply the two-step method to implementation:
+
+1. Make the change easy through behavior-preserving preparation, such as reviewing nearby design skill patterns, confirming available identifier slots, identifying generator registration points, and preparing focused acceptance expectations.
+2. Make the behavior change by adding the `052-design-hamburger-method` XML source, generator registration, acceptance coverage, and generated local validation.
+
+Validation must happen after preparation and again after the behavior-changing additions.
+
+## Validation Strategy
+
+- Validate changed XML files with `xmllint --noout`.
+- Run `./mvnw clean install -pl skills-generator` to regenerate local skills into `.agents/skills` without refreshing public `skills/`.
+- Inspect generated local `.agents/skills/052-design-hamburger-method/SKILL.md`.
+- Add or update `skills-generator/src/test/resources/gherkin/skills/052-design-hamburger-method.feature`.
+- Add `052-design-hamburger-method` to `skills-generator/src/test/resources/gherkin/skills/acceptance-tests-prompts-skills.md`.
+- Execute only the listed `052-design-hamburger-method` acceptance prompt and verify it passes.
+- Run `./mvnw clean verify -pl skills-generator`.
+- Run `openspec validate --all`.
+
+## Open Questions
+
+None for this change. Follow-up tracker issues can be created later if implementation planning identifies independent execution slices.

--- a/documentation/openspec/changes/add-hamburger-method-design-skill/proposal.md
+++ b/documentation/openspec/changes/add-hamburger-method-design-skill/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+GitHub issue [#874](https://github.com/jabrena/cursor-rules-java/issues/874) requests a new `052-design-hamburger-method` skill for applying the Hamburger Method to large features, stories, plans, and OpenSpec changes.
+
+Planning work can become too large when teams split by technical layer rather than by user-visible value. The Hamburger Method gives agents a structured way to identify workflow layers, compare quality options per layer, trim overbuilt choices, and compose small vertical slices that still deliver observable value.
+
+## What Changes
+
+- Add `052-design-hamburger-method` as a generated design skill for vertical story slicing.
+- Guide agents to identify 3-6 functional or workflow layers and 4-5 implementation or quality options per layer.
+- Guide agents to compose a smallest useful end-to-end slice, then suggest follow-up slices that improve quality, automation, robustness, reach, or observability.
+- Add tracker-routing guidance so actionable split candidates can become GitHub or Jira issues through the appropriate planning skills.
+- Register the skill in the generator inventory so local skill generation emits `.agents/skills/052-design-hamburger-method`.
+- Keep generated public `skills/` output out of scope unless a release profile is intentionally run later.
+
+## Capabilities
+
+### New Capabilities
+
+- `hamburger-method-design-skill-reference`: Adds Hamburger Method design skill guidance.
+
+### Modified Capabilities
+
+None.
+
+## Source and Derivation
+
+- Source artifact: GitHub issue [#874](https://github.com/jabrena/cursor-rules-java/issues/874).
+- External source: [Gojko Adzic, "Splitting user stories -- the hamburger method"](https://gojko.net/2012/01/23/splitting-user-stories-the-hamburger-method/).
+- External reference implementation: [skill-factory hamburger-method skill](https://github.com/eferro/skill-factory/tree/main/output_skills/practices/hamburger-method).
+- Existing implementation model: `051-design-two-steps-methods`.
+- Related planning skills: `041-planning-plan-mode`, `042-planning-openspec`, `043-planning-github-issues`, and `044-planning-jira`.
+- Derivation direction: issue #874 plus external Hamburger Method references plus existing design skill pattern -> OpenSpec change artifacts -> XML skill source implementation -> local generated skill validation.
+
+## Change Boundary Assessment
+
+This is one OpenSpec change because the requested outcome is one independently reviewable generated skill. The change may touch several generator files, tests, and prompt inventory entries, but those edits all support the same skill capability.
+
+Additional GitHub or Jira issues may be created later for clear execution slices discovered during planning. Additional OpenSpec changes are only needed if a follow-up slice introduces a separate product, workflow, or architectural decision.
+
+## Impact
+
+XML skill indexes, XML skill references, `skills.xml`, Gherkin skill acceptance tests, acceptance prompt inventory, local generated skill output, and OpenSpec artifacts are affected. Generated `.cursor/rules/`, public `skills/`, and `docs/` must not be edited directly. Public `skills/` should only change through the documented release profile when release output is intentionally in scope.

--- a/documentation/openspec/changes/add-hamburger-method-design-skill/specs/hamburger-method-design-skill-reference/spec.md
+++ b/documentation/openspec/changes/add-hamburger-method-design-skill/specs/hamburger-method-design-skill-reference/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: Hamburger Method design skill
+
+The repository MUST define `052-design-hamburger-method` as a generated design skill for applying the Hamburger Method to vertical story slicing.
+
+#### Scenario: Hamburger Method skill identifier is standardized
+
+- **GIVEN** maintainers implement Hamburger Method guidance in generator sources
+- **WHEN** they create or reference the skill in XML, inventories, OpenSpec artifacts, Gherkin tests, prompt inventories, or generated local skill output
+- **THEN** the identifier is `052-design-hamburger-method`
+- **AND** the supplied external source includes `https://gojko.net/2012/01/23/splitting-user-stories-the-hamburger-method/`
+
+#### Scenario: Hamburger Method guidance creates a first vertical slice
+
+- **GIVEN** a maintainer, tech lead, or agent has a large feature, story, plan, or spec idea
+- **WHEN** the `052-design-hamburger-method` skill is applied
+- **THEN** the skill guides the agent to identify 3-6 functional or workflow layers
+- **AND** it guides the agent to generate 4-5 implementation or quality options per layer
+- **AND** it guides the agent to filter options that are too costly, redundant, irreversible, or unnecessary for early learning
+- **AND** it guides the agent to compose one smallest useful end-to-end vertical slice
+- **AND** it guides the agent to propose follow-up vertical slices that incrementally improve quality, automation, robustness, reach, or observability
+
+#### Scenario: Hamburger Method guidance avoids horizontal task decomposition
+
+- **GIVEN** an agent has identified workflow layers and layer options
+- **WHEN** the agent recommends split work
+- **THEN** the recommendation emphasizes vertical slices that deliver observable value
+- **AND** it does not present isolated technical layers as independently shippable stories
+- **AND** each proposed slice is checked for value, size, testability, deliverability, and issue-tracking suitability
+
+### Requirement: Relationship to planning and tracker skills
+
+The Hamburger Method skill MUST route follow-up planning and tracker work through the existing planning skills.
+
+#### Scenario: Route actionable split candidates to tracker skills
+
+- **GIVEN** the Hamburger Method identifies actionable split candidates
+- **WHEN** the agent determines that those candidates should become tracked work
+- **THEN** the skill asks whether new tracker issues should be created or existing issues should be updated
+- **AND** it routes GitHub-backed work tracking through `043-planning-github-issues`
+- **AND** it routes Jira-backed work tracking through `044-planning-jira`
+
+#### Scenario: Route plan and spec changes through planning skills
+
+- **GIVEN** the Hamburger Method identifies split candidates during planning or OpenSpec work
+- **WHEN** a candidate needs an implementation plan
+- **THEN** the skill routes the work through `041-planning-plan-mode`
+- **AND** when a candidate introduces a separate product, workflow, or architectural decision, it routes the work through `042-planning-openspec`
+- **AND** mechanical implementation tasks remain ordinary task or issue work unless they introduce a separate reviewed capability
+
+### Requirement: Generator registration
+
+The Hamburger Method skill source MUST be registered in the generator inventory so local skill generation emits it.
+
+#### Scenario: Register Hamburger Method design skill
+
+- **WHEN** `skills-generator/src/main/resources/skills.xml` is inspected
+- **THEN** skill id `052` declares explicit skill id `052-design-hamburger-method`
+- **AND** skill id `052` registers reference `052-design-hamburger-method`
+
+#### Scenario: Generate local Hamburger Method skill
+
+- **WHEN** `./mvnw clean install -pl skills-generator` is run
+- **THEN** generated local skill output includes `.agents/skills/052-design-hamburger-method/SKILL.md`
+- **AND** generated references contain no unresolved include markers or broken local reference paths
+
+### Requirement: Acceptance coverage
+
+The Hamburger Method skill MUST include Gherkin acceptance coverage and a matching prompt inventory entry.
+
+#### Scenario: Add acceptance test for Hamburger Method guidance
+
+- **WHEN** `skills-generator/src/test/resources/gherkin/skills/052-design-hamburger-method.feature` is inspected
+- **THEN** it includes an acceptance scenario for splitting a large feature into a smallest useful vertical slice
+- **AND** it includes expectations for follow-up slices and tracker-routing guidance
+- **AND** `skills-generator/src/test/resources/gherkin/skills/acceptance-tests-prompts-skills.md` lists `execute @skills-generator/src/test/resources/gherkin/skills/052-design-hamburger-method.feature`
+
+### Requirement: Source and generated-output boundaries
+
+The implementation MUST edit XML sources and validate generated local skill output without directly editing generated legacy, local generated, or release outputs.
+
+#### Scenario: Preserve generated-output ownership
+
+- **WHEN** implementation files are reviewed
+- **THEN** `.cursor/rules/` is not edited directly
+- **AND** `.agents/skills/` is not edited directly
+- **AND** public `skills/` release output is not edited manually
+- **AND** public `skills/` is refreshed only through the release profile when release output is intentionally in scope

--- a/documentation/openspec/changes/add-hamburger-method-design-skill/tasks.md
+++ b/documentation/openspec/changes/add-hamburger-method-design-skill/tasks.md
@@ -5,19 +5,20 @@
 - [x] 1.1 Review GitHub issue #874 and record source artifacts, derivation direction, scope boundary, and validation expectations.
 - [x] 1.2 Assess the scope as one OpenSpec change for one generated design skill.
 - [x] 1.3 Apply the two-step method by separating behavior-preserving preparation from the behavior-changing skill addition.
-- [ ] 1.4 Step 1 preparation: review nearby design skill sources, especially `051-design-two-steps-methods`, and confirm the `052` identifier is available.
-- [ ] 1.5 Step 1 preparation: inspect generator registration patterns in `skills-generator/src/main/resources/skills.xml` and `skills-generator/src/main/resources/skill-indexes/`.
-- [ ] 1.6 Step 1 validation: confirm no generated output is edited directly and record the existing generator validation commands.
-- [ ] 1.7 Step 2 behavior change: add `skills-generator/src/main/resources/skill-indexes/052-skill.xml`.
-- [ ] 1.8 Step 2 behavior change: add `skills-generator/src/main/resources/skill-references/052-design-hamburger-method.xml`.
-- [ ] 1.9 Step 2 behavior change: register skill id `052` with explicit `skillId="052-design-hamburger-method"` and reference `052-design-hamburger-method` in `skills-generator/src/main/resources/skills.xml`.
-- [ ] 1.10 Step 2 behavior change: include guidance for layers, options per layer, smallest useful slice, option filtering, follow-up slices, and self-check criteria.
-- [ ] 1.11 Step 2 behavior change: include related-skill routing for `041-planning-plan-mode`, `042-planning-openspec`, `043-planning-github-issues`, and `044-planning-jira`.
-- [ ] 1.12 Add `skills-generator/src/test/resources/gherkin/skills/052-design-hamburger-method.feature`.
-- [ ] 1.13 Add `052-design-hamburger-method` to `skills-generator/src/test/resources/gherkin/skills/acceptance-tests-prompts-skills.md`.
-- [ ] 1.14 Validate changed XML files with `xmllint --noout`.
-- [ ] 1.15 Run `./mvnw clean install -pl skills-generator`.
-- [ ] 1.16 Inspect generated local `.agents/skills/052-design-hamburger-method/SKILL.md`.
+- [x] 1.4 Step 1 preparation: review nearby design skill sources, especially `051-design-two-steps-methods`, and confirm the `052` identifier is available.
+- [x] 1.5 Step 1 preparation: inspect generator registration patterns in `skills-generator/src/main/resources/skills.xml` and `skills-generator/src/main/resources/skill-indexes/`.
+- [x] 1.6 Step 1 validation: confirm no generated output is edited directly and record the existing generator validation commands.
+- [x] 1.7 Step 2 behavior change: add `skills-generator/src/main/resources/skill-indexes/052-skill.xml`.
+- [x] 1.8 Step 2 behavior change: add `skills-generator/src/main/resources/skill-references/052-design-hamburger-method.xml`.
+- [x] 1.9 Step 2 behavior change: register skill id `052` with explicit `skillId="052-design-hamburger-method"` and reference `052-design-hamburger-method` in `skills-generator/src/main/resources/skills.xml`.
+- [x] 1.10 Step 2 behavior change: include guidance for layers, options per layer, smallest useful slice, option filtering, follow-up slices, and self-check criteria.
+- [x] 1.11 Step 2 behavior change: include related-skill routing for `041-planning-plan-mode`, `042-planning-openspec`, `043-planning-github-issues`, and `044-planning-jira`.
+- [x] 1.12 Add `skills-generator/src/test/resources/gherkin/skills/052-design-hamburger-method.feature`.
+- [x] 1.13 Add `052-design-hamburger-method` to `skills-generator/src/test/resources/gherkin/skills/acceptance-tests-prompts-skills.md`.
+- [x] 1.14 Validate changed XML files with `xmllint --noout`.
+- [x] 1.15 Run `./mvnw clean install -pl skills-generator`.
+- [x] 1.16 Inspect generated local `.agents/skills/052-design-hamburger-method/SKILL.md`.
 - [ ] 1.17 Execute the listed `052-design-hamburger-method` acceptance prompt and verify it passes.
-- [ ] 1.18 Run `./mvnw clean verify -pl skills-generator`.
-- [ ] 1.19 Run `openspec validate --all`.
+  - Skipped for now: no executable prompt-runner command is available in this checkout for `execute @skills-generator/src/test/resources/gherkin/skills/052-design-hamburger-method.feature`; the generated skill and reference were inspected manually after local regeneration.
+- [x] 1.18 Run `./mvnw clean verify -pl skills-generator`.
+- [x] 1.19 Run `openspec validate --all`.

--- a/documentation/openspec/changes/add-hamburger-method-design-skill/tasks.md
+++ b/documentation/openspec/changes/add-hamburger-method-design-skill/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+## 1. Implementation Checklist
+
+- [x] 1.1 Review GitHub issue #874 and record source artifacts, derivation direction, scope boundary, and validation expectations.
+- [x] 1.2 Assess the scope as one OpenSpec change for one generated design skill.
+- [x] 1.3 Apply the two-step method by separating behavior-preserving preparation from the behavior-changing skill addition.
+- [ ] 1.4 Step 1 preparation: review nearby design skill sources, especially `051-design-two-steps-methods`, and confirm the `052` identifier is available.
+- [ ] 1.5 Step 1 preparation: inspect generator registration patterns in `skills-generator/src/main/resources/skills.xml` and `skills-generator/src/main/resources/skill-indexes/`.
+- [ ] 1.6 Step 1 validation: confirm no generated output is edited directly and record the existing generator validation commands.
+- [ ] 1.7 Step 2 behavior change: add `skills-generator/src/main/resources/skill-indexes/052-skill.xml`.
+- [ ] 1.8 Step 2 behavior change: add `skills-generator/src/main/resources/skill-references/052-design-hamburger-method.xml`.
+- [ ] 1.9 Step 2 behavior change: register skill id `052` with explicit `skillId="052-design-hamburger-method"` and reference `052-design-hamburger-method` in `skills-generator/src/main/resources/skills.xml`.
+- [ ] 1.10 Step 2 behavior change: include guidance for layers, options per layer, smallest useful slice, option filtering, follow-up slices, and self-check criteria.
+- [ ] 1.11 Step 2 behavior change: include related-skill routing for `041-planning-plan-mode`, `042-planning-openspec`, `043-planning-github-issues`, and `044-planning-jira`.
+- [ ] 1.12 Add `skills-generator/src/test/resources/gherkin/skills/052-design-hamburger-method.feature`.
+- [ ] 1.13 Add `052-design-hamburger-method` to `skills-generator/src/test/resources/gherkin/skills/acceptance-tests-prompts-skills.md`.
+- [ ] 1.14 Validate changed XML files with `xmllint --noout`.
+- [ ] 1.15 Run `./mvnw clean install -pl skills-generator`.
+- [ ] 1.16 Inspect generated local `.agents/skills/052-design-hamburger-method/SKILL.md`.
+- [ ] 1.17 Execute the listed `052-design-hamburger-method` acceptance prompt and verify it passes.
+- [ ] 1.18 Run `./mvnw clean verify -pl skills-generator`.
+- [ ] 1.19 Run `openspec validate --all`.

--- a/skills-generator/src/main/resources/skill-indexes/052-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/052-skill.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="https://jabrena.github.io/pml/schemas/0.7.0/pml.xsd"
+      id="052-design-hamburger-method"
+      interactive="true">
+  <metadata>
+    <author>Juan Antonio Breña Moral</author>
+    <version>0.17.0-SNAPSHOT</version>
+    <license>Apache-2.0</license>
+    <description>Use when a large feature, story, plan, or spec idea needs to be split into small vertical slices with the Hamburger Method. This should trigger for requests such as Split this oversized story; Find the smallest useful slice; Break this feature into vertical slices; Apply the Hamburger Method; Turn this broad plan into tracked slices.</description>
+  </metadata>
+
+  <title>Hamburger Method Design</title>
+  <goal><![CDATA[
+Guide Java teams through the Hamburger Method for splitting oversized work into small, valuable, end-to-end vertical slices. **This is an interactive SKILL**.
+
+**What is covered in this Skill?**
+
+- Recognizing oversized feature, story, plan, or spec work
+- Identifying 3-6 functional or workflow layers that participate in delivering value
+- Generating 4-5 implementation or quality options per layer
+- Challenging scope with the smallest useful version question
+- Filtering options that are too costly, redundant, irreversible, or unnecessary for early learning
+- Composing one first vertical slice and follow-up slices
+- Self-checking value, size, testability, deliverability, and issue-tracking suitability
+- Routing plan, OpenSpec, GitHub issue, and Jira follow-up through the existing planning skills
+]]></goal>
+
+  <constraints>
+    <constraints-description>Split oversized work into vertical slices that deliver observable value, not isolated horizontal technical tasks.</constraints-description>
+    <constraint-list>
+      <constraint>**MUST** read `references/052-design-hamburger-method.md` before applying the method</constraint>
+      <constraint>**MUST** identify 3-6 functional or workflow layers before selecting a slice</constraint>
+      <constraint>**MUST** generate 4-5 options per layer, ordered from simplest acceptable option to richer options</constraint>
+      <constraint>**MUST** challenge scope with the smallest-useful-version question before recommending a first slice</constraint>
+      <constraint>**MUST** filter costly, redundant, irreversible, or unnecessary options before composing the first slice</constraint>
+      <constraint>**MUST** keep recommended work as vertical slices that deliver observable value</constraint>
+      <constraint>**MUST NOT** present isolated technical layers as independently shippable stories</constraint>
+    </constraint-list>
+  </constraints>
+
+  <triggers>
+    <trigger-list>
+      <trigger>Apply the Hamburger Method</trigger>
+      <trigger>Split this oversized story</trigger>
+      <trigger>Find the smallest useful slice</trigger>
+      <trigger>Break this feature into vertical slices</trigger>
+      <trigger>Turn this broad plan into tracked slices</trigger>
+      <trigger>This feature is too large</trigger>
+    </trigger-list>
+  </triggers>
+
+  <steps>
+    <step number="1">
+      <step-title>Recognize Oversized Work</step-title>
+      <step-content>Read `references/052-design-hamburger-method.md`, then restate the large feature, story, plan, or spec idea and why ordinary implementation task decomposition would be too broad, risky, or horizontal.</step-content>
+    </step>
+    <step number="2">
+      <step-title>Map Layers and Options</step-title>
+      <step-content>Identify 3-6 functional or workflow layers needed for observable value. For each layer, generate 4-5 implementation or quality options ordered from the simplest acceptable choice to richer choices.</step-content>
+    </step>
+    <step number="3">
+      <step-title>Challenge Scope</step-title>
+      <step-content>Ask: "If this had to ship tomorrow, what would be the smallest useful version?" Use the answer to remove options that are too costly, redundant, irreversible, or unnecessary for early learning.</step-content>
+    </step>
+    <step number="4">
+      <step-title>Compose the First Slice</step-title>
+      <step-content>Select one option from each relevant layer to create the smallest useful end-to-end vertical slice. Explain the user-visible value, validation signal, and why rejected layer options wait for later slices.</step-content>
+    </step>
+    <step number="5">
+      <step-title>Plan Follow-Up Slices</step-title>
+      <step-content>Propose follow-up vertical slices that incrementally improve quality, automation, robustness, reach, observability, operational behavior, or supported workflows without turning them into isolated technical layers.</step-content>
+    </step>
+    <step number="6">
+      <step-title>Self-Check and Route Follow-Up</step-title>
+      <step-content>Check every slice for value, size, testability, deliverability, and issue-tracking suitability. Route implementation planning through `041-planning-plan-mode`, spec-level changes through `042-planning-openspec`, GitHub issue work through `043-planning-github-issues`, and Jira work through `044-planning-jira`.</step-content>
+    </step>
+  </steps>
+</prompt>

--- a/skills-generator/src/main/resources/skill-references/052-design-hamburger-method.xml
+++ b/skills-generator/src/main/resources/skill-references/052-design-hamburger-method.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <metadata>
+        <author>Juan Antonio Breña Moral</author>
+        <version>0.17.0-SNAPSHOT</version>
+        <license>Apache-2.0</license>
+        <title>Hamburger Method Design</title>
+        <description>Use when a large feature, story, plan, or spec idea should be split into small vertical slices that still deliver observable value.</description>
+    </metadata>
+
+    <role>You are a senior Java technical lead who turns broad product, platform, and implementation ideas into small vertical slices without losing user value.</role>
+
+    <tone>Be concrete, skeptical of excess scope, and helpful. Keep the user oriented around value, learning, testability, and the next deliverable slice.</tone>
+
+    <goal>
+        Apply the Hamburger Method to split oversized work into the smallest useful end-to-end vertical slice, then propose follow-up vertical slices. External reference supplied for this method is https://gojko.net/2012/01/23/splitting-user-stories-the-hamburger-method/.
+    </goal>
+
+    <steps>
+        <step number="1">
+            <step-title>Recognize Oversized Work</step-title>
+            <step-content><![CDATA[
+Start by deciding whether the Hamburger Method is needed. Use it when the request is a large feature, story, plan, OpenSpec change, modernization, workflow, integration, or reporting capability where a flat task list would hide risk or produce horizontal work.
+
+Signals that work is oversized:
+
+- It touches several user workflow steps, APIs, jobs, persistence paths, messages, external systems, or operational concerns
+- The first useful release is unclear
+- The proposed work is mostly a list of technical layers such as "database", "backend", "frontend", and "tests"
+- The story could not be reviewed, tested, or shipped in a short cycle
+- The team is debating too many nice-to-have quality or automation choices before learning from a first version
+
+Restate the desired outcome and name the risk of horizontal decomposition before proposing slices.
+            ]]></step-content>
+            <step-constraints>
+                <step-constraint-list>
+                    <step-constraint>**MUST** preserve the user's stated outcome and authoritative project artifacts</step-constraint>
+                    <step-constraint>**MUST** call out when a proposed split is only a technical layer and not independently valuable</step-constraint>
+                    <step-constraint>**MUST NOT** invent product requirements to make a slice look useful</step-constraint>
+                </step-constraint-list>
+            </step-constraints>
+        </step>
+
+        <step number="2">
+            <step-title>Identify Layers</step-title>
+            <step-content><![CDATA[
+Identify 3-6 functional or workflow layers that participate in delivering value. A layer can be a user decision point, UI/API surface, business rule, data lifecycle step, integration, operational concern, test approach, or rollout path.
+
+Prefer layers that describe the value stream rather than the organization chart of the code. Useful layer examples:
+
+- User entry point or trigger
+- API, command, scheduled job, message, or workflow surface
+- Decision rule, validation policy, transformation, or orchestration
+- Data read/write, migration, search, or reporting path
+- Integration, notification, export, import, or downstream event
+- Quality, observability, security, rollout, or recovery concern
+
+Avoid layer names that already imply a horizontal story, such as "build all persistence", "write all unit tests", or "create the entire UI". Technical layers may appear in the map, but a shippable slice must choose across layers.
+            ]]></step-content>
+            <step-constraints>
+                <step-constraint-list>
+                    <step-constraint>**MUST** identify 3-6 layers before options are selected</step-constraint>
+                    <step-constraint>**MUST** explain how each layer participates in observable value</step-constraint>
+                    <step-constraint>**MUST NOT** treat one layer as a complete independently shippable story</step-constraint>
+                </step-constraint-list>
+            </step-constraints>
+        </step>
+
+        <step number="3">
+            <step-title>Generate Layer Options</step-title>
+            <step-content><![CDATA[
+For each layer, generate 4-5 options ordered from the simplest acceptable option to richer choices. The options should make trade-offs visible, not create a backlog of everything the system could eventually do.
+
+A good option set usually includes:
+
+- A manual, narrow, stubbed, read-only, or one-case option that can still teach the team something
+- A focused automated option that covers the first valuable path
+- A broader workflow option that covers more cases or users
+- A robustness, observability, security, or operational hardening option
+- A future richer option only when the domain genuinely needs it
+
+Name the cost, reversibility, test signal, and value of each option in short phrases. This gives the team ingredients for slices instead of a premature design commitment.
+            ]]></step-content>
+            <step-constraints>
+                <step-constraint-list>
+                    <step-constraint>**MUST** produce 4-5 options for each layer</step-constraint>
+                    <step-constraint>**MUST** order options from simplest acceptable to richer or more robust</step-constraint>
+                    <step-constraint>**MUST** include quality options only when they can support a useful slice or later slice</step-constraint>
+                </step-constraint-list>
+            </step-constraints>
+        </step>
+
+        <step number="4">
+            <step-title>Challenge Scope and Filter Options</step-title>
+            <step-content><![CDATA[
+Before composing the first slice, ask the smallest-useful-version question:
+
+"If this had to ship tomorrow, what would be the smallest useful version?"
+
+Use the answer to filter the option list. Remove or defer options that are:
+
+- Too costly for the first learning step
+- Redundant with a simpler option that provides the same signal
+- Irreversible when a reversible experiment would work
+- Unnecessary for early learning or first user value
+- Mostly internal cleanup unless it is required to make the first slice deliverable
+
+Filtering is not deletion from the product vision. It is a decision about what must be true in the first vertical slice versus what can wait for follow-up slices.
+            ]]></step-content>
+            <step-constraints>
+                <step-constraint-list>
+                    <step-constraint>**MUST** ask or answer the smallest-useful-version question before recommending the first slice</step-constraint>
+                    <step-constraint>**MUST** explicitly defer costly, redundant, irreversible, or unnecessary options</step-constraint>
+                    <step-constraint>**MUST NOT** keep options merely because they are conventional parts of a full implementation</step-constraint>
+                </step-constraint-list>
+            </step-constraints>
+        </step>
+
+        <step number="5">
+            <step-title>Compose the First Vertical Slice</step-title>
+            <step-content><![CDATA[
+Compose one first vertical slice by selecting one option from each relevant layer. The slice should be end-to-end enough to produce observable value or validated learning, even if it is narrow, manual in places, or supports only one happy-path case.
+
+Describe the first slice with:
+
+- Slice name
+- User or stakeholder value
+- Selected option from each relevant layer
+- Explicit exclusions and why they wait
+- Acceptance signal or test strategy
+- Delivery notes and dependencies
+
+The first slice should not be "build the database", "create the API", "write tests", or "set up infrastructure" unless that work alone produces an observable product, operational, or learning outcome. If a technical enabler is required, include the smallest amount needed inside the vertical slice.
+            ]]></step-content>
+            <step-constraints>
+                <step-constraint-list>
+                    <step-constraint>**MUST** select across relevant layers to form one vertical slice</step-constraint>
+                    <step-constraint>**MUST** make the first slice valuable, small, testable, and deliverable</step-constraint>
+                    <step-constraint>**MUST NOT** recommend isolated horizontal technical tasks as independently shippable stories</step-constraint>
+                </step-constraint-list>
+            </step-constraints>
+        </step>
+
+        <step number="6">
+            <step-title>Propose Follow-Up Slices</step-title>
+            <step-content><![CDATA[
+After the first slice, propose follow-up vertical slices that incrementally improve the capability. Good follow-up slices often add:
+
+- Another user role, workflow branch, data case, integration, or input source
+- Stronger automation after a manual or narrow first version
+- Better validation, error handling, recovery, security, or compliance behavior
+- Observability, alerting, auditability, performance, or operational controls
+- Broader reach such as more tenants, locales, environments, APIs, or UI paths
+
+Each follow-up slice must still cross the layers needed to deliver value. Do not split follow-ups as "all tests", "all observability", or "all UI" unless the work itself is the product capability being delivered.
+            ]]></step-content>
+        </step>
+
+        <step number="7">
+            <step-title>Self-Check Slices</step-title>
+            <step-content><![CDATA[
+Check each recommended slice before handing it off:
+
+- Value: Does someone get observable value or validated learning?
+- Size: Is the slice small enough for a short delivery cycle?
+- Testability: Can the team verify it with focused automated or manual checks?
+- Deliverability: Are dependencies, data, environments, and review boundaries realistic?
+- Issue-tracking suitability: Is the slice clear enough to become a tracked issue, task, or plan item?
+- Verticality: Does it cross the necessary layers instead of stopping at one technical layer?
+
+If a slice fails the check, narrow it, combine the necessary minimum from another layer, or move it to a later slice.
+            ]]></step-content>
+        </step>
+
+        <step number="8">
+            <step-title>Route Planning and Tracker Follow-Up</step-title>
+            <step-content><![CDATA[
+The Hamburger Method shapes work; it does not create tracker issues directly. When slices are actionable, ask whether they should become tracked work or update existing tracked work.
+
+Route follow-up through the existing planning skills:
+
+- Use `041-planning-plan-mode` when slices need to become or update an implementation plan
+- Use `042-planning-openspec` when a slice introduces a separate product, workflow, or architectural decision
+- Use `043-planning-github-issues` for GitHub-backed issue creation or updates
+- Use `044-planning-jira` for Jira-backed issue creation or updates
+
+Mechanical implementation tasks such as registry updates, acceptance prompt coverage, generated-output inspection, or release validation remain ordinary task or issue work unless they introduce a separate reviewed capability.
+            ]]></step-content>
+            <step-constraints>
+                <step-constraint-list>
+                    <step-constraint>**MUST** ask before creating or updating tracker work</step-constraint>
+                    <step-constraint>**MUST** route GitHub and Jira tracking through the dedicated tracker skills</step-constraint>
+                    <step-constraint>**MUST** route plan and OpenSpec changes through the dedicated planning skills</step-constraint>
+                </step-constraint-list>
+            </step-constraints>
+        </step>
+    </steps>
+
+    <output-format>
+        <output-format-list>
+            <output-format-item>State why the work is oversized and name the desired outcome</output-format-item>
+            <output-format-item>List 3-6 layers and 4-5 ordered options per layer</output-format-item>
+            <output-format-item>Answer the smallest-useful-version question and summarize filtered options</output-format-item>
+            <output-format-item>Recommend one first vertical slice with selected layer options, exclusions, and verification</output-format-item>
+            <output-format-item>Propose follow-up vertical slices that incrementally improve quality, automation, robustness, reach, or observability</output-format-item>
+            <output-format-item>Self-check every slice for value, size, testability, deliverability, issue-tracking suitability, and verticality</output-format-item>
+            <output-format-item>Route plan, OpenSpec, GitHub issue, or Jira follow-up through the appropriate planning skill</output-format-item>
+        </output-format-list>
+    </output-format>
+
+    <safeguards>
+        <safeguards-list>
+            <safeguards-item>Do not turn layers into separate shippable stories when they lack observable value alone</safeguards-item>
+            <safeguards-item>Do not recommend the richest option in every layer for the first slice</safeguards-item>
+            <safeguards-item>Do not skip the smallest-useful-version challenge before composing the first slice</safeguards-item>
+            <safeguards-item>Do not hide irreversible or expensive decisions inside an early learning slice when a reversible option is available</safeguards-item>
+            <safeguards-item>Do not create or update tracker issues directly; route that work through the appropriate planning skill after asking the user</safeguards-item>
+        </safeguards-list>
+    </safeguards>
+</prompt>

--- a/skills-generator/src/main/resources/skill-references/assets/agents/robot-tech-lead.md
+++ b/skills-generator/src/main/resources/skill-references/assets/agents/robot-tech-lead.md
@@ -17,7 +17,9 @@ You are a **Tech Lead** for Java Enterprise Development. Your primary responsibi
 - Translate an issue, approved design, ADR set, OpenSpec change, or valid combination of these sources into executable technical work.
 - Create and refine an implementation plan using `@041-planning-plan-mode`.
 - Use `@051-design-two-steps-methods` for every plan so tasks separate behavior-preserving preparation, validation that behavior stayed unchanged, the intended behavior change, and final verification.
+- Use `@052-design-hamburger-method` when a plan request is broad enough to need smallest-useful vertical slices before tasking.
 - Define approach, affected files, dependencies, risks, verification, milestones, and parallel groups.
+- For broad plan scope, identify the first vertical slice, defer costly or unnecessary options, and propose follow-up slices that remain valuable, testable, deliverable, and suitable for issue tracking.
 - Record source artifacts and unresolved decisions so the plan does not silently override requirements or ADRs.
 - A plan may be created directly from an issue; OpenSpec is not a mandatory prerequisite.
 
@@ -25,8 +27,10 @@ You are a **Tech Lead** for Java Enterprise Development. Your primary responsibi
 
 - Create or update an OpenSpec change using `@042-planning-openspec`.
 - Use `@051-design-two-steps-methods` for every OpenSpec change so proposal, design, specs, and tasks preserve the two-step sequence.
+- Use `@052-design-hamburger-method` when an OpenSpec request is broad enough to need smallest-useful vertical slices before tasking.
 - Accept an issue, approved design, ADRs, implementation plan, existing OpenSpec artifacts, or a valid combination as input.
 - Assess whether the scope fits one reviewable change; propose multiple changes and dependencies when outcomes have distinct release, ownership, risk, or deployment boundaries.
+- For broad scope, identify the first vertical slice, defer costly or unnecessary options, and propose follow-up slices that remain valuable, testable, deliverable, and suitable for issue tracking.
 - Record derivation direction and source artifacts. Never silently synchronize a source artifact from a derived artifact.
 - OpenSpec may be created directly from an issue; an implementation plan is not a mandatory prerequisite.
 
@@ -45,6 +49,7 @@ You are a **Tech Lead** for Java Enterprise Development. Your primary responsibi
 - **[@robot-java-micronaut-coder](robot-java-micronaut-coder.md):** Micronaut implementation (`@Controller`, validation, security, programmatic JDBC, Micronaut Data, Flyway migrations, Kafka messaging, MongoDB, `Micronaut.run`, CDI-style beans, Micronaut tests — `@501`–`@515`, `@521`–`@523`). Use when **Framework identification** yields **Micronaut** as the application framework.
 - **[@robot-no-java](robot-no-java.md):** Default implementation for non-Java work. Use when the issue, plan, or OpenSpec task list names a non-Java stack or has no Java, Maven, or JVM implementation scope.
 - **Two-step change shaping:** Use `@051-design-two-steps-methods` during every plan or OpenSpec creation so preparatory work is validated before behavior-changing work begins.
+- **Hamburger Method vertical slicing:** Use `@052-design-hamburger-method` during broad plan or OpenSpec creation so the first slice is the smallest useful vertical slice and follow-up slices remain independently valuable.
 - **Shared implementation routing:** In coder handoffs, prefer `@143` for expected domain failures and reserve `@126` for exceptional/system boundaries. Apply design guidance in the order `@121` → `@122` → `@123`, with `@142` inside those boundaries. Include `@124` for general secure coding, prefer framework JDBC plus `@704` for relational persistence, use `@705` for MongoDB modeling, and use `@701` for OpenAPI contracts when those concerns are in scope.
 - **Parallel column drives grouping:** The plan's task list table includes a **Parallel** column (or **Agent** if the plan uses that name). Treat each **distinct value** in that column as a **delegation group** identifier (e.g. `A1`, `A2`, `A3-timeout`, `A3-retry`, `A4`).
 - **One logical developer per group:** For each distinct **Parallel** value, assign a **separate** instance of the **same** chosen implementation agent (`robot-java-coder`, `robot-java-spring-boot-coder`, `robot-java-quarkus-coder`, `robot-java-micronaut-coder`, or `robot-no-java`) whose scope is **only** the rows for that value. Label every handoff, e.g. `Developer (Parallel=A3-timeout): tasks 12-16 only; verify milestone before A3-retry starts.`

--- a/skills-generator/src/main/resources/skill-references/assets/commands/create-plan.md
+++ b/skills-generator/src/main/resources/skill-references/assets/commands/create-plan.md
@@ -21,14 +21,16 @@ Create or refine an executable technical implementation plan from the available 
 ## Associated Skills
 - `041-planning-plan-mode`
 - `051-design-two-steps-methods` for every plan so preparatory work, behavior change, and verification remain explicitly sequenced
+- `052-design-hamburger-method` when the requested plan is broad enough to need smallest-useful vertical slices before tasking
 
 ## Workflow
 1. Identify the available source artifacts and their authority.
 2. Resolve material implementation questions without inventing requirements.
 3. Apply the two-step method so the plan orders behavior-preserving preparation, behavior-preservation validation, the intended behavior change, and final verification.
-4. Define the technical approach, affected areas, ordered tasks, risks, and verification.
-5. Record source links and any assumptions or unresolved blockers.
-6. Present the plan for approval.
+4. For broad scope, apply the Hamburger Method to identify the smallest useful vertical slice, defer costly or unnecessary options, and propose follow-up slices.
+5. Define the technical approach, affected areas, ordered tasks, risks, and verification.
+6. Record source links and any assumptions or unresolved blockers.
+7. Present the plan for approval.
 
 ## Output
 - Executable implementation plan

--- a/skills-generator/src/main/resources/skill-references/assets/commands/create-spec.md
+++ b/skills-generator/src/main/resources/skill-references/assets/commands/create-spec.md
@@ -21,15 +21,17 @@ Create or update one or more OpenSpec changes from the available issue, design, 
 ## Associated Skills
 - `042-planning-openspec`
 - `051-design-two-steps-methods` for every OpenSpec change so preparatory work, behavior change, and verification remain explicitly sequenced
+- `052-design-hamburger-method` when the requested spec is broad enough to need smallest-useful vertical slices before tasking
 
 ## Workflow
 1. Identify the available source artifacts and their authority.
 2. Assess whether the scope fits one reviewable change.
 3. Apply the two-step method so OpenSpec separates behavior-preserving preparation from behavior-changing work and validates each step.
-4. For broad scope, propose independently valuable changes and dependencies for approval.
-5. Create or update the approved OpenSpec proposal, design, specifications, and tasks.
-6. Record derivation direction, source links, and unresolved questions.
-7. Validate the resulting OpenSpec changes.
+4. For broad scope, apply the Hamburger Method to identify the smallest useful vertical slice, defer costly or unnecessary options, and propose follow-up slices.
+5. Propose independently valuable changes and dependencies for approval when slicing reveals separate review, release, ownership, risk, or deployment boundaries.
+6. Create or update the approved OpenSpec proposal, design, specifications, and tasks.
+7. Record derivation direction, source links, and unresolved questions.
+8. Validate the resulting OpenSpec changes.
 
 ## Output
 - One OpenSpec change, or an approved map of multiple changes

--- a/skills-generator/src/main/resources/skills.xml
+++ b/skills-generator/src/main/resources/skills.xml
@@ -96,6 +96,11 @@
             <reference>051-design-two-steps-methods</reference>
         </reference-list>
     </skill>
+    <skill id="052" skillId="052-design-hamburger-method">
+        <reference-list>
+            <reference>052-design-hamburger-method</reference>
+        </reference-list>
+    </skill>
     <skill id="110">
         <reference-list>
             <reference>110-java-maven-best-practices</reference>

--- a/skills-generator/src/test/resources/gherkin/skills/052-design-hamburger-method.feature
+++ b/skills-generator/src/test/resources/gherkin/skills/052-design-hamburger-method.feature
@@ -1,0 +1,25 @@
+Feature: Validate changes from usage of hamburger method design skill
+
+Background:
+  Given the skill "052-design-hamburger-method"
+
+@acceptance-test
+Scenario: Split a large feature into a smallest useful vertical slice
+  Given the user request is "Apply the Hamburger Method to split a large customer health reporting feature into tracked vertical slices"
+  And the local generated skill path ".agents/skills/052-design-hamburger-method"
+  When the skill ".agents/skills/052-design-hamburger-method" is applied to the large feature request
+  Then the skill reads "references/052-design-hamburger-method.md"
+  And the analysis recognizes the request as oversized feature, story, plan, or spec work
+  And the analysis identifies 3-6 functional or workflow layers that participate in delivering value
+  And each layer includes 4-5 implementation or quality options ordered from simplest acceptable option to richer options
+  And the analysis asks or answers "If this had to ship tomorrow, what would be the smallest useful version?"
+  And the analysis filters options that are too costly, redundant, irreversible, or unnecessary for early learning
+  And the recommendation composes one smallest useful end-to-end vertical slice by selecting one option from each relevant layer
+  And the recommendation does not present isolated technical layers as independently shippable stories
+  And the recommendation proposes follow-up vertical slices that incrementally improve quality, automation, robustness, reach, or observability
+  And each proposed slice is checked for value, size, testability, deliverability, and issue-tracking suitability
+  And the skill asks whether actionable split candidates should become tracked work or update existing tracked work
+  And the skill routes implementation planning through "041-planning-plan-mode"
+  And the skill routes separate spec-level product, workflow, or architectural decisions through "042-planning-openspec"
+  And the skill routes GitHub-backed issue tracking through "043-planning-github-issues"
+  And the skill routes Jira-backed issue tracking through "044-planning-jira"

--- a/skills-generator/src/test/resources/gherkin/skills/acceptance-tests-prompts-skills.md
+++ b/skills-generator/src/test/resources/gherkin/skills/acceptance-tests-prompts-skills.md
@@ -78,6 +78,13 @@ execute @skills-generator/src/test/resources/gherkin/skills/051-design-two-steps
 and verify that acceptance-tests passes.
 ```
 
+## 052-design-hamburger-method
+
+```bash
+execute @skills-generator/src/test/resources/gherkin/skills/052-design-hamburger-method.feature
+and verify that acceptance-tests passes.
+```
+
 ## 110-java-maven-best-practices
 
 ```bash


### PR DESCRIPTION
## Summary

- Add OpenSpec change for GitHub issue #874 and the new `052-design-hamburger-method` skill.
- Define proposal, design decisions, requirements, and implementation tasks for Hamburger Method vertical slicing guidance.
- Include tracker-routing expectations for GitHub/Jira and planning/OpenSpec related skills.

## Validation

- `openspec validate --all` -> 24 passed, 0 failed

Closes #874
