### PR TITLE
docs(project): replace repository references with plinth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,10 +226,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added tone support for interactive prompts.
 
 - **Website**:
-  - Added a website covering system prompts for Java: https://jabrena.github.io/cursor-rules-java/
+  - Added a website covering system prompts for Java: [jabrena/plinth](https://github.com/jabrena/plinth)
 
 - **Educational content**:
-  - New "System Prompts for Java" course (#335). https://jabrena.github.io/cursor-rules-java/courses/system-prompts-java/index.html
+  - New "System Prompts for Java" course (#335). [jabrena/plinth](https://github.com/jabrena/plinth)
 
 - **Documentation & Diagrams**:
   - ADR-003 documenting JBake website generation strategy (#326).
@@ -267,7 +267,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - JMH (Java Microbenchmark Harness) support for Maven projects without modules
   - Enhanced Maven plugins cursor rule with comprehensive JMH integration
 
-- Tested the project for Cursor, Cursor CLI, Claude Code, GitHub Copilot, and JetBrains Junie. Further information: https://github.com/jabrena/cursor-rules-java/blob/main/docs/reviews/review-20250829.md
+- Tested the project for Cursor, Cursor CLI, Claude Code, GitHub Copilot, and JetBrains Junie. Further information: https://github.com/jabrena/plinth/blob/main/docs/reviews/review-20250829.md
 
 ### Changed
 
@@ -474,18 +474,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added initial cursor rules (Java, Effective Java, Concurrency, Functional programming, Data-Oriented programming & Spring Boot)
 
-[0.15.0]: https://github.com/jabrena/cursor-rules-java/compare/0.14.0...0.15.0
-[0.14.0]: https://github.com/jabrena/cursor-rules-java/compare/0.13.0...0.14.0
-[0.13.0]: https://github.com/jabrena/cursor-rules-java/compare/0.12.0...0.13.0
-[0.12.0]: https://github.com/jabrena/cursor-rules-java/compare/0.11.0...0.12.0
-[0.11.0]: https://github.com/jabrena/cursor-rules-java/compare/0.10.0...0.11.0
-[0.10.0]: https://github.com/jabrena/cursor-rules-java/compare/0.9.0...0.10.0
-[0.9.0]: https://github.com/jabrena/cursor-rules-java/compare/0.8.0...0.9.0
-[0.8.0]: https://github.com/jabrena/cursor-rules-java/compare/0.7.0...0.8.0
-[0.7.0]: https://github.com/jabrena/cursor-rules-java/compare/0.6.0...0.7.0
-[0.6.0]: https://github.com/jabrena/cursor-rules-java/compare/0.5.0...0.6.0
-[0.5.0]: https://github.com/jabrena/cursor-rules-java/compare/0.4.0...0.5.0
-[0.4.0]: https://github.com/jabrena/cursor-rules-java/compare/0.3.0...0.4.0
-[0.3.0]: https://github.com/jabrena/cursor-rules-java/compare/0.2.0...0.3.0
-[0.2.0]: https://github.com/jabrena/cursor-rules-java/compare/0.1.0...0.2.0
-[0.1.0]: https://github.com/jabrena/cursor-rules-java/releases/tag/0.1.0
+[0.15.0]: https://github.com/jabrena/plinth/compare/0.14.0...0.15.0
+[0.14.0]: https://github.com/jabrena/plinth/compare/0.13.0...0.14.0
+[0.13.0]: https://github.com/jabrena/plinth/compare/0.12.0...0.13.0
+[0.12.0]: https://github.com/jabrena/plinth/compare/0.11.0...0.12.0
+[0.11.0]: https://github.com/jabrena/plinth/compare/0.10.0...0.11.0
+[0.10.0]: https://github.com/jabrena/plinth/compare/0.9.0...0.10.0
+[0.9.0]: https://github.com/jabrena/plinth/compare/0.8.0...0.9.0
+[0.8.0]: https://github.com/jabrena/plinth/compare/0.7.0...0.8.0
+[0.7.0]: https://github.com/jabrena/plinth/compare/0.6.0...0.7.0
+[0.6.0]: https://github.com/jabrena/plinth/compare/0.5.0...0.6.0
+[0.5.0]: https://github.com/jabrena/plinth/compare/0.4.0...0.5.0
+[0.4.0]: https://github.com/jabrena/plinth/compare/0.3.0...0.4.0
+[0.3.0]: https://github.com/jabrena/plinth/compare/0.2.0...0.3.0
+[0.2.0]: https://github.com/jabrena/plinth/compare/0.1.0...0.2.0
+[0.1.0]: https://github.com/jabrena/plinth/releases/tag/0.1.0

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ An opinionated AI-native workflow for evolving modern Java Enterprise `SDLC` pra
 
 ## Latest Updates
 
-Explore the latest published content on the [project website](https://jabrena.github.io/cursor-rules-java/) and follow its evolution through new skills, improvements, and fixes in the [CHANGELOG](./CHANGELOG.md).
+Explore the latest published content on [jabrena/plinth](https://github.com/jabrena/plinth) and follow its evolution through new skills, improvements, and fixes in the [CHANGELOG](./CHANGELOG.md).
 
 ## Start in 60 seconds
 
@@ -34,16 +34,16 @@ Install every skill for your preferred agent:
 
 ```bash
 # Cursor
-npx skills add jabrena/cursor-rules-java --skill '*' --agent cursor -y
+npx skills add jabrena/plinth --skill '*' --agent cursor -y
 
 # Claude Code
-npx skills add jabrena/cursor-rules-java --skill '*' --agent claude-code -y
+npx skills add jabrena/plinth --skill '*' --agent claude-code -y
 
 # Codex
-npx skills add jabrena/cursor-rules-java --skill '*' --agent codex -y
+npx skills add jabrena/plinth --skill '*' --agent codex -y
 
 # GitHub Copilot
-npx skills add jabrena/cursor-rules-java --skill '*' --agent github-copilot -y
+npx skills add jabrena/plinth --skill '*' --agent github-copilot -y
 ```
 
 ### See it in action
@@ -189,7 +189,7 @@ The project generates a set of deliverables at the end of any iteration.
 | --------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | 1. [Commands](./documentation/guides/INVENTORY-COMMANDS-JAVA.md) | `@004-commands-installation` Install Commands in project | [`Commands`](./documentation/guides/COMMANDS.md) |
 | 2. [Agents](./documentation/guides/INVENTORY-AGENTS-JAVA.md) | `@005-agents-installation` Install Agents in Cursor/Claude | [`Agents`](./documentation/guides/GETTING-STARTED-AGENTS.md)     |
-| 3. [Skills](./documentation/guides/INVENTORY-SKILLS-JAVA.md) | `npx skills add jabrena/cursor-rules-java --skill '*' --agent cursor -y` | [`Skills`](./documentation/guides/GETTING-STARTED-SKILLS.md)     |
+| 3. [Skills](./documentation/guides/INVENTORY-SKILLS-JAVA.md) | `npx skills add jabrena/plinth --skill '*' --agent cursor -y` | [`Skills`](./documentation/guides/GETTING-STARTED-SKILLS.md)     |
 
 ### Compatibility
 
@@ -233,7 +233,7 @@ Use caution when a problem involves corporate databases or other sensitive organ
 
 - Follow the [5-minute guide](./documentation/guides/GETTING-STARTED-IN-5-MINUTES.md) and tell us where the experience can improve.
 - [Browse the skill inventory](./documentation/guides/INVENTORY-SKILLS-JAVA.md) and propose a missing Java workflow.
-- [Open an issue](https://github.com/jabrena/cursor-rules-java/issues) to report a problem or suggest an enhancement.
+- [Open an issue](https://github.com/jabrena/plinth/issues) to report a problem or suggest an enhancement.
 - Read [CONTRIBUTING.md](./CONTRIBUTING.md) to improve a skill, agent, command, or project guide.
 - Star the repository if these workflows help your Java projects.
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -26,7 +26,7 @@ Un flujo de trabajo nativo de IA, con criterio propio, para evolucionar las prá
 
 ## Últimas actualizaciones
 
-Explora el contenido publicado más reciente en el [sitio web del proyecto](https://jabrena.github.io/cursor-rules-java/) y sigue su evolución mediante nuevos skills, mejoras y correcciones en el [CHANGELOG](./CHANGELOG.md).
+Explora el contenido publicado más reciente en [jabrena/plinth](https://github.com/jabrena/plinth) y sigue su evolución mediante nuevos skills, mejoras y correcciones en el [CHANGELOG](./CHANGELOG.md).
 
 ## Empieza en 60 segundos
 
@@ -34,16 +34,16 @@ Instala todos los skills para tu agente preferido:
 
 ```bash
 # Cursor
-npx skills add jabrena/cursor-rules-java --skill '*' --agent cursor -y
+npx skills add jabrena/plinth --skill '*' --agent cursor -y
 
 # Claude Code
-npx skills add jabrena/cursor-rules-java --skill '*' --agent claude-code -y
+npx skills add jabrena/plinth --skill '*' --agent claude-code -y
 
 # Codex
-npx skills add jabrena/cursor-rules-java --skill '*' --agent codex -y
+npx skills add jabrena/plinth --skill '*' --agent codex -y
 
 # GitHub Copilot
-npx skills add jabrena/cursor-rules-java --skill '*' --agent github-copilot -y
+npx skills add jabrena/plinth --skill '*' --agent github-copilot -y
 ```
 
 ### Míralo en acción
@@ -148,7 +148,7 @@ Convierte una idea en un cambio accionable mediante user stories, GitHub Issues 
 | --- | --- |
 | **Commands** | [`/update-issue`](./.cursor/commands/update-issue.md) · `/explore-design` · `/create-adr` · `/create-diagram` · `/create-spec` · `/review-alignment` |
 | **Agents** | `@robot-business-analyst` · `@robot-architect` · `@robot-tech-lead` |
-| **Skills** | [014-agile-user-story](https://www.skills.sh/jabrena/cursor-rules-java/014-agile-user-story) · [030-architecture-adr-general](https://www.skills.sh/jabrena/cursor-rules-java/030-architecture-adr-general) · [031-architecture-adr-functional-requirements](https://www.skills.sh/jabrena/cursor-rules-java/031-architecture-adr-functional-requirements) · [032-architecture-adr-non-functional-requirements](https://www.skills.sh/jabrena/cursor-rules-java/032-architecture-adr-non-functional-requirements) · [033-architecture-diagrams](https://www.skills.sh/jabrena/cursor-rules-java/033-architecture-diagrams) · [034-architecture-design-exploration](https://www.skills.sh/jabrena/cursor-rules-java/034-architecture-design-exploration) · [041-planning-plan-mode](https://www.skills.sh/jabrena/cursor-rules-java/041-planning-plan-mode) · [042-planning-openspec](https://www.skills.sh/jabrena/cursor-rules-java/042-planning-openspec) · [043-planning-github-issues](https://www.skills.sh/jabrena/cursor-rules-java/043-planning-github-issues) · [044-planning-jira](https://www.skills.sh/jabrena/cursor-rules-java/044-planning-jira) · [051-design-two-steps-methods](https://www.skills.sh/jabrena/cursor-rules-java/051-design-two-steps-methods) · [052-design-hamburger-method](https://www.skills.sh/jabrena/cursor-rules-java/052-design-hamburger-method) · [053-design-simple-rules](https://www.skills.sh/jabrena/cursor-rules-java/053-design-simple-rules) · [056-design-avoid-breaking-changes](https://www.skills.sh/jabrena/cursor-rules-java/056-design-avoid-breaking-changes) · [200-agents-md](https://www.skills.sh/jabrena/cursor-rules-java/200-agents-md) |
+| **Skills** | [014-agile-user-story](https://www.skills.sh/jabrena/plinth/014-agile-user-story) · [030-architecture-adr-general](https://www.skills.sh/jabrena/plinth/030-architecture-adr-general) · [031-architecture-adr-functional-requirements](https://www.skills.sh/jabrena/plinth/031-architecture-adr-functional-requirements) · [032-architecture-adr-non-functional-requirements](https://www.skills.sh/jabrena/plinth/032-architecture-adr-non-functional-requirements) · [033-architecture-diagrams](https://www.skills.sh/jabrena/plinth/033-architecture-diagrams) · [034-architecture-design-exploration](https://www.skills.sh/jabrena/plinth/034-architecture-design-exploration) · [041-planning-plan-mode](https://www.skills.sh/jabrena/plinth/041-planning-plan-mode) · [042-planning-openspec](https://www.skills.sh/jabrena/plinth/042-planning-openspec) · [043-planning-github-issues](https://www.skills.sh/jabrena/plinth/043-planning-github-issues) · [044-planning-jira](https://www.skills.sh/jabrena/plinth/044-planning-jira) · [051-design-two-steps-methods](https://www.skills.sh/jabrena/plinth/051-design-two-steps-methods) · [052-design-hamburger-method](https://www.skills.sh/jabrena/plinth/052-design-hamburger-method) · [053-design-simple-rules](https://www.skills.sh/jabrena/plinth/053-design-simple-rules) · [056-design-avoid-breaking-changes](https://www.skills.sh/jabrena/plinth/056-design-avoid-breaking-changes) · [200-agents-md](https://www.skills.sh/jabrena/plinth/200-agents-md) |
 | **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) |
 
 ### Construir
@@ -159,7 +159,7 @@ Implementa y mejora aplicaciones Java con orientación sobre Maven, diseño, pro
 | --- | --- |
 | **Commands** | [`/create-feature-branch`](./.cursor/commands/create-feature-branch.md) · [`/create-worktree`](./.cursor/commands/create-worktree.md) · [`/implement-issue`](./.cursor/commands/implement-issue.md) |
 | **Agents** | `@robot-tech-lead` · `@robot-no-java` · `@robot-java-coder` · `@robot-java-spring-boot-coder` · `@robot-java-quarkus-coder` · `@robot-java-micronaut-coder` |
-| **Skills** | [110-java-maven-best-practices](https://www.skills.sh/jabrena/cursor-rules-java/110-java-maven-best-practices) · [111-java-maven-dependencies](https://www.skills.sh/jabrena/cursor-rules-java/111-java-maven-dependencies) · [121-java-object-oriented-design](https://www.skills.sh/jabrena/cursor-rules-java/121-java-object-oriented-design) · [124-java-secure-coding](https://www.skills.sh/jabrena/cursor-rules-java/124-java-secure-coding) · [143-java-functional-exception-handling](https://www.skills.sh/jabrena/cursor-rules-java/143-java-functional-exception-handling) |
+| **Skills** | [110-java-maven-best-practices](https://www.skills.sh/jabrena/plinth/110-java-maven-best-practices) · [111-java-maven-dependencies](https://www.skills.sh/jabrena/plinth/111-java-maven-dependencies) · [121-java-object-oriented-design](https://www.skills.sh/jabrena/plinth/121-java-object-oriented-design) · [124-java-secure-coding](https://www.skills.sh/jabrena/plinth/124-java-secure-coding) · [143-java-functional-exception-handling](https://www.skills.sh/jabrena/plinth/143-java-functional-exception-handling) |
 | **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [JavaDocs](https://www.javadocs.dev/mcp) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) |
 
 ### Operar
@@ -170,7 +170,7 @@ Mide y mejora el comportamiento en producción mediante observabilidad, profilin
 | --- | --- |
 | **Commands** | [`/profile`](./.cursor/commands/profile.md) · [`/benchmark`](./.cursor/commands/benchmark.md) |
 | **Agents** | `@robot-java-performance` |
-| **Skills** | [151-java-performance-jmeter](https://www.skills.sh/jabrena/cursor-rules-java/151-java-performance-jmeter) · [161-java-profiling-detect](https://www.skills.sh/jabrena/cursor-rules-java/161-java-profiling-detect) · [162-java-profiling-analyze](https://www.skills.sh/jabrena/cursor-rules-java/162-java-profiling-analyze) · [163-java-profiling-refactor](https://www.skills.sh/jabrena/cursor-rules-java/163-java-profiling-refactor) · [164-java-profiling-verify](https://www.skills.sh/jabrena/cursor-rules-java/164-java-profiling-verify) |
+| **Skills** | [151-java-performance-jmeter](https://www.skills.sh/jabrena/plinth/151-java-performance-jmeter) · [161-java-profiling-detect](https://www.skills.sh/jabrena/plinth/161-java-profiling-detect) · [162-java-profiling-analyze](https://www.skills.sh/jabrena/plinth/162-java-profiling-analyze) · [163-java-profiling-refactor](https://www.skills.sh/jabrena/plinth/163-java-profiling-refactor) · [164-java-profiling-verify](https://www.skills.sh/jabrena/plinth/164-java-profiling-verify) |
 | **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) · [Grafana](https://grafana.com/docs/grafana/latest/developer-resources/mcp/) |
 
 ### Cumplimiento (Alpha)
@@ -203,7 +203,7 @@ El proyecto genera un conjunto de entregables al final de cualquier iteración.
 | --------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | 1. [Commands](./documentation/guides/INVENTORY-COMMANDS-JAVA.md) | `@004-commands-installation` Instalar Commands en el proyecto | [`Commands`](./documentation/guides/COMMANDS.md) |
 | 2. [Agents](./documentation/guides/INVENTORY-AGENTS-JAVA.md) | `@005-agents-installation` Instalar Agents en Cursor/Claude | [`Agents`](./documentation/guides/GETTING-STARTED-AGENTS_ES.md)     |
-| 3. [Skills](./documentation/guides/INVENTORY-SKILLS-JAVA.md) | `npx skills add jabrena/cursor-rules-java --skill '*' --agent cursor -y` | [`Skills`](./documentation/guides/GETTING-STARTED-SKILLS_ES.md)     |
+| 3. [Skills](./documentation/guides/INVENTORY-SKILLS-JAVA.md) | `npx skills add jabrena/plinth --skill '*' --agent cursor -y` | [`Skills`](./documentation/guides/GETTING-STARTED-SKILLS_ES.md)     |
 
 ### Compatibilidad
 
@@ -247,7 +247,7 @@ Actúa con precaución cuando un problema involucre bases de datos corporativas 
 
 - Sigue la [guía de 5 minutos](./documentation/guides/GETTING-STARTED-IN-5-MINUTES_ES.md) y cuéntanos dónde puede mejorar la experiencia.
 - [Explora el inventario de skills](./documentation/guides/INVENTORY-SKILLS-JAVA.md) y propón un flujo de trabajo Java que falte.
-- [Abre una issue](https://github.com/jabrena/cursor-rules-java/issues) para informar de un problema o sugerir una mejora.
+- [Abre una issue](https://github.com/jabrena/plinth/issues) para informar de un problema o sugerir una mejora.
 - Lee [CONTRIBUTING.md](./CONTRIBUTING.md) para mejorar un skill, agent, command o guía del proyecto.
 - Da una estrella al repositorio si estos flujos ayudan a tus proyectos Java.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -26,7 +26,7 @@
 
 ## 最新动态
 
-访问[项目网站](https://jabrena.github.io/cursor-rules-java/)探索最新发布的内容，并通过 [CHANGELOG](./CHANGELOG.md) 了解新 skills、改进和修复如何推动项目持续演进。
+访问 [jabrena/plinth](https://github.com/jabrena/plinth) 探索最新发布的内容，并通过 [CHANGELOG](./CHANGELOG.md) 了解新 skills、改进和修复如何推动项目持续演进。
 
 ## 60 秒开始使用
 
@@ -34,16 +34,16 @@
 
 ```bash
 # Cursor
-npx skills add jabrena/cursor-rules-java --skill '*' --agent cursor -y
+npx skills add jabrena/plinth --skill '*' --agent cursor -y
 
 # Claude Code
-npx skills add jabrena/cursor-rules-java --skill '*' --agent claude-code -y
+npx skills add jabrena/plinth --skill '*' --agent claude-code -y
 
 # Codex
-npx skills add jabrena/cursor-rules-java --skill '*' --agent codex -y
+npx skills add jabrena/plinth --skill '*' --agent codex -y
 
 # GitHub Copilot
-npx skills add jabrena/cursor-rules-java --skill '*' --agent github-copilot -y
+npx skills add jabrena/plinth --skill '*' --agent github-copilot -y
 ```
 
 ### 查看实际效果
@@ -148,7 +148,7 @@ MCP Servers
 | --- | --- |
 | **Commands** | [`/update-issue`](./.cursor/commands/update-issue.md) · `/explore-design` · `/create-adr` · `/create-diagram` · `/create-spec` · `/review-alignment` |
 | **Agents** | `@robot-business-analyst` · `@robot-architect` · `@robot-tech-lead` |
-| **Skills** | [014-agile-user-story](https://www.skills.sh/jabrena/cursor-rules-java/014-agile-user-story) · [030-architecture-adr-general](https://www.skills.sh/jabrena/cursor-rules-java/030-architecture-adr-general) · [031-architecture-adr-functional-requirements](https://www.skills.sh/jabrena/cursor-rules-java/031-architecture-adr-functional-requirements) · [032-architecture-adr-non-functional-requirements](https://www.skills.sh/jabrena/cursor-rules-java/032-architecture-adr-non-functional-requirements) · [033-architecture-diagrams](https://www.skills.sh/jabrena/cursor-rules-java/033-architecture-diagrams) · [034-architecture-design-exploration](https://www.skills.sh/jabrena/cursor-rules-java/034-architecture-design-exploration) · [041-planning-plan-mode](https://www.skills.sh/jabrena/cursor-rules-java/041-planning-plan-mode) · [042-planning-openspec](https://www.skills.sh/jabrena/cursor-rules-java/042-planning-openspec) · [043-planning-github-issues](https://www.skills.sh/jabrena/cursor-rules-java/043-planning-github-issues) · [044-planning-jira](https://www.skills.sh/jabrena/cursor-rules-java/044-planning-jira) · [051-design-two-steps-methods](https://www.skills.sh/jabrena/cursor-rules-java/051-design-two-steps-methods) · [052-design-hamburger-method](https://www.skills.sh/jabrena/cursor-rules-java/052-design-hamburger-method) · [053-design-simple-rules](https://www.skills.sh/jabrena/cursor-rules-java/053-design-simple-rules) · [056-design-avoid-breaking-changes](https://www.skills.sh/jabrena/cursor-rules-java/056-design-avoid-breaking-changes) · [200-agents-md](https://www.skills.sh/jabrena/cursor-rules-java/200-agents-md) |
+| **Skills** | [014-agile-user-story](https://www.skills.sh/jabrena/plinth/014-agile-user-story) · [030-architecture-adr-general](https://www.skills.sh/jabrena/plinth/030-architecture-adr-general) · [031-architecture-adr-functional-requirements](https://www.skills.sh/jabrena/plinth/031-architecture-adr-functional-requirements) · [032-architecture-adr-non-functional-requirements](https://www.skills.sh/jabrena/plinth/032-architecture-adr-non-functional-requirements) · [033-architecture-diagrams](https://www.skills.sh/jabrena/plinth/033-architecture-diagrams) · [034-architecture-design-exploration](https://www.skills.sh/jabrena/plinth/034-architecture-design-exploration) · [041-planning-plan-mode](https://www.skills.sh/jabrena/plinth/041-planning-plan-mode) · [042-planning-openspec](https://www.skills.sh/jabrena/plinth/042-planning-openspec) · [043-planning-github-issues](https://www.skills.sh/jabrena/plinth/043-planning-github-issues) · [044-planning-jira](https://www.skills.sh/jabrena/plinth/044-planning-jira) · [051-design-two-steps-methods](https://www.skills.sh/jabrena/plinth/051-design-two-steps-methods) · [052-design-hamburger-method](https://www.skills.sh/jabrena/plinth/052-design-hamburger-method) · [053-design-simple-rules](https://www.skills.sh/jabrena/plinth/053-design-simple-rules) · [056-design-avoid-breaking-changes](https://www.skills.sh/jabrena/plinth/056-design-avoid-breaking-changes) · [200-agents-md](https://www.skills.sh/jabrena/plinth/200-agents-md) |
 | **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) |
 
 ### 构建
@@ -159,7 +159,7 @@ MCP Servers
 | --- | --- |
 | **Commands** | [`/create-feature-branch`](./.cursor/commands/create-feature-branch.md) · [`/create-worktree`](./.cursor/commands/create-worktree.md) · [`/implement-issue`](./.cursor/commands/implement-issue.md) |
 | **Agents** | `@robot-tech-lead` · `@robot-no-java` · `@robot-java-coder` · `@robot-java-spring-boot-coder` · `@robot-java-quarkus-coder` · `@robot-java-micronaut-coder` |
-| **Skills** | [110-java-maven-best-practices](https://www.skills.sh/jabrena/cursor-rules-java/110-java-maven-best-practices) · [111-java-maven-dependencies](https://www.skills.sh/jabrena/cursor-rules-java/111-java-maven-dependencies) · [121-java-object-oriented-design](https://www.skills.sh/jabrena/cursor-rules-java/121-java-object-oriented-design) · [124-java-secure-coding](https://www.skills.sh/jabrena/cursor-rules-java/124-java-secure-coding) · [143-java-functional-exception-handling](https://www.skills.sh/jabrena/cursor-rules-java/143-java-functional-exception-handling) |
+| **Skills** | [110-java-maven-best-practices](https://www.skills.sh/jabrena/plinth/110-java-maven-best-practices) · [111-java-maven-dependencies](https://www.skills.sh/jabrena/plinth/111-java-maven-dependencies) · [121-java-object-oriented-design](https://www.skills.sh/jabrena/plinth/121-java-object-oriented-design) · [124-java-secure-coding](https://www.skills.sh/jabrena/plinth/124-java-secure-coding) · [143-java-functional-exception-handling](https://www.skills.sh/jabrena/plinth/143-java-functional-exception-handling) |
 | **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [JavaDocs](https://www.javadocs.dev/mcp) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) |
 
 ### 运维
@@ -170,7 +170,7 @@ MCP Servers
 | --- | --- |
 | **Commands** | [`/profile`](./.cursor/commands/profile.md) · [`/benchmark`](./.cursor/commands/benchmark.md) |
 | **Agents** | `@robot-java-performance` |
-| **Skills** | [151-java-performance-jmeter](https://www.skills.sh/jabrena/cursor-rules-java/151-java-performance-jmeter) · [161-java-profiling-detect](https://www.skills.sh/jabrena/cursor-rules-java/161-java-profiling-detect) · [162-java-profiling-analyze](https://www.skills.sh/jabrena/cursor-rules-java/162-java-profiling-analyze) · [163-java-profiling-refactor](https://www.skills.sh/jabrena/cursor-rules-java/163-java-profiling-refactor) · [164-java-profiling-verify](https://www.skills.sh/jabrena/cursor-rules-java/164-java-profiling-verify) |
+| **Skills** | [151-java-performance-jmeter](https://www.skills.sh/jabrena/plinth/151-java-performance-jmeter) · [161-java-profiling-detect](https://www.skills.sh/jabrena/plinth/161-java-profiling-detect) · [162-java-profiling-analyze](https://www.skills.sh/jabrena/plinth/162-java-profiling-analyze) · [163-java-profiling-refactor](https://www.skills.sh/jabrena/plinth/163-java-profiling-refactor) · [164-java-profiling-verify](https://www.skills.sh/jabrena/plinth/164-java-profiling-verify) |
 | **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) · [Grafana](https://grafana.com/docs/grafana/latest/developer-resources/mcp/) |
 
 ### 合规 (Alpha)
@@ -203,7 +203,7 @@ MCP Servers
 | --------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | 1. [Commands](./documentation/guides/INVENTORY-COMMANDS-JAVA.md) | `@004-commands-installation` 在项目中安装 Commands | [`Commands`](./documentation/guides/COMMANDS.md) |
 | 2. [Agents](./documentation/guides/INVENTORY-AGENTS-JAVA.md) | `@005-agents-installation` 在 Cursor/Claude 中安装 Agents | [`Agents`](./documentation/guides/GETTING-STARTED-AGENTS_ZH.md)     |
-| 3. [Skills](./documentation/guides/INVENTORY-SKILLS-JAVA.md) | `npx skills add jabrena/cursor-rules-java --skill '*' --agent cursor -y` | [`Skills`](./documentation/guides/GETTING-STARTED-SKILLS_ZH.md)     |
+| 3. [Skills](./documentation/guides/INVENTORY-SKILLS-JAVA.md) | `npx skills add jabrena/plinth --skill '*' --agent cursor -y` | [`Skills`](./documentation/guides/GETTING-STARTED-SKILLS_ZH.md)     |
 
 ### 兼容性
 
@@ -247,7 +247,7 @@ MCP Servers
 
 - 按照 [5 分钟快速入门](./documentation/guides/GETTING-STARTED-IN-5-MINUTES_ZH.md) 操作，并告诉我们哪些体验可以改进。
 - [浏览 skill 清单](./documentation/guides/INVENTORY-SKILLS-JAVA.md)，并提出尚未覆盖的 Java 工作流。
-- [创建 issue](https://github.com/jabrena/cursor-rules-java/issues)，报告问题或提出改进建议。
+- [创建 issue](https://github.com/jabrena/plinth/issues)，报告问题或提出改进建议。
 - 阅读 [CONTRIBUTING.md](./CONTRIBUTING.md)，改进 skill、agent、command 或项目指南。
 - 如果这些工作流对你的 Java 项目有所帮助，请为本仓库加星。
 

--- a/docs/2/index.html
+++ b/docs/2/index.html
@@ -291,7 +291,7 @@ In this release, the project introduc...
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/3/index.html
+++ b/docs/3/index.html
@@ -284,7 +284,7 @@ Added Consultative Interaction Technique in the majority of R...
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/4/index.html
+++ b/docs/4/index.html
@@ -194,7 +194,7 @@ In the previous release, the project added interactive behavior to a few complex
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/about.html
+++ b/docs/about.html
@@ -112,7 +112,7 @@ The available System prompts for Java cover aspects like Build system based on M
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/archive.html
+++ b/docs/archive.html
@@ -178,7 +178,7 @@
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/blog/2025/07/prompt-quality-framework.html
+++ b/docs/blog/2025/07/prompt-quality-framework.html
@@ -296,7 +296,7 @@
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/blog/2025/07/release-0.8.0.html
+++ b/docs/blog/2025/07/release-0.8.0.html
@@ -102,7 +102,7 @@
 <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
 <article role="main" class="blog-post">
 <h2>New interactive behaviors in the Cursor rules</h2>
-<p>In the previous release, the project added interactive behavior to a few complex rules to improve the developer experience, but in this release, new rules have evolved to add more interactive behavior regardless of complexity. The motivation behind this change: now the rules suggest alternatives to the software engineer to improve development at the package/class/method level. Maybe you could ask the question: why that change? Every software engineer has a unique way to solve software problems, so why force a suggestion in the code without a preliminary review? Let's explain the idea with an example to show the evolution in the cursor rule. The repository cursor-rules-java has different working examples that can be improved with the rules. Let's use an example based on Spring Boot: <a href="https://github.com/jabrena/cursor-rules-java/tree/main/examples/spring-boot-demo/implementation">https://github.com/jabrena/cursor-rules-java/tree/main/examples/spring-boot-demo/implementation</a><br />
+<p>In the previous release, the project added interactive behavior to a few complex rules to improve the developer experience, but in this release, new rules have evolved to add more interactive behavior regardless of complexity. The motivation behind this change: now the rules suggest alternatives to the software engineer to improve development at the package/class/method level. Maybe you could ask the question: why that change? Every software engineer has a unique way to solve software problems, so why force a suggestion in the code without a preliminary review? Let's explain the idea with an example to show the evolution in the cursor rule. The repository cursor-rules-java has different working examples that can be improved with the rules. Let's use an example based on Spring Boot: <a href="https://github.com/jabrena/plinth/tree/main/examples/spring-boot-demo/implementation">https://github.com/jabrena/plinth/tree/main/examples/spring-boot-demo/implementation</a><br />
 Over this example, add the following user prompt:</p>
 <blockquote>
 <p>&quot;Review my code for object-oriented design using the cursor rule @121-java-object-oriented-design.md @src/&quot;</p>
@@ -127,7 +127,7 @@ Over this example, add the following user prompt:</p>
 </ul>
 <p>Remember that models don't answer in a deterministic way, in the same way that in your team, not all software engineers solve problems in the same way.</p>
 <h2>Consistency in the syntax</h2>
-<p>When the repository is growing and there are 18 rules and counting, consistency is something important to take into account to improve maintenance and accuracy in the way software engineers use natural language to interact with models. With this purpose, in release 0.8.0 I invested effort to convert all Cursor rules from Markdown to XML in order to have the flexibility of this format to have strict rules about the design of the language and the flexibility to convert XML into Markdown with front matter. With this goal, there now exists a new XML Schema dedicated to prompts: <a href="https://github.com/jabrena/cursor-rules-java/blob/main/generator/src/main/resources/pml.xsd">https://github.com/jabrena/cursor-rules-java/blob/main/generator/src/main/resources/pml.xsd</a> which was designed with ideas from the main players in the models market (Anthropic, OpenAI, Google) in order to structure a prompt:</p>
+<p>When the repository is growing and there are 18 rules and counting, consistency is something important to take into account to improve maintenance and accuracy in the way software engineers use natural language to interact with models. With this purpose, in release 0.8.0 I invested effort to convert all Cursor rules from Markdown to XML in order to have the flexibility of this format to have strict rules about the design of the language and the flexibility to convert XML into Markdown with front matter. With this goal, there now exists a new XML Schema dedicated to prompts: <a href="https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/pml.xsd">https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/pml.xsd</a> which was designed with ideas from the main players in the models market (Anthropic, OpenAI, Google) in order to structure a prompt:</p>
 <pre><code class="language-xml">    &lt;xs:element name=&quot;prompt&quot;&gt;
         &lt;xs:complexType&gt;
             &lt;xs:sequence&gt;
@@ -145,7 +145,7 @@ Over this example, add the following user prompt:</p>
         &lt;/xs:complexType&gt;
     &lt;/xs:element&gt;
 </code></pre>
-<p>Once all cursor rules are modeled in XML format, it is easy to convert them into the format used by Cursor AI, Markdown with front matter: <a href="https://github.com/jabrena/cursor-rules-java/blob/main/generator/src/main/resources/cursor-rules.xsl">https://github.com/jabrena/cursor-rules-java/blob/main/generator/src/main/resources/cursor-rules.xsl</a></p>
+<p>Once all cursor rules are modeled in XML format, it is easy to convert them into the format used by Cursor AI, Markdown with front matter: <a href="https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/cursor-rules.xsl">https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/cursor-rules.xsl</a></p>
 <p>Using a schema and transformation, it is possible to guarantee consistency in the sources and the output format.</p>
 <h2>Safeguards in the system prompts</h2>
 <p>When you are working with AI models, safety is a critical aspect that cannot be ignored. In release 0.8.0, safeguards have been introduced to ensure that the cursor rules provide responsible validation of the changes introduced in the code.</p>
@@ -157,7 +157,7 @@ Over this example, add the following user prompt:</p>
 </code></pre>
 <p>It's not only that the model changes the code; the model needs to finish the prompt execution with a formal validation of the changes.</p>
 <h2>My 20 Cents</h2>
-<p>Using models &amp; system prompts like this project: <a href="https://github.com/jabrena/cursor-rules-java">https://github.com/jabrena/cursor-rules-java</a> could increase your squad velocity and increase squad satisfaction as part of the <a href="https://queue.acm.org/detail.cfm?id=3454124">SPACE framework</a>.</p>
+<p>Using models &amp; system prompts like this project: <a href="https://github.com/jabrena/plinth">https://github.com/jabrena/plinth</a> could increase your squad velocity and increase squad satisfaction as part of the <a href="https://queue.acm.org/detail.cfm?id=3454124">SPACE framework</a>.</p>
 <p>Join us with more than 600+ users in the last 14 days.</p>
 <p><img src="/plintch/images/2025/7/0.8.0-4.png" alt="" /></p>
 <p>Enjoy</p>
@@ -182,7 +182,7 @@ Over this example, add the following user prompt:</p>
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/blog/2025/07/release-0.8.0.html
+++ b/docs/blog/2025/07/release-0.8.0.html
@@ -107,9 +107,9 @@ Over this example, add the following user prompt:</p>
 <blockquote>
 <p>&quot;Review my code for object-oriented design using the cursor rule @121-java-object-oriented-design.md @src/&quot;</p>
 </blockquote>
-<p><img src="/plintch/images/2025/7/0.8.0-1.png" alt="" /><br />
-<img src="/plintch/images/2025/7/0.8.0-2.png" alt="" /><br />
-<img src="/plintch/images/2025/7/0.8.0-3.png" alt="" /></p>
+<p><img src="/plinth/images/2025/7/0.8.0-1.png" alt="" /><br />
+<img src="/plinth/images/2025/7/0.8.0-2.png" alt="" /><br />
+<img src="/plinth/images/2025/7/0.8.0-3.png" alt="" /></p>
 <p>Now, the software engineer has full control over the suggestion and later refactoring because they are able to interact with the Cursor rule and guide how the solution could be improved. If you like this feature, you can try the following cursor rules included in the release:</p>
 <ul>
 <li>110-java-maven-best-practices</li>
@@ -159,7 +159,7 @@ Over this example, add the following user prompt:</p>
 <h2>My 20 Cents</h2>
 <p>Using models &amp; system prompts like this project: <a href="https://github.com/jabrena/plinth">https://github.com/jabrena/plinth</a> could increase your squad velocity and increase squad satisfaction as part of the <a href="https://queue.acm.org/detail.cfm?id=3454124">SPACE framework</a>.</p>
 <p>Join us with more than 600+ users in the last 14 days.</p>
-<p><img src="/plintch/images/2025/7/0.8.0-4.png" alt="" /></p>
+<p><img src="/plinth/images/2025/7/0.8.0-4.png" alt="" /></p>
 <p>Enjoy</p>
 <p>Juan Antonio</p>
 

--- a/docs/blog/2025/07/release-0.9.0.html
+++ b/docs/blog/2025/07/release-0.9.0.html
@@ -111,7 +111,7 @@
 <p>A betterf Getting Started documentation</p>
 <p>Specific rules for Maven Dependencies &amp; Maven plugins</p>
 <p>Profiling improvements</p>
-<p>For further information about the full CHANGELOG, visit the following link: <a href="https://github.com/jabrena/cursor-rules-java/blob/main/CHANGELOG.md#090-2025-07-22">https://github.com/jabrena/cursor-rules-java/blob/main/CHANGELOG.md#090-2025-07-22</a></p>
+<p>For further information about the full CHANGELOG, visit the following link: <a href="https://github.com/jabrena/plinth/blob/main/CHANGELOG.md#090-2025-07-22">https://github.com/jabrena/plinth/blob/main/CHANGELOG.md#090-2025-07-22</a></p>
 <p>Added Version Control<br />
 If you are one of the thousands of users who at some point in time cloned the Git repository, maybe you don't remember when the system prompt was added to your workspace. In this version, all prompts include in the Markdown Frontmatter section, metadata about the version to track which version you are using and whether you need to update to the latest version.</p>
 <p>This way, you will have full awareness of whether you need to upgrade your system prompt or not.</p>
@@ -133,7 +133,7 @@ You are a Senior software engineer with extensive experience in Java software de
 <p>Exception handling is a core feature in Java, but that feature didn't have a specific system prompt. In this release, a specific rule about exception handling with a functional point of view was added.</p>
 <p><img src="/plintch/images/2025/7/java-exceptions-goto.png" alt="" /></p>
 <p>Consultative Interaction Technique<br />
-In the previous release, the project added a way to interact with software engineers. In this release, we externalized the behavior in the following building block: <a href="https://github.com/jabrena/cursor-rules-java/blob/main/generator/src/main/resources/fragments/system-prompt-behaviour-consultative-interaction-template.md">https://github.com/jabrena/cursor-rules-java/blob/main/generator/src/main/resources/fragments/system-prompt-behaviour-consultative-interaction-template.md</a></p>
+In the previous release, the project added a way to interact with software engineers. In this release, we externalized the behavior in the following building block: <a href="https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/fragments/system-prompt-behaviour-consultative-interaction-template.md">https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/fragments/system-prompt-behaviour-consultative-interaction-template.md</a></p>
 <p>Now that solution has been extended to the majority of the provided system prompts,  adding consultative behavior:</p>
 <pre><code class="language-xml">    &lt;goal&gt;&lt;![CDATA[
         Effective Maven usage involves robust dependency management via `&lt;dependencyManagement&gt;` and BOMs, adherence to the standard directory layout, and centralized plugin management. Build profiles should be used for environment-specific configurations. POMs must be kept readable and maintainable with logical structure and properties for versions. Custom repositories should be declared explicitly and their use minimized, preferably managed via a central repository manager.
@@ -143,10 +143,10 @@ In the previous release, the project added a way to interact with software engin
 
     &lt;/goal&gt;
 </code></pre>
-<p>Example: <a href="https://github.com/jabrena/cursor-rules-java/blob/main/generator/src/main/resources/110-java-maven-best-practices.xml">https://github.com/jabrena/cursor-rules-java/blob/main/generator/src/main/resources/110-java-maven-best-practices.xml</a></p>
+<p>Example: <a href="https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/110-java-maven-best-practices.xml">https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/110-java-maven-best-practices.xml</a></p>
 <p><img src="/plintch/images/2025/7/example-rules.png" alt="" /></p>
 <h3>A better Getting Started documentation</h3>
-<p>The repository has improved the documentation for new users in order to reduce the Onboarding time for new users: <a href="https://github.com/jabrena/cursor-rules-java/blob/main/GETTING-STARTED.md">https://github.com/jabrena/cursor-rules-java/blob/main/GETTING-STARTED.md</a></p>
+<p>The repository has improved the documentation for new users in order to reduce the Onboarding time for new users: <a href="https://github.com/jabrena/plinth/blob/main/GETTING-STARTED.md">https://github.com/jabrena/plinth/blob/main/GETTING-STARTED.md</a></p>
 <h3>Specific rules for Maven Dependencies &amp; Maven plugins</h3>
 <p>One of the obsessions in this project is to provide solutions that are easy to maintain in the medium term. In the past, the system prompt 111-java-maven-deps-and-plugins offered a very nice experience, but in terms of maintenance, it was a bit complex, so in this release it was split into 2: 111-java-maven-dependencies &amp; 112-java-maven-plugins</p>
 <h3>Profiling improvements</h3>
@@ -157,7 +157,7 @@ Thread Pool Leaks Fixed: Thread dump reduced from 5.9MB to 44KB, indicating prop
 Bounded Collections Active: Memory retention baseline improved by 55% (49MB→22MB)
 GC Pressure Reduced: More efficient garbage collection with stable retention patterns
 </code></pre>
-<p>Full sample document: <a href="https://github.com/jabrena/cursor-rules-java/blob/main/examples/spring-boot-memory-leak-demo/profiler/docs/profiling-comparison-analysis-20250720.md">https://github.com/jabrena/cursor-rules-java/blob/main/examples/spring-boot-memory-leak-demo/profiler/docs/profiling-comparison-analysis-20250720.md</a></p>
+<p>Full sample document: <a href="https://github.com/jabrena/plinth/blob/main/examples/spring-boot-memory-leak-demo/profiler/docs/profiling-comparison-analysis-20250720.md">https://github.com/jabrena/plinth/blob/main/examples/spring-boot-memory-leak-demo/profiler/docs/profiling-comparison-analysis-20250720.md</a></p>
 
 </article>
 </div>
@@ -178,7 +178,7 @@ GC Pressure Reduced: More efficient garbage collection with stable retention pat
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/blog/2025/07/release-0.9.0.html
+++ b/docs/blog/2025/07/release-0.9.0.html
@@ -131,7 +131,7 @@ You are a Senior software engineer with extensive experience in Java software de
 </code></pre>
 <h3>Exceptions handling</h3>
 <p>Exception handling is a core feature in Java, but that feature didn't have a specific system prompt. In this release, a specific rule about exception handling with a functional point of view was added.</p>
-<p><img src="/plintch/images/2025/7/java-exceptions-goto.png" alt="" /></p>
+<p><img src="/plinth/images/2025/7/java-exceptions-goto.png" alt="" /></p>
 <p>Consultative Interaction Technique<br />
 In the previous release, the project added a way to interact with software engineers. In this release, we externalized the behavior in the following building block: <a href="https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/fragments/system-prompt-behaviour-consultative-interaction-template.md">https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/fragments/system-prompt-behaviour-consultative-interaction-template.md</a></p>
 <p>Now that solution has been extended to the majority of the provided system prompts,  adding consultative behavior:</p>
@@ -144,7 +144,7 @@ In the previous release, the project added a way to interact with software engin
     &lt;/goal&gt;
 </code></pre>
 <p>Example: <a href="https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/110-java-maven-best-practices.xml">https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/110-java-maven-best-practices.xml</a></p>
-<p><img src="/plintch/images/2025/7/example-rules.png" alt="" /></p>
+<p><img src="/plinth/images/2025/7/example-rules.png" alt="" /></p>
 <h3>A better Getting Started documentation</h3>
 <p>The repository has improved the documentation for new users in order to reduce the Onboarding time for new users: <a href="https://github.com/jabrena/plinth/blob/main/GETTING-STARTED.md">https://github.com/jabrena/plinth/blob/main/GETTING-STARTED.md</a></p>
 <h3>Specific rules for Maven Dependencies &amp; Maven plugins</h3>

--- a/docs/blog/2025/09/jfr-modern-java-profiling.html
+++ b/docs/blog/2025/09/jfr-modern-java-profiling.html
@@ -385,7 +385,7 @@ spec:
 4. Share JFR knowledge with your team to elevate everyone's performance engineering skills</p>
 <p>The future of Java performance optimization is here, and JFR provides the foundation for building exceptional, high-performance applications. Every profiling session is an opportunity to learn something new about your application and improve its performance.</p>
 <hr />
-<p><em>Ready to dive deeper into JFR? Check out the <a href="https://github.com/jabrena/cursor-rules-java">java-cursor-rules</a> project for automated JFR profiling workflows and interactive profiling scripts that implement the techniques described in this article.</em></p>
+<p><em>Ready to dive deeper into JFR? Check out the <a href="https://github.com/jabrena/plinth">java-cursor-rules</a> project for automated JFR profiling workflows and interactive profiling scripts that implement the techniques described in this article.</em></p>
 
 </article>
 </div>
@@ -406,7 +406,7 @@ spec:
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/blog/2025/09/release-0.10.0.html
+++ b/docs/blog/2025/09/release-0.10.0.html
@@ -103,7 +103,7 @@
 <article role="main" class="blog-post">
 <h2>What are Cursor rules for Java?</h2>
 <p>The project provides a collection of System prompts for Java that help software engineers in their daily programming work.<br />
-The <a href="https://github.com/jabrena/cursor-rules-java/blob/main/SYSTEM-PROMPTS-JAVA.md">available System prompts for Java</a> cover aspects like <code>Build system based on Maven</code>, <code>Design</code>, <code>Coding</code>, <code>Testing</code>, <code>Refactoring &amp; JMH Benchmarking</code>, <code>Performance testing with JMeter</code>, <code>Profiling with Async profiler/JDK tools</code> &amp; <code>Documentation</code>.</p>
+The <a href="https://github.com/jabrena/plinth/blob/main/SYSTEM-PROMPTS-JAVA.md">available System prompts for Java</a> cover aspects like <code>Build system based on Maven</code>, <code>Design</code>, <code>Coding</code>, <code>Testing</code>, <code>Refactoring &amp; JMH Benchmarking</code>, <code>Performance testing with JMeter</code>, <code>Profiling with Async profiler/JDK tools</code> &amp; <code>Documentation</code>.</p>
 <p><img src="/plintch/images/2025/9/workflow.png" alt="" /></p>
 <h2>What is new in this release?</h2>
 <p>In this release, the project has released several features:</p>
@@ -300,7 +300,7 @@ public class ResultSample {
 <li>GitHub Copilot (Free tier)</li>
 <li>JetBrains IntelliJ IDEA + JetBrains Junie</li>
 </ul>
-<p>If you are interested, you can take a look at the <a href="https://github.com/jabrena/cursor-rules-java/blob/main/docs/reviews/review-20250829.md">latest review</a>.</p>
+<p>If you are interested, you can take a look at the <a href="https://github.com/jabrena/plinth/blob/main/docs/reviews/review-20250829.md">latest review</a>.</p>
 <p><strong>Summary:</strong> Currently the best environments to use this repository are: <code>Cursor</code>, <code>Cursor CLI</code> &amp; <code>Claude Code CLI</code>. If you use <code>JetBrains IntelliJ IDEA</code>, you could combine it with <code>Cursor CLI</code> or <code>Claude Code</code>.</p>
 <h3>Use the System prompts in a purist way</h3>
 <p>Normally, when you try to solve a software problem, the solution can be implemented in different ways. This is the reason that several cursor rules have an interactive approach (the system prompts show different alternatives to improve the code), but in some scenarios, the software engineer might prefer to delegate the action directly to the model at the risk that the implemented solution doesn't match their programming style.</p>
@@ -314,10 +314,10 @@ public class ResultSample {
 <p><strong>Example 3:</strong></p>
 <pre><code class="language-bash">Add tests for the following classes with  @131-java-unit-testing
 </code></pre>
-<p>Additional examples in the <a href="https://github.com/jabrena/cursor-rules-java/blob/main/SYSTEM-PROMPTS-JAVA.md">documentation</a>.</p>
+<p>Additional examples in the <a href="https://github.com/jabrena/plinth/blob/main/SYSTEM-PROMPTS-JAVA.md">documentation</a>.</p>
 <h3>Improve readability in system prompts</h3>
 <p>The project has renamed all system prompts from the <code>.mdc</code> file extension to the classic Markdown extension <code>.md</code>. Now, everyone can read the files easily on <code>GitHub</code>:<br />
-<a href="https://github.com/jabrena/cursor-rules-java/tree/main/.cursor/rules">https://github.com/jabrena/cursor-rules-java/tree/main/.cursor/rules</a></p>
+<a href="https://github.com/jabrena/plinth/tree/main/.cursor/rules">https://github.com/jabrena/plinth/tree/main/.cursor/rules</a></p>
 <h2>Do you still have doubts about the project?</h2>
 <p>If you feel stuck using this project or you have any doubts, you could attend the following talk at Devoxx BE in October: <a href="https://devoxx.be/app/talk/4715/the-power-of-cursor-rules-in-java-enterprise-development">https://devoxx.be/app/talk/4715/the-power-of-cursor-rules-in-java-enterprise-development</a></p>
 <p><a href="https://devoxx.be/"><img src="/plintch/images/2025/9/devoxx-logo.png" alt="" /></a></p>
@@ -341,7 +341,7 @@ public class ResultSample {
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/blog/2025/09/release-0.10.0.html
+++ b/docs/blog/2025/09/release-0.10.0.html
@@ -104,7 +104,7 @@
 <h2>What are Cursor rules for Java?</h2>
 <p>The project provides a collection of System prompts for Java that help software engineers in their daily programming work.<br />
 The <a href="https://github.com/jabrena/plinth/blob/main/SYSTEM-PROMPTS-JAVA.md">available System prompts for Java</a> cover aspects like <code>Build system based on Maven</code>, <code>Design</code>, <code>Coding</code>, <code>Testing</code>, <code>Refactoring &amp; JMH Benchmarking</code>, <code>Performance testing with JMeter</code>, <code>Profiling with Async profiler/JDK tools</code> &amp; <code>Documentation</code>.</p>
-<p><img src="/plintch/images/2025/9/workflow.png" alt="" /></p>
+<p><img src="/plinth/images/2025/9/workflow.png" alt="" /></p>
 <h2>What is new in this release?</h2>
 <p>In this release, the project has released several features:</p>
 <ul>
@@ -136,7 +136,7 @@ java -cp target/jmh-benchmarks.jar info.jab.demo.benchmarks.FibonacciBenchmark #
 <pre><code class="language-bash">Can you explain the JMH results and advise about the best implementation?
 </code></pre>
 <p>This kind of analysis can help the team make decisions about which alternative is better to maintain in the repository.</p>
-<p><img src="/plintch/images/2025/9/jmh-summary-visualization-sample.png" alt="" /></p>
+<p><img src="/plinth/images/2025/9/jmh-summary-visualization-sample.png" alt="" /></p>
 <p>Further information about JMH:</p>
 <ul>
 <li><a href="https://github.com/openjdk/jmh">https://github.com/openjdk/jmh</a></li>
@@ -152,7 +152,7 @@ java -cp target/jmh-benchmarks.jar info.jab.demo.benchmarks.FibonacciBenchmark #
 <li>Diagrams (UML Class diagram, UML Sequence diagram &amp; C4 Model diagrams)</li>
 </ul>
 <p><strong>UML class diagram sample:</strong></p>
-<p><img src="/plintch/images/2025/9/uml-class-diagram-sample.png" alt="" /></p>
+<p><img src="/plinth/images/2025/9/uml-class-diagram-sample.png" alt="" /></p>
 <p>Using <code>UML Class diagrams</code>, you can understand how is currently the implementation and if you can improve in some way the code from a high level perspective.</p>
 <p><strong>Note:</strong> All diagrams are generated in <code>PlantUML</code> format. To convert <code>.puml</code> files into <code>.png</code> format you could use the following command line tool: <code>jbang puml-to-png@jabrena --watch .</code> or generate the images <a href="https://www.plantuml.com/plantuml/uml/">online</a>.</p>
 <p>Further information about documentation &amp; diagrams:</p>
@@ -165,7 +165,7 @@ java -cp target/jmh-benchmarks.jar info.jab.demo.benchmarks.FibonacciBenchmark #
 </ul>
 <h3>Added support for Java Generics</h3>
 <p>Java Generics is not an easy feature in Java. Indeed, if you interact with <a href="https://claude.ai/new">Claude</a> and ask about <code>What are the hardest parts in Java to master for a Software engineer?</code></p>
-<p><img src="/plintch/images/2025/9/claude-question.png" alt="" /></p>
+<p><img src="/plinth/images/2025/9/claude-question.png" alt="" /></p>
 <p><code>Java Generics</code> always appears. In this release, the project has added a new system prompt to cover this gap. Now, you can create the following interactive user prompt:</p>
 <pre><code class="language-bash">Review my code to show several alternatives to apply Java Generics with the cursor rule @128-java-generics
 </code></pre>
@@ -320,7 +320,7 @@ public class ResultSample {
 <a href="https://github.com/jabrena/plinth/tree/main/.cursor/rules">https://github.com/jabrena/plinth/tree/main/.cursor/rules</a></p>
 <h2>Do you still have doubts about the project?</h2>
 <p>If you feel stuck using this project or you have any doubts, you could attend the following talk at Devoxx BE in October: <a href="https://devoxx.be/app/talk/4715/the-power-of-cursor-rules-in-java-enterprise-development">https://devoxx.be/app/talk/4715/the-power-of-cursor-rules-in-java-enterprise-development</a></p>
-<p><a href="https://devoxx.be/"><img src="/plintch/images/2025/9/devoxx-logo.png" alt="" /></a></p>
+<p><a href="https://devoxx.be/"><img src="/plinth/images/2025/9/devoxx-logo.png" alt="" /></a></p>
 
 </article>
 </div>

--- a/docs/blog/2025/09/release-0.11.0.html
+++ b/docs/blog/2025/09/release-0.11.0.html
@@ -102,7 +102,7 @@
 <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
 <article role="main" class="blog-post">
 <h2>What are Cursor rules for Java?</h2>
-<p>The project provides a collection of System prompts for Java Enterprise development that help software engineers in their daily programming work &amp; data pipelines. The <a href="https://github.com/jabrena/cursor-rules-java/blob/main/SYSTEM-PROMPTS-JAVA.md">available System prompts for Java</a> cover areas such as <code>Build system based on Maven</code>, <code>Design</code>, <code>Coding</code>, <code>Testing</code>, <code>Refactoring &amp; JMH Benchmarking</code>, <code>Performance testing with JMeter</code>, <code>Profiling with async-profiler/JDK tools</code>, <code>Documentation</code>, and <code>Diagrams</code>.</p>
+<p>The project provides a collection of System prompts for Java Enterprise development that help software engineers in their daily programming work &amp; data pipelines. The <a href="https://github.com/jabrena/plinth/blob/main/SYSTEM-PROMPTS-JAVA.md">available System prompts for Java</a> cover areas such as <code>Build system based on Maven</code>, <code>Design</code>, <code>Coding</code>, <code>Testing</code>, <code>Refactoring &amp; JMH Benchmarking</code>, <code>Performance testing with JMeter</code>, <code>Profiling with async-profiler/JDK tools</code>, <code>Documentation</code>, and <code>Diagrams</code>.</p>
 <h2>What's new in this release?</h2>
 <p>In this release, the project introduces several updates:</p>
 <ul>
@@ -142,32 +142,32 @@ and place the course here
 <pre><code>Improve the classes provided in the context
 by applying the system prompt @128-java-generics
 </code></pre>
-<p>Further information: <a href="https://github.com/jabrena/cursor-rules-java/blob/0.11.0/SYSTEM-PROMPTS-JAVA.md">https://github.com/jabrena/cursor-rules-java/blob/0.11.0/SYSTEM-PROMPTS-JAVA.md</a></p>
+<p>Further information: <a href="https://github.com/jabrena/plinth/blob/0.11.0/SYSTEM-PROMPTS-JAVA.md">https://github.com/jabrena/plinth/blob/0.11.0/SYSTEM-PROMPTS-JAVA.md</a></p>
 <p>With this evolution, software engineers now can combine pure system prompts and specialized behaviors in <code>16^3 = 4096</code> combinations by design.</p>
 <p><strong>Pure system prompts:</strong></p>
 <ul>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/100-java-system-prompt-java-list.md"><code>@100-java-system-prompt-java-list</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/110-java-maven-best-practices.md"><code>@110-java-maven-best-practices</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/111-java-maven-dependencies.md"><code>@111-java-maven-dependencies</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/113-java-maven-documentation.md"><code>@113-java-maven-documentation</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/121-java-object-oriented-design.md"><code>@121-java-object-oriented-design</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/122-java-type-design.md"><code>@122-java-type-design</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/124-java-secure-coding.md"><code>@124-java-secure-coding</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/125-java-concurrency.md"><code>@125-java-concurrency</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/126-java-logging.md"><code>@126-java-logging</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/127-java-exception-handling.md"><code>@127-java-exception-handling</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/128-java-generics.md"><code>@128-java-generics</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/131-java-unit-testing.md"><code>@131-java-unit-testing</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/141-java-refactoring-with-modern-features.md"><code>@141-java-refactoring-with-modern-features</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/142-java-functional-programming.md"><code>@142-java-functional-programming</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/143-java-functional-exception-handling.md"><code>@143-java-functional-exception-handling</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/144-java-data-oriented-programming.md"><code>@144-java-data-oriented-programming</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/100-java-system-prompt-java-list.md"><code>@100-java-system-prompt-java-list</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/110-java-maven-best-practices.md"><code>@110-java-maven-best-practices</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/111-java-maven-dependencies.md"><code>@111-java-maven-dependencies</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/113-java-maven-documentation.md"><code>@113-java-maven-documentation</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/121-java-object-oriented-design.md"><code>@121-java-object-oriented-design</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/122-java-type-design.md"><code>@122-java-type-design</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/124-java-secure-coding.md"><code>@124-java-secure-coding</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/125-java-concurrency.md"><code>@125-java-concurrency</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/126-java-logging.md"><code>@126-java-logging</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/127-java-exception-handling.md"><code>@127-java-exception-handling</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/128-java-generics.md"><code>@128-java-generics</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/131-java-unit-testing.md"><code>@131-java-unit-testing</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/141-java-refactoring-with-modern-features.md"><code>@141-java-refactoring-with-modern-features</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/142-java-functional-programming.md"><code>@142-java-functional-programming</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/143-java-functional-exception-handling.md"><code>@143-java-functional-exception-handling</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/144-java-data-oriented-programming.md"><code>@144-java-data-oriented-programming</code></a></li>
 </ul>
 <p><strong>Specialized behaviors:</strong></p>
 <ul>
 <li>Default behavior</li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/behaviour-consultative-interaction.md"><code>@behaviour-consultative-interaction</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/behaviour-progressive-learning.md"><code>@behaviour-progressive-learning</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/behaviour-consultative-interaction.md"><code>@behaviour-consultative-interaction</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/behaviour-progressive-learning.md"><code>@behaviour-progressive-learning</code></a></li>
 </ul>
 <p>Using specialized behaviours such as <code>@behaviour-progressive-learning</code> creatively in your repositories can increase collective ownership and help spread the code standards implemented in the codebase.</p>
 <h3>Using Pure System Prompts in Data Pipelines</h3>
@@ -193,16 +193,12 @@ https://github.com/jabrena/kafka/tree/trunk/clients/src/main/java/org/apache/kaf
 <li><code>@162-java-profiling-analyze</code></li>
 <li><code>@164-java-profiling-compare</code></li>
 </ul>
-<p>You could review the course about <a href="https://jabrena.github.io/cursor-rules-java/courses/profile-memory-leak/index.html">Detecting memory leaks with System prompts</a>.</p>
+<p>You could review <a href="https://github.com/jabrena/plinth">jabrena/plinth</a>.</p>
 <h2>A new website</h2>
-<p>In recent releases, the project published an article summarizing its evolution and shared it across channels like Twitter, Reddit, and LinkedIn. To unify the source of truth, and leveraging <a href="https://docs.github.com/es/pages">GitHub Pages</a>, the project now has <a href="https://jabrena.github.io/cursor-rules-java/index.html">a dedicated website</a>.</p>
-<p>The website includes information about releases, technical articles you can apply in your projects, and courses.</p>
+<p>In recent releases, the project published an article summarizing its evolution and shared it across channels like Twitter, Reddit, and LinkedIn. To unify the source of truth, and leveraging <a href="https://docs.github.com/es/pages">GitHub Pages</a>, the project now has <a href="https://github.com/jabrena/plinth">jabrena/plinth</a>.</p>
+<p>The project includes information about releases, technical articles you can apply in your projects, and courses.</p>
 <p><strong>What courses were created in this release?</strong></p>
-<ul>
-<li><a href="https://jabrena.github.io/cursor-rules-java/courses/system-prompts-java/index.html">Learn to use System prompts for Java</a></li>
-<li><a href="https://jabrena.github.io/cursor-rules-java/courses/java-generics/index.html">Learn to improve your development with Java Generics</a></li>
-<li><a href="https://jabrena.github.io/cursor-rules-java/courses/profile-memory-leak/index.html">Learn how to detect memory leaks with System prompts</a></li>
-</ul>
+<p>See <a href="https://github.com/jabrena/plinth">jabrena/plinth</a> for the updated project home.</p>
 <h2>Do you still have questions about the project?</h2>
 <p>If you feel stuck using this project or have questions, you can attend the following talks at Devoxx BE in October:</p>
 <ul>
@@ -231,7 +227,7 @@ https://github.com/jabrena/kafka/tree/trunk/clients/src/main/java/org/apache/kaf
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/blog/2025/09/release-0.11.0.html
+++ b/docs/blog/2025/09/release-0.11.0.html
@@ -172,7 +172,7 @@ by applying the system prompt @128-java-generics
 <p>Using specialized behaviours such as <code>@behaviour-progressive-learning</code> creatively in your repositories can increase collective ownership and help spread the code standards implemented in the codebase.</p>
 <h3>Using Pure System Prompts in Data Pipelines</h3>
 <p>Little by little, organizations will evolve current <code>data pipeline</code> adding new features combining multiple system prompts for different use cases such as <code>automatic coding</code>, <code>code refactoring</code>, <code>continuous profiling</code>, and more.</p>
-<p><img src="/plintch/images/2025/9/data-pipeline-workflow.png" alt="" /></p>
+<p><img src="/plinth/images/2025/9/data-pipeline-workflow.png" alt="" /></p>
 <h2>New UML state machine diagrams for better understanding in complex dependencies.</h2>
 <p>Sometimes you need to use complex dependencies in your projects, like Apache Kafka clients, and the team may not be strong enough in the early stages. If you don't have much experience with them, a good practice is to run a <code>spike</code> and review how the client works under the hood to mitigate risks.</p>
 <p>During the spike, you may need to visualize internal aspects of the clients, so why not generate a <code>UML state machine diagram</code> to gain more insights.</p>
@@ -181,11 +181,11 @@ by applying the system prompt @128-java-generics
 https://github.com/jabrena/kafka/tree/trunk/clients/src/main/java/org/apache/kafka/clients/producer
 </code></pre>
 <p><strong>Result:</strong></p>
-<p><img src="/plintch/images/2025/9/0.11.0-uml-state-machine-diagram-example.png" alt="" /></p>
+<p><img src="/plinth/images/2025/9/0.11.0-uml-state-machine-diagram-example.png" alt="" /></p>
 <p>With this visualization, you can see whether something is missing in your Java integration.</p>
 <h2>Profiling improvements</h2>
 <p>In this release, the script <code>profile-java-process.sh</code>, included in  <code>@161-java-profiling-detect</code>, was updated to include the latest release (v4.1) of the popular profiling tool <code>Async-profiler</code>. In addition, the script added new <code>JFR</code> options available in <code>Java 25</code> and earlier.</p>
-<p><img src="/plintch/images/2025/9/0.11.0-profiling-menu.png" alt="" /></p>
+<p><img src="/plinth/images/2025/9/0.11.0-profiling-menu.png" alt="" /></p>
 <p>In recent months, I have been inspired by the work of outstanding engineers in this field: <a href="https://x.com/forked_franz">Francesco Nigro</a>, <a href="https://x.com/jerrinot">Jaromir Hamala</a>, <a href="https://x.com/parttimen3rd">Johannes Bechberger</a>, <a href="https://x.com/ErikGahlin">Erik Gahlin</a>, <a href="https://x.com/hirt">Marcus Hirt</a> &amp; <a href="https://x.com/brendangregg">Brendan Gregg</a>. I highly recommend following them.</p>
 <p>If you are interested in the Profiling model <code>Detect, Analyze, Refactor &amp; Compare</code> implemented with the following set of System prompts:</p>
 <ul>
@@ -205,8 +205,8 @@ https://github.com/jabrena/kafka/tree/trunk/clients/src/main/java/org/apache/kaf
 <li><a href="https://devoxx.be/app/talk/4715/the-power-of-cursor-rules-in-java-enterprise-development">https://devoxx.be/app/talk/4715/the-power-of-cursor-rules-in-java-enterprise-development</a></li>
 <li><a href="https://devoxx.be/app/talk/4708/101-cursor-ai-learning-to-use-for-java-enterprise-projects/">https://devoxx.be/app/talk/4708/101-cursor-ai-learning-to-use-for-java-enterprise-projects/</a></li>
 </ul>
-<p><a href="https://devoxx.be/"><img src="/plintch/images/2025/9/devoxx-logo.png" alt="" /></a></p>
-<p><img src="/plintch/images/2025/9/0.11.0-github-stats.png" alt="" /></p>
+<p><a href="https://devoxx.be/"><img src="/plinth/images/2025/9/devoxx-logo.png" alt="" /></a></p>
+<p><img src="/plinth/images/2025/9/0.11.0-github-stats.png" alt="" /></p>
 
 </article>
 </div>

--- a/docs/blog/2025/11/the-tour-in-europe-2025-is-over.html
+++ b/docs/blog/2025/11/the-tour-in-europe-2025-is-over.html
@@ -171,21 +171,21 @@
 </code></pre>
 <p><a href="https://forms.gle/TpNXENjmu45wuXoi6">https://forms.gle/TpNXENjmu45wuXoi6</a></p>
 <p>Recently, this technique was identified in the latest <code>Thoughtworks Radar #33</code>: <strong>Curated shared instructions for software teams</strong></p>
-<p><a href="https://www.thoughtworks.com/radar/techniques/curated-shared-instructions-for-software-teams"><img src="/plintch/images/2025/11/thoughtworks-radar-system-prompts.jpg" alt="" /></a></p>
+<p><a href="https://www.thoughtworks.com/radar/techniques/curated-shared-instructions-for-software-teams"><img src="/plinth/images/2025/11/thoughtworks-radar-system-prompts.jpg" alt="" /></a></p>
 <p><strong>Problem it tries to solve:</strong> Maintain a specialized collection of system prompts for Software development in Java.</p>
 <p>This project uses PML under the hood to model all System prompts in homogeneous Markdown syntax. Read the file <a href="https://github.com/jabrena/plinth/blob/main/CURSOR-RULES-JAVA.md">CURSOR-RULES-JAVA.md</a> to understand all possibilities.</p>
 <p><a href="https://github.com/jabrena/plinth">https://github.com/jabrena/plinth</a></p>
 <h3>Churrera, tasks like churros!</h3>
 <p>Churrera is a CLI tool designed to operate with <code>Cursor Cloud Agents API</code> easily. The Cloud Agents API (Beta) allows you to programmatically create and manage AI-powered coding agents that work autonomously on your repositories.</p>
-<p><img src="/plintch/images/2025/11/churrera-2.png" alt="" /></p>
+<p><img src="/plinth/images/2025/11/churrera-2.png" alt="" /></p>
 <p><strong>Problem it tries to solve:</strong> Enhance your pipelines with <code>AI Glue</code>.</p>
 <p><strong>Use cases:</strong> <code>Automate repetitive Java coding tasks</code> (with TDD if required), <code>Continuous documentation</code>, <code>Continuous Profiling</code>. You could refactor the results using <code>System prompts</code> from the project <code>Cursor rules for Java</code> or use your own System prompts. Your creativity defines your limits.</p>
 <p><strong>Note:</strong> At the moment, the unique service which provides this kind of APIs is <code>Cursor Cloud agents API</code>. If new alternatives exist in the future, I would be happy to implement a factory to support more alternatives.</p>
 <p><a href="https://github.com/jabrena/churrera">https://github.com/jabrena/churrera</a></p>
 <h2>Observations in Devoxx 2025</h2>
-<p><img src="/plintch/images/2025/11/devoxx-be-room-4.jpg" alt="" /></p>
+<p><img src="/plinth/images/2025/11/devoxx-be-room-4.jpg" alt="" /></p>
 <p>In 2025, the entire JVM industry is moving around AI and if you attended the different sessions in Devoxx, you may feel it. In the conference, I listened to the different proposals from the most used frameworks <code>Spring</code> &amp; <code>Quarkus</code> in the Java industry and in this year, I observed that there exists a real parity between Spring ecosystem and Quarkus ecosystem in terms of talks. Congratulations to <code>Mario Fusco</code>, <code>Georgios Andrianakis</code>, <code>Clement Escoffier</code>, <code>Rod Johnson</code> &amp; <code>Christian Tzolov</code> for their hard work. I would not like to forget the nice proposal from <code>Akka</code> which shared the new features oriented to <code>Agents</code>.</p>
-<p><img src="/plintch/images/2025/11/devoxx-quarkus-agentic-talk.png" alt="" /></p>
+<p><img src="/plinth/images/2025/11/devoxx-quarkus-agentic-talk.png" alt="" /></p>
 <p><strong>Can Spring AI or Langchain4j use PML or Cursor rules for Java?</strong></p>
 <p>Yes, for sure. Happy to talk with <code>Spring AI</code> team or <code>Quarkus</code> team in the future.</p>
 <h3>What talks I loved in Devoxx BE 2025?</h3>
@@ -212,9 +212,9 @@
 <li><a href="https://m.devoxx.com/events/dvbe25/talks/6238/whats-new-in-spring-modulith">https://m.devoxx.com/events/dvbe25/talks/6238/whats-new-in-spring-modulith</a></li>
 </ul>
 <h2>Observations in W-JAX-2025</h2>
-<p><img src="/plintch/images/2025/11/wjax-atlanta-room.png" alt="" /></p>
+<p><img src="/plinth/images/2025/11/wjax-atlanta-room.png" alt="" /></p>
 <p>In this case, I visited the conference for a shorter time so my observations were limited, but in the conference the talks put focus on AI also. In the another hand, I observed less presence of Quarkus talks, in Germain Speakers continue with more experience in Spring. Gathering feedback from my talk, many <code>Java Software engineers</code> in Germany are starting to use this kind of modern tools but in general, the usage is not massive.</p>
-<p><img src="/plintch/images/2025/11/crossing-the-chasm.png" alt="" /></p>
+<p><img src="/plinth/images/2025/11/crossing-the-chasm.png" alt="" /></p>
 <h3>What talks I loved in W-JAX 2025?</h3>
 <p><strong>Cloud:</strong></p>
 <ul>

--- a/docs/blog/2025/11/the-tour-in-europe-2025-is-over.html
+++ b/docs/blog/2025/11/the-tour-in-europe-2025-is-over.html
@@ -114,7 +114,7 @@
 </ul>
 <p>and the associated Slides:</p>
 <ul>
-<li><a href="https://github.com/jabrena/plinth">jabrena/plinth</a></li>
+<li><a href="https://jabrena.github.io/plinth/dvbe25/index.html">https://jabrena.github.io/plinth/dvbe25/index.html</a></li>
 <li><a href="https://jabrena.github.io/101-cursor/">https://jabrena.github.io/101-cursor/</a></li>
 </ul>
 <h2>Emerging new solutions from the Gemba</h2>

--- a/docs/blog/2025/11/the-tour-in-europe-2025-is-over.html
+++ b/docs/blog/2025/11/the-tour-in-europe-2025-is-over.html
@@ -114,7 +114,7 @@
 </ul>
 <p>and the associated Slides:</p>
 <ul>
-<li><a href="https://jabrena.github.io/cursor-rules-java/dvbe25/index.html">https://jabrena.github.io/cursor-rules-java/dvbe25/index.html</a></li>
+<li><a href="https://github.com/jabrena/plinth">jabrena/plinth</a></li>
 <li><a href="https://jabrena.github.io/101-cursor/">https://jabrena.github.io/101-cursor/</a></li>
 </ul>
 <h2>Emerging new solutions from the Gemba</h2>
@@ -143,7 +143,7 @@
     &lt;/xs:complexType&gt;
 &lt;/xs:element&gt;
 </code></pre>
-<p>You can see PML in action <a href="https://github.com/jabrena/cursor-rules-java/tree/main/skills-generator/src/main/resources">here</a>.</p>
+<p>You can see PML in action <a href="https://github.com/jabrena/plinth/tree/main/skills-generator/src/main/resources">here</a>.</p>
 <p>Finally, here is a novel Schema dedicated to Workflows:</p>
 <pre><code class="language-xml">&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
 &lt;pml-workflow xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
@@ -173,8 +173,8 @@
 <p>Recently, this technique was identified in the latest <code>Thoughtworks Radar #33</code>: <strong>Curated shared instructions for software teams</strong></p>
 <p><a href="https://www.thoughtworks.com/radar/techniques/curated-shared-instructions-for-software-teams"><img src="/plintch/images/2025/11/thoughtworks-radar-system-prompts.jpg" alt="" /></a></p>
 <p><strong>Problem it tries to solve:</strong> Maintain a specialized collection of system prompts for Software development in Java.</p>
-<p>This project uses PML under the hood to model all System prompts in homogeneous Markdown syntax. Read the file <a href="https://github.com/jabrena/cursor-rules-java/blob/main/CURSOR-RULES-JAVA.md">CURSOR-RULES-JAVA.md</a> to understand all possibilities.</p>
-<p><a href="https://github.com/jabrena/cursor-rules-java">https://github.com/jabrena/cursor-rules-java</a></p>
+<p>This project uses PML under the hood to model all System prompts in homogeneous Markdown syntax. Read the file <a href="https://github.com/jabrena/plinth/blob/main/CURSOR-RULES-JAVA.md">CURSOR-RULES-JAVA.md</a> to understand all possibilities.</p>
+<p><a href="https://github.com/jabrena/plinth">https://github.com/jabrena/plinth</a></p>
 <h3>Churrera, tasks like churros!</h3>
 <p>Churrera is a CLI tool designed to operate with <code>Cursor Cloud Agents API</code> easily. The Cloud Agents API (Beta) allows you to programmatically create and manage AI-powered coding agents that work autonomously on your repositories.</p>
 <p><img src="/plintch/images/2025/11/churrera-2.png" alt="" /></p>
@@ -276,7 +276,7 @@
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/blog/2026/03/release-0.12.0.html
+++ b/docs/blog/2026/03/release-0.12.0.html
@@ -124,7 +124,7 @@
 </ul>
 <p>Let's walk through each feature. You can also review the <a href="https://github.com/jabrena/plinth/blob/main/CHANGELOG.md#0120-2026-03-08">CHANGELOG.md</a></p>
 <h2>Why Skills?</h2>
-<p><img src="/plintch/images/2026/3/skills-everywhere.png" alt="" /></p>
+<p><img src="/plinth/images/2026/3/skills-everywhere.png" alt="" /></p>
 <p>The <a href="https://aws.amazon.com/en/blogs/devops/aws-named-as-a-leader-in-the-2025-gartner-magic-quadrant-for-ai-code-assistants/">AI Assistants</a> market is reshaping how we build software. A growing number of tools offer similar capabilities, yet until recently there was no standard way to extend them across vendors. <code>Cursor</code> pioneered <code>System prompts</code>, but that approach lacked a shared specification for others to adopt. A <code>Skill</code> fills that gap: it extends AI agents with specialized knowledge and workflows that work across different products.</p>
 <p>This project has long focused on <code>Prompt engineering</code> and maintains a curated collection of <code>System prompts</code> (formerly Cursor rules). As Skills gained traction, we recognized that a Skill is essentially a System prompt with a standardized format—and that migrating to this format would keep the project relevant as the ecosystem evolves.</p>
 <p>Each <code>Skill</code> lives in a <code>SKILL.md</code> file. The specification allows up to 600 lines per file, though files in the <code>references</code> folder may exceed that limit.</p>
@@ -199,7 +199,7 @@ npx skills add https://github.com/jabrena/plinth \
 npx skills install jabrena/plinth --all --agent cursor
 </code></pre>
 <p>One feature I like: Security pipelines that audit Skills for safety.</p>
-<p><a href="https://skills.sh/jabrena/plinth/110-java-maven-best-practices"><img src="/plintch/images/2026/3/skill-security-audit.png" alt="" /></a></p>
+<p><a href="https://skills.sh/jabrena/plinth/110-java-maven-best-practices"><img src="/plinth/images/2026/3/skill-security-audit.png" alt="" /></a></p>
 <p><strong>Source:</strong> <a href="https://skills.sh/jabrena/plinth/110-java-maven-best-practices">https://skills.sh/jabrena/plinth/110-java-maven-best-practices</a></p>
 <p><strong>Note:</strong> I recommend skills.sh and similar sites—Skills there have passed security audits. Be aware that Skills can include scripts, which may be an attack vector.</p>
 <h3>What are SkillsJars?</h3>
@@ -456,11 +456,11 @@ META-INF/skills/jabrena/plinth/111-java-maven-dependencies/references/111-java-m
 <h2>How to use Prompts, Agents.md, Skills &amp; MCP/CLI tools in your daily workflow?</h2>
 <p>In 2026, AI tools are essential—but which ones you use depends on your organization and project. Check with your <code>Platform Engineering team</code> to see which AI tools, Skills, and MCP/CLI tools are approved.</p>
 <p>With Agile (Intents, Epics, User Stories, Tasks), start by reviewing your backlog and ensuring tasks are ready for development.</p>
-<p><a href="https://learn.microsoft.com/en-us/azure/devops/boards/backlogs/define-features-epics?view=azure-devops&amp;tabs=agile-process"><img src="/plintch/images/2026/3/agile.png" alt="" /></a></p>
+<p><a href="https://learn.microsoft.com/en-us/azure/devops/boards/backlogs/define-features-epics?view=azure-devops&amp;tabs=agile-process"><img src="/plinth/images/2026/3/agile.png" alt="" /></a></p>
 <p><strong>Source:</strong> <a href="https://learn.microsoft.com/en-us/azure/devops/boards/backlogs/define-features-epics?view=azure-devops&amp;tabs=agile-process">https://learn.microsoft.com/en-us/azure/devops/boards/backlogs/define-features-epics?view=azure-devops&amp;tabs=agile-process</a></p>
 <p>Use <a href="https://github.com/jabrena/cursor-rules-agile"><code>System prompts for Agile</code></a> to improve analysis and design: Epics, Features, User Stories (with <a href="https://cucumber.io/docs/gherkin/reference">Gherkin</a>), diagrams, and solutions for functional and non-functional requirements (<a href="https://iso25000.com/index.php/en/iso-25000-standards/iso-25010">ISO-25010</a>).</p>
 <p>These tools boost delivery. To keep pace, consider a Double Agile Loop for defining User Stories:</p>
-<p><a href="https://www.stride.build/blog/what-is-dual-track-agile-and-how-does-it-work"><img src="/plintch/images/2026/3/double-agile-loop.png" alt="" /></a></p>
+<p><a href="https://www.stride.build/blog/what-is-dual-track-agile-and-how-does-it-work"><img src="/plinth/images/2026/3/double-agile-loop.png" alt="" /></a></p>
 <p><strong>Source:</strong> <a href="https://www.stride.build/blog/what-is-dual-track-agile-and-how-does-it-work">https://www.stride.build/blog/what-is-dual-track-agile-and-how-does-it-work</a></p>
 <h3>Solving a User Story with a Prompt Engineering approach</h3>
 <p>Suppose you pick up this <a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md">User Story</a> from the backlog:</p>
@@ -506,7 +506,7 @@ So that I can perform cross-pantheon analysis and aggregate mythology data for r
 <li><a href="https://code.claude.com/docs/en/common-workflows#use-plan-mode-for-safe-code-analysis">https://code.claude.com/docs/en/common-workflows#use-plan-mode-for-safe-code-analysis</a></li>
 </ul>
 <p>Review and iterate until the Plan is stable, then hand it to the model. Include design artifacts, OAS files, and Gherkin in the context.</p>
-<p><img src="/plintch/images/2026/3/workflow.png" alt="" /></p>
+<p><img src="/plinth/images/2026/3/workflow.png" alt="" /></p>
 <p>Expect to iterate. Have the model verify its own changes rather than doing it manually. <code>AGENTS.md</code> helps here—it documents the technical details the model needs.</p>
 <p>When executing the plan, you can choose:</p>
 <ul>
@@ -515,11 +515,11 @@ So that I can perform cross-pantheon analysis and aggregate mythology data for r
 <li>Implement using London style (outside-in)</li>
 </ul>
 <p>Depending on your preferences, you can build a plan that includes a task list like this:</p>
-<p><img src="/plintch/images/2026/3/plan-task-list-example.png" alt="" /></p>
+<p><img src="/plinth/images/2026/3/plan-task-list-example.png" alt="" /></p>
 <p>Read this section carefully and explore this approach. In the following Git repository, you could find other non-trivial problems: <a href="https://github.com/jabrena/latency-problems">https://github.com/jabrena/latency-problems</a> that you could solve with this approach.</p>
 <h3>Enhance your pipeline with AI Tools</h3>
 <p>If you are interested in adding <code>AI Capabilities</code> to your pipelines:</p>
-<p><img src="/plintch/images/2026/3/workflow-pipelines.png" alt="" /></p>
+<p><img src="/plinth/images/2026/3/workflow-pipelines.png" alt="" /></p>
 <p>I recommend reading the following article: <a href="https://www.javaadvent.com/2025/12/delegating-java-tasks-to-supervised-ai-dev-pipelines.html">https://www.javaadvent.com/2025/12/delegating-java-tasks-to-supervised-ai-dev-pipelines.html</a></p>
 <h2>But not everything is perfect—your repository is full of configuration folders</h2>
 <p>Currently, every product has a particular folder like <code>.cursor</code>, <code>.claude</code>, <code>.agents</code>, <code>.ai</code>, etc. This is horrible, but it is part of the game. At some point, these kinds of configuration folders should be unified, meanwhile, we need to have patience.</p>
@@ -547,7 +547,7 @@ So that I can perform cross-pantheon analysis and aggregate mythology data for r
 </ul>
 <h2>Conclusions</h2>
 <p>If you followed the article, the project is evolving from <code>System prompts</code> to <code>Skills</code>—and continues to advance practices such as curated shared instructions for software teams and <code>AGENTS.md</code>, both recognized in the <a href="https://www.thoughtworks.com/radar/techniques">Thoughtworks Technology Radar</a>. During the time between <a href="https://github.com/jabrena/plinth/releases/tag/0.11.0"><code>v0.11.0</code></a> to <a href="https://github.com/jabrena/plinth/releases/tag/0.12.0"><code>v0.12.0</code></a>, new elements have appeared in the market, such as: <code>Subagents</code>, <code>Commands</code>, <code>Hooks</code>, <code>Plugins</code>, <code>Spec-driven</code>. In the next release, the project will review how to use <code>Skills</code> with <strong>Subagents</strong>.</p>
-<p><img src="/plintch/images/2026/3/subagents.png" alt="" /></p>
+<p><img src="/plinth/images/2026/3/subagents.png" alt="" /></p>
 <p><strong>Source:</strong> <a href="https://code.claude.com/docs/en/agent-teams">https://code.claude.com/docs/en/agent-teams</a></p>
 <p>When you talk with people using these technologies, you notice that software delivery has increased—but design and requirements gathering must keep pace on quality too. If you accelerate delivery without investing in requirements, you end up with fast products that conceal potential design flaws.</p>
 <pre><code>------------- Design phase ----------- | Planning  | ----- Development -----
@@ -559,7 +559,7 @@ Jira / Github / Azure Devops / RedMine &gt; Plan Mode &gt; Agent Mode to deliver
 <p>Putting this in perspective, this kind of product has improved performance so much that you can now pick a complex feature and, if the requirements are complete, execution using techniques like <code>Plan mode</code> will help greatly—without the poor experience from the <a href="https://jabrena.github.io/101-cursor/v010/index.html#/10/15">past (Madrid Jug - May 2025)</a>. Using <code>Plan Mode</code> doesn't require you to change how you organize your requirements, unlike new SDD tools such as Spec-kit.</p>
 <h2>Do you still have questions about the project?</h2>
 <p>If you feel stuck using this project or have questions, you can attend the following Workshop at <code>Codemotion Madrid 2026</code>:</p>
-<p><a href="https://conferences.codemotion.com/madrid/"><img src="/plintch/images/2026/3/codemotion-madrid-2026.jpg" alt="" /></a></p>
+<p><a href="https://conferences.codemotion.com/madrid/"><img src="/plinth/images/2026/3/codemotion-madrid-2026.jpg" alt="" /></a></p>
 <p><a href="https://conferences.codemotion.com/madrid/workshop/">https://conferences.codemotion.com/madrid/workshop/</a></p>
 
 </article>

--- a/docs/blog/2026/03/release-0.12.0.html
+++ b/docs/blog/2026/03/release-0.12.0.html
@@ -122,7 +122,7 @@
 <li>Added a new generator to manage <code>SKILL</code> generation</li>
 <li>Added a validator to ensure good quality in <code>SKILL</code> validation against the <a href="https://agentskills.io/specification">Skill Specification</a></li>
 </ul>
-<p>Let's walk through each feature. You can also review the <a href="https://github.com/jabrena/cursor-rules-java/blob/main/CHANGELOG.md#0120-2026-03-08">CHANGELOG.md</a></p>
+<p>Let's walk through each feature. You can also review the <a href="https://github.com/jabrena/plinth/blob/main/CHANGELOG.md#0120-2026-03-08">CHANGELOG.md</a></p>
 <h2>Why Skills?</h2>
 <p><img src="/plintch/images/2026/3/skills-everywhere.png" alt="" /></p>
 <p>The <a href="https://aws.amazon.com/en/blogs/devops/aws-named-as-a-leader-in-the-2025-gartner-magic-quadrant-for-ai-code-assistants/">AI Assistants</a> market is reshaping how we build software. A growing number of tools offer similar capabilities, yet until recently there was no standard way to extend them across vendors. <code>Cursor</code> pioneered <code>System prompts</code>, but that approach lacked a shared specification for others to adopt. A <code>Skill</code> fills that gap: it extends AI agents with specialized knowledge and workflows that work across different products.</p>
@@ -185,22 +185,22 @@ metadata:
 <li><code>@164-java-profiling-compare</code></li>
 <li><code>@164-java-profiling-verify</code></li>
 </ul>
-<p>Plus others tracked in the <a href="https://github.com/jabrena/cursor-rules-java/issues"><code>Backlog</code></a>.</p>
+<p>Plus others tracked in the <a href="https://github.com/jabrena/plinth/issues"><code>Backlog</code></a>.</p>
 <p>Previously, the project offered a CLI to install System prompts from this repo or any repo with <code>.cursor/rules</code> (or a symlink to it):</p>
 <pre><code class="language-bash">jbang setup@jabrena init \
---cursor https://github.com/jabrena/cursor-rules-java
+--cursor https://github.com/jabrena/plinth
 </code></pre>
 <p>With Skills, <a href="https://vercel.com/"><code>Vercel</code></a> offers a better option at <a href="https://skills.sh/">https://skills.sh/</a>, where you can find and install Skills easily.</p>
 <p>Browse this project's Skills <a href="https://skills.sh/?q=jabrena">here</a> and install them with:</p>
 <pre><code class="language-bash">brew install node
-npx skills add jabrena/cursor-rules-java --list
-npx skills add https://github.com/jabrena/cursor-rules-java \
+npx skills add jabrena/plinth --list
+npx skills add https://github.com/jabrena/plinth \
 --skill 110-java-maven-best-practices
-npx skills install jabrena/cursor-rules-java --all --agent cursor
+npx skills install jabrena/plinth --all --agent cursor
 </code></pre>
 <p>One feature I like: Security pipelines that audit Skills for safety.</p>
-<p><a href="https://skills.sh/jabrena/cursor-rules-java/110-java-maven-best-practices"><img src="/plintch/images/2026/3/skill-security-audit.png" alt="" /></a></p>
-<p><strong>Source:</strong> <a href="https://skills.sh/jabrena/cursor-rules-java/110-java-maven-best-practices">https://skills.sh/jabrena/cursor-rules-java/110-java-maven-best-practices</a></p>
+<p><a href="https://skills.sh/jabrena/plinth/110-java-maven-best-practices"><img src="/plintch/images/2026/3/skill-security-audit.png" alt="" /></a></p>
+<p><strong>Source:</strong> <a href="https://skills.sh/jabrena/plinth/110-java-maven-best-practices">https://skills.sh/jabrena/plinth/110-java-maven-best-practices</a></p>
 <p><strong>Note:</strong> I recommend skills.sh and similar sites—Skills there have passed security audits. Be aware that Skills can include scripts, which may be an attack vector.</p>
 <h3>What are SkillsJars?</h3>
 <p><a href="https://www.webjars.org/">WebJars</a> package popular web libraries for the JVM. <a href="https://www.skillsjars.com/">SkillsJars</a> applies the same idea to Skills: JVM agents can consume Skills as Maven artifacts. It was created by <a href="https://x.com/JamesWard">James Ward</a>.</p>
@@ -211,15 +211,15 @@ npx skills install jabrena/cursor-rules-java --all --agent cursor
 <pre><code class="language-bash">META-INF/
 META-INF/skills/
 META-INF/skills/jabrena/
-META-INF/skills/jabrena/cursor-rules-java/
+META-INF/skills/jabrena/plinth/
 META-INF/maven/
 META-INF/maven/com.skillsjars/
 META-INF/MANIFEST.MF
 META-INF/maven/com.skillsjars/jabrena__cursor-rules-java__111-java-maven-dependencies/pom.xml
 META-INF/maven/com.skillsjars/jabrena__cursor-rules-java__111-java-maven-dependencies/pom.properties
-META-INF/skills/jabrena/cursor-rules-java/111-java-maven-dependencies/SKILL.md
-META-INF/skills/jabrena/cursor-rules-java/111-java-maven-dependencies/references/
-META-INF/skills/jabrena/cursor-rules-java/111-java-maven-dependencies/references/111-java-maven-dependencies.md
+META-INF/skills/jabrena/plinth/111-java-maven-dependencies/SKILL.md
+META-INF/skills/jabrena/plinth/111-java-maven-dependencies/references/
+META-INF/skills/jabrena/plinth/111-java-maven-dependencies/references/111-java-maven-dependencies.md
 </code></pre>
 <p><strong>Source:</strong> <a href="https://central.sonatype.com/artifact/com.skillsjars/jabrena__cursor-rules-java__111-java-maven-dependencies">https://central.sonatype.com/artifact/com.skillsjars/jabrena__cursor-rules-java__111-java-maven-dependencies</a><br />
 <strong>Skill:</strong> <code>@111-java-maven-dependencies</code></p>
@@ -546,7 +546,7 @@ So that I can perform cross-pantheon analysis and aggregate mythology data for r
 <li>Added support to generate <code>AGENTS.md</code> with <code>@173-java-agents</code>: Added this specific missing feature.</li>
 </ul>
 <h2>Conclusions</h2>
-<p>If you followed the article, the project is evolving from <code>System prompts</code> to <code>Skills</code>—and continues to advance practices such as curated shared instructions for software teams and <code>AGENTS.md</code>, both recognized in the <a href="https://www.thoughtworks.com/radar/techniques">Thoughtworks Technology Radar</a>. During the time between <a href="https://github.com/jabrena/cursor-rules-java/releases/tag/0.11.0"><code>v0.11.0</code></a> to <a href="https://github.com/jabrena/cursor-rules-java/releases/tag/0.12.0"><code>v0.12.0</code></a>, new elements have appeared in the market, such as: <code>Subagents</code>, <code>Commands</code>, <code>Hooks</code>, <code>Plugins</code>, <code>Spec-driven</code>. In the next release, the project will review how to use <code>Skills</code> with <strong>Subagents</strong>.</p>
+<p>If you followed the article, the project is evolving from <code>System prompts</code> to <code>Skills</code>—and continues to advance practices such as curated shared instructions for software teams and <code>AGENTS.md</code>, both recognized in the <a href="https://www.thoughtworks.com/radar/techniques">Thoughtworks Technology Radar</a>. During the time between <a href="https://github.com/jabrena/plinth/releases/tag/0.11.0"><code>v0.11.0</code></a> to <a href="https://github.com/jabrena/plinth/releases/tag/0.12.0"><code>v0.12.0</code></a>, new elements have appeared in the market, such as: <code>Subagents</code>, <code>Commands</code>, <code>Hooks</code>, <code>Plugins</code>, <code>Spec-driven</code>. In the next release, the project will review how to use <code>Skills</code> with <strong>Subagents</strong>.</p>
 <p><img src="/plintch/images/2026/3/subagents.png" alt="" /></p>
 <p><strong>Source:</strong> <a href="https://code.claude.com/docs/en/agent-teams">https://code.claude.com/docs/en/agent-teams</a></p>
 <p>When you talk with people using these technologies, you notice that software delivery has increased—but design and requirements gathering must keep pace on quality too. If you accelerate delivery without investing in requirements, you end up with fast products that conceal potential design flaws.</p>
@@ -581,7 +581,7 @@ Jira / Github / Azure Devops / RedMine &gt; Plan Mode &gt; Agent Mode to deliver
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/blog/2026/03/release-0.13.0.html
+++ b/docs/blog/2026/03/release-0.13.0.html
@@ -200,14 +200,14 @@
 <li><code>@522-frameworks-micronaut-testing-integration-tests</code></li>
 <li><code>@523-frameworks-micronaut-testing-acceptance-tests</code></li>
 </ul>
-<p>Let's walk through each feature. You can also review the <a href="https://github.com/jabrena/cursor-rules-java/blob/main/CHANGELOG.md#0130-2026-03-30">CHANGELOG</a>.</p>
+<p>Let's walk through each feature. You can also review the <a href="https://github.com/jabrena/plinth/blob/main/CHANGELOG.md#0130-2026-03-30">CHANGELOG</a>.</p>
 <h2>What workflows were updated in this release?</h2>
 <h3>Local workflows</h3>
 <p>Now, <code>Product Owners</code> and <code>Business Analysts</code> have new tools to improve thin, one-line user stories, and <code>Architects</code> can take part in development by adding <code>ADRs</code> asynchronously. With that context, you can validate those documents for inconsistencies using the new agent. When the documents are aligned, the <code>Software Engineer</code> can draft a plan and refine it with the Plan mode skill (<code>@040-planning-plan-mode</code>). After the plan is reviewed, you can hand it off to the new <code>Coordinator Agent</code>, which owns end-to-end development.</p>
-<p>Take a look at the following <a href="https://github.com/jabrena/cursor-rules-java/blob/main/documentation/guides/GETTING-STARTED-SKILLS.md">Getting Started</a> guide for further details.</p>
+<p>Take a look at the following <a href="https://github.com/jabrena/plinth/blob/main/documentation/guides/GETTING-STARTED-SKILLS.md">Getting Started</a> guide for further details.</p>
 <h3>CI/CD Pipeline workflows</h3>
 <p>With the new improvements for architectural tasks, it is now easier to keep architecture diagrams current—including C4 views, data mapping, business glossary documentation, and database ER diagrams.</p>
-<p>Take a look at the following <a href="https://github.com/jabrena/cursor-rules-java/blob/main/documentation/guides/GETTING-STARTED-PIPELINES.md">Getting Started</a> guide for further details.</p>
+<p>Take a look at the following <a href="https://github.com/jabrena/plinth/blob/main/documentation/guides/GETTING-STARTED-PIPELINES.md">Getting Started</a> guide for further details.</p>
 <hr />
 <p>Drawing on ideas from others, it is impressive to see the new processes that <a href="https://x.com/juanmacias">Juan Macias</a> is developing:</p>
 <p><a href="https://x.com/juanmacias/status/2037973784674611648?s=20"><img src="/plintch/images/2026/3/juan-macias.png" alt="" /></a></p>
@@ -230,8 +230,8 @@
 <p>Currently, there is lively debate about which online Skill registry is best.<br />
 You can find the Skills from this project on several sites.</p>
 <ul>
-<li><a href="https://skills.sh/jabrena/cursor-rules-java">https://skills.sh/jabrena/cursor-rules-java</a></li>
-<li><a href="https://tessl.io/registry/skills/github/jabrena/cursor-rules-java">https://tessl.io/registry/skills/github/jabrena/cursor-rules-java</a></li>
+<li><a href="https://skills.sh/jabrena/plinth">https://skills.sh/jabrena/plinth</a></li>
+<li><a href="https://tessl.io/registry/skills/github/jabrena/plinth">https://tessl.io/registry/skills/github/jabrena/plinth</a></li>
 <li><a href="https://agent-skills.cc/zh/skills/jabrena-cursor-rules-java">https://agent-skills.cc/zh/skills/jabrena-cursor-rules-java</a></li>
 <li><a href="https://skillsmp.com/skills/jabrena-cursor-rules-java-skills-014-agile-user-story-skill-md">https://skillsmp.com/skills/jabrena-cursor-rules-java-skills-014-agile-user-story-skill-md</a></li>
 </ul>
@@ -340,7 +340,7 @@ reliable access to curated deity information.
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/blog/2026/03/release-0.13.0.html
+++ b/docs/blog/2026/03/release-0.13.0.html
@@ -210,7 +210,7 @@
 <p>Take a look at the following <a href="https://github.com/jabrena/plinth/blob/main/documentation/guides/GETTING-STARTED-PIPELINES.md">Getting Started</a> guide for further details.</p>
 <hr />
 <p>Drawing on ideas from others, it is impressive to see the new processes that <a href="https://x.com/juanmacias">Juan Macias</a> is developing:</p>
-<p><a href="https://x.com/juanmacias/status/2037973784674611648?s=20"><img src="/plintch/images/2026/3/juan-macias.png" alt="" /></a></p>
+<p><a href="https://x.com/juanmacias/status/2037973784674611648?s=20"><img src="/plinth/images/2026/3/juan-macias.png" alt="" /></a></p>
 <p>I recommend reading <a href="https://thebrokentelephone.com/">The broken telephone</a> and the associated <a href="https://github.com/darkspock/thebrokentelephone_sample">GitHub repository</a>.</p>
 <h2>Finally, the Java frameworks have arrived!</h2>
 <p>Initial Spring Boot support was added in another <a href="https://github.com/jabrena/cursor-rules-spring-boot">repository</a>; but in this release, that support was merged here and extended. The project now covers the main Java frameworks—Spring Boot, Quarkus, and Micronaut—on Maven.</p>
@@ -285,11 +285,11 @@ reliable access to curated deity information.
 <p><strong>Note:</strong> Remember to have <code>AGENTS.md</code>/<code>CLAUDE.md</code> in your repository to close the loop to verify your development. If you don´t know how to create that file, you can use <code>@200-agents-md</code>.</p>
 <p>When the plan is revised and you agree with it, you can invoke the new Agent: <code>/robot-coordinator</code> to implement the full plan or the first milestone.</p>
 <p>This agent will review the plan and repository and, depending on the context, it will delegate the coding tasks to a specific agent. Specialized agents are currently available for Pure Java, Spring Boot, Quarkus, and Micronaut.</p>
-<p><img src="/plintch/images/2026/3/robot-coordinator-example.jpg" alt="" /></p>
+<p><img src="/plinth/images/2026/3/robot-coordinator-example.jpg" alt="" /></p>
 <p>When you achieve the first milestone, you can review whether the implementation matches the coding standards and continue until the end of all tasks in the task list.</p>
-<p><img src="/plintch/images/2026/3/robot-quarkus-coder-example.jpg" alt="" /></p>
+<p><img src="/plinth/images/2026/3/robot-quarkus-coder-example.jpg" alt="" /></p>
 <p>Using incremental review, you can minimize potential deviations and commit small parts.</p>
-<p><img src="/plintch/images/2026/3/robot-coordinator-example2.png" alt="" /></p>
+<p><img src="/plinth/images/2026/3/robot-coordinator-example2.png" alt="" /></p>
 <p>If you have good ADRs and you invested time in a plan, the time spent on refactorings should be minimized. Indeed, I recommend making small commits per milestone.</p>
 <h2>What is the next step?</h2>
 <h3>Internal changes in the generators</h3>
@@ -318,7 +318,7 @@ reliable access to curated deity information.
 </ul>
 <h2>Do you still have questions about the project?</h2>
 <p>If you feel stuck using this project or have questions, you can attend the following workshop at <code>Codemotion Madrid 2026</code>:</p>
-<p><a href="https://conferences.codemotion.com/madrid/"><img src="/plintch/images/2026/3/codemotion-madrid-2026.jpg" alt="" /></a></p>
+<p><a href="https://conferences.codemotion.com/madrid/"><img src="/plinth/images/2026/3/codemotion-madrid-2026.jpg" alt="" /></a></p>
 <p><a href="https://conferences.codemotion.com/madrid/workshop/">https://conferences.codemotion.com/madrid/workshop/</a></p>
 
 </article>

--- a/docs/blog/2026/04/release-0.14.0.html
+++ b/docs/blog/2026/04/release-0.14.0.html
@@ -103,12 +103,12 @@
 <article role="main" class="blog-post">
 <h2>What are Cursor rules for Java?</h2>
 <p>A curated and opinionated collection of <code>Skills</code> and <code>Agents</code> to be used in modern <code>SDLC</code> workflows for Java Enterprise development with your favorite AI Agent harness.</p>
-<p><img src="/plintch/images/2026/4/scope.png" alt="" /></p>
+<p><img src="/plinth/images/2026/4/scope.png" alt="" /></p>
 <p>Thanks to our community members in <code>Singapore</code>, <code>Chengdu</code>, <code>Hanoi</code>, <code>Copenhagen</code>, and <code>Quito</code>. 👋👋👋</p>
 <h2>What's new in this release?</h2>
 <h3>Rules support dropped in favor of Skills</h3>
 <p>Until this release, the project maintained three very different deliverables: Rules, Skills, and Agents. <code>Rules</code> and <code>Skills</code> both guide model behavior in broadly similar ways, but Rules were Cursor’s approach while <code>Skills</code> have recently become the standard, so consolidating on a single solution makes more sense. <strong>On the other hand</strong>, maintaining a single generator (<code>skills-generator</code>) made it possible to improve how skills are packaged, which was somewhat constrained when both <code>rules-generator</code> and <code>skills-generator</code> existed. If you followed the various <a href="https://github.com/jabrena/plinth/tree/main/documentation/adr">ADRs published</a> in the repository, you could see why the project preserves the same guidance while adopting Skills-based packaging. In previous months, users developed or refactored code using <code>System prompts/Rules</code> in this way:</p>
-<p><img src="/plintch/images/2026/4/manual-trigger.png" alt="" /></p>
+<p><img src="/plinth/images/2026/4/manual-trigger.png" alt="" /></p>
 <p>But now, you can do the same by adding the Skill to the context of your favorite <code>AI Agent harness</code>. You can add the Skill you want to the context explicitly, or leave it to the AI tool to use or skip depending on the context—so you can achieve the same outcomes with Skills as you could with system prompts in the past.</p>
 <p>On the main branch, a few resources about <code>System-prompts/rules</code> remain temporarily; we still see web traffic for them:</p>
 <ul>
@@ -126,7 +126,7 @@
 <h3>Improvements in the planning process</h3>
 <p>It is tedious to copy issue details from your issue tracker into the context of whichever AI tool you use. With that in mind, you can now access assigned issues more easily if you work with <code>GitHub Issues</code> or <code>Jira</code>. Those <code>Skills</code> combine well with <code>@014-agile-user-story</code> to turn the classic <code>Anemic one-line User Story</code> into something richer.</p>
 <p>Once the information is <code>ready for development</code>, you can convert it into a <code>Change</code> or <code>Delta</code> using <code>OpenSpec</code>.</p>
-<p><img src="/plintch/images/2026/4/issue-to-openspec.png" alt="" /></p>
+<p><img src="/plinth/images/2026/4/issue-to-openspec.png" alt="" /></p>
 <h4>How does OpenSpec work?</h4>
 <p>OpenSpec is a spec-driven change workflow: you capture what you want and how you will verify it before (or alongside) changing code and generators.</p>
 <p>The scaffolding for any project using OpenSpec looks like this:</p>
@@ -153,7 +153,7 @@ openspec archive &lt;change-name&gt;
 <p>If you pick up a user story from any issue-tracking tool and it relates to a service you know well, you can use the following workflow directly:</p>
 <pre><code class="language-bash">User story &gt; Create a Change in OpenSpec &gt; Implement with Java Agents
 </code></pre>
-<p><img src="/plintch/images/2026/4/implement-openspec-change.png" alt="" /></p>
+<p><img src="/plinth/images/2026/4/implement-openspec-change.png" alt="" /></p>
 <p>But if you are less sure about the assigned user story, invest more time in the analysis phase:</p>
 <pre><code class="language-bash">User story &gt; Create a Plan &gt; Enhance the plan &gt; Convert into multiple Changes in OpenSpec &gt; Implement with Java Agents
 </code></pre>
@@ -184,7 +184,7 @@ openspec archive &lt;change-name&gt;
 </ul>
 <h4>Reinforced REST API desing and testing</h4>
 <p>Now, you can review and harden <strong>OpenAPI 3.x</strong> contracts with <code>@701-technologies-openapi</code> when the specification still needs work. As you develop integration tests, you can strengthen them with <strong>HTTP stubs</strong> from <strong>WireMock</strong> using <code>@702-technologies-wiremock</code>. Finally, if you want <strong>black-box testing</strong> driven by your OpenAPI specification, <code>@703-technologies-fuzzing-testing</code> based on <strong>CATS</strong> can help surface defects through contract-driven negative testing, malformed and boundary inputs, and related edge cases.</p>
-<p><a href="https://endava.github.io/cats/"><img src="/plintch/images/2026/4/cats.png" alt="" /></a></p>
+<p><a href="https://endava.github.io/cats/"><img src="/plinth/images/2026/4/cats.png" alt="" /></a></p>
 <p>Further information about CATS: <a href="https://github.com/Endava/cats">https://github.com/Endava/cats</a></p>
 <p><strong>Skills</strong></p>
 <ul>
@@ -246,7 +246,7 @@ npx skills add jabrena/plinth --all --agent claude-code
 <p>Separately, the Skills need a few improvements to increase quality, so we will use notes from <a href="https://tessl.io/registry">Tessl</a>.</p>
 <h2>Do you still have questions about the project?</h2>
 <p>If you feel stuck using this project or have questions, you can attend the following workshop at <code>Codemotion Madrid 2026</code>:</p>
-<p><a href="https://conferences.codemotion.com/madrid/"><img src="/plintch/images/2026/3/codemotion-madrid-2026.jpg" alt="" /></a></p>
+<p><a href="https://conferences.codemotion.com/madrid/"><img src="/plinth/images/2026/3/codemotion-madrid-2026.jpg" alt="" /></a></p>
 <p><a href="https://conferences.codemotion.com/madrid/workshop/">https://conferences.codemotion.com/madrid/workshop/</a></p>
 
 </article>

--- a/docs/blog/2026/04/release-0.14.0.html
+++ b/docs/blog/2026/04/release-0.14.0.html
@@ -107,16 +107,16 @@
 <p>Thanks to our community members in <code>Singapore</code>, <code>Chengdu</code>, <code>Hanoi</code>, <code>Copenhagen</code>, and <code>Quito</code>. 👋👋👋</p>
 <h2>What's new in this release?</h2>
 <h3>Rules support dropped in favor of Skills</h3>
-<p>Until this release, the project maintained three very different deliverables: Rules, Skills, and Agents. <code>Rules</code> and <code>Skills</code> both guide model behavior in broadly similar ways, but Rules were Cursor’s approach while <code>Skills</code> have recently become the standard, so consolidating on a single solution makes more sense. <strong>On the other hand</strong>, maintaining a single generator (<code>skills-generator</code>) made it possible to improve how skills are packaged, which was somewhat constrained when both <code>rules-generator</code> and <code>skills-generator</code> existed. If you followed the various <a href="https://github.com/jabrena/cursor-rules-java/tree/main/documentation/adr">ADRs published</a> in the repository, you could see why the project preserves the same guidance while adopting Skills-based packaging. In previous months, users developed or refactored code using <code>System prompts/Rules</code> in this way:</p>
+<p>Until this release, the project maintained three very different deliverables: Rules, Skills, and Agents. <code>Rules</code> and <code>Skills</code> both guide model behavior in broadly similar ways, but Rules were Cursor’s approach while <code>Skills</code> have recently become the standard, so consolidating on a single solution makes more sense. <strong>On the other hand</strong>, maintaining a single generator (<code>skills-generator</code>) made it possible to improve how skills are packaged, which was somewhat constrained when both <code>rules-generator</code> and <code>skills-generator</code> existed. If you followed the various <a href="https://github.com/jabrena/plinth/tree/main/documentation/adr">ADRs published</a> in the repository, you could see why the project preserves the same guidance while adopting Skills-based packaging. In previous months, users developed or refactored code using <code>System prompts/Rules</code> in this way:</p>
 <p><img src="/plintch/images/2026/4/manual-trigger.png" alt="" /></p>
 <p>But now, you can do the same by adding the Skill to the context of your favorite <code>AI Agent harness</code>. You can add the Skill you want to the context explicitly, or leave it to the AI tool to use or skip depending on the context—so you can achieve the same outcomes with Skills as you could with system prompts in the past.</p>
 <p>On the main branch, a few resources about <code>System-prompts/rules</code> remain temporarily; we still see web traffic for them:</p>
 <ul>
-<li>All rules from v0.13.0: <a href="https://github.com/jabrena/cursor-rules-java/tree/main/.cursor/rules">https://github.com/jabrena/cursor-rules-java/tree/main/.cursor/rules</a></li>
-<li>Getting Started: <a href="https://github.com/jabrena/cursor-rules-java/blob/main/documentation/guides/GETTING-STARTED-SYSTEM-PROMPTS.md">https://github.com/jabrena/cursor-rules-java/blob/main/documentation/guides/GETTING-STARTED-SYSTEM-PROMPTS.md</a></li>
+<li>All rules from v0.13.0: <a href="https://github.com/jabrena/plinth/tree/main/.cursor/rules">https://github.com/jabrena/plinth/tree/main/.cursor/rules</a></li>
+<li>Getting Started: <a href="https://github.com/jabrena/plinth/blob/main/documentation/guides/GETTING-STARTED-SYSTEM-PROMPTS.md">https://github.com/jabrena/plinth/blob/main/documentation/guides/GETTING-STARTED-SYSTEM-PROMPTS.md</a></li>
 </ul>
-<p>That usage is <code>deprecated</code> in favor of <code>Skills</code> and will be removed in the coming months; review <a href="https://github.com/jabrena/cursor-rules-java?tab=readme-ov-file#deliverables">the new documentation</a> and adapt your process or pipelines.</p>
-<p>Separately, you can still download the last generated <code>System prompts/rules</code> from <a href="https://github.com/jabrena/cursor-rules-java/releases/tag/0.13.0">release 0.13.0</a> if you need them, but development is frozen in favor of the <a href="https://agentskills.io/specification">Skill Standard</a>.</p>
+<p>That usage is <code>deprecated</code> in favor of <code>Skills</code> and will be removed in the coming months; review <a href="https://github.com/jabrena/plinth?tab=readme-ov-file#deliverables">the new documentation</a> and adapt your process or pipelines.</p>
+<p>Separately, you can still download the last generated <code>System prompts/rules</code> from <a href="https://github.com/jabrena/plinth/releases/tag/0.13.0">release 0.13.0</a> if you need them, but development is frozen in favor of the <a href="https://agentskills.io/specification">Skill Standard</a>.</p>
 <h3>Improvements in the Agile process</h3>
 <p>When you create a <code>User Story</code>, the flow not only generates the usual structure and acceptance criteria in <code>Gherkin</code> format, but it also reviews the user story as a whole using <code>INVEST</code>. INVEST is an acronym used in Agile to evaluate the quality of a user story, ensuring it is <code>Independent</code>, <code>Negotiable</code>, <code>Valuable</code>, <code>Estimable</code>, <code>Small</code>, and <code>Testable</code>.</p>
 <p><strong>Skills:</strong></p>
@@ -195,8 +195,8 @@ openspec archive &lt;change-name&gt;
 <h3>Skill inventory</h3>
 <p>In version <code>v0.14.0</code>, the project ships <code>68 Skills</code>.</p>
 <p>You can install the <code>Skills</code> easily with:</p>
-<pre><code class="language-bash">npx skills add jabrena/cursor-rules-java --all --agent cursor
-npx skills add jabrena/cursor-rules-java --all --agent claude-code
+<pre><code class="language-bash">npx skills add jabrena/plinth --all --agent cursor
+npx skills add jabrena/plinth --all --agent claude-code
 </code></pre>
 <p>Once you have the skills installed, you can install the <code>Agents</code> with:</p>
 <pre><code>@005-agents-installation Install Agents in Cursor
@@ -268,7 +268,7 @@ npx skills add jabrena/cursor-rules-java --all --agent claude-code
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/blog/2026/06/from-code-generation-to-software-engineering.html
+++ b/docs/blog/2026/06/from-code-generation-to-software-engineering.html
@@ -229,7 +229,7 @@
 <p><code>@056-design-avoid-breaking-changes</code> gives the agent a review posture before it changes those surfaces. The goal is not to forbid breaking changes forever. The goal is to make them deliberate, documented, versioned, and coordinated.</p>
 <h2>Share your experience</h2>
 <p>If you are using these workflows, experimenting with OpenSpec, or trying to introduce design skills into AI-assisted delivery, share your experience with the project.</p>
-<p>Use <a href="https://github.com/jabrena/cursor-rules-java/discussions">GitHub Discussions</a> to post what is working, where the workflow feels unclear, which doubts you have, and what worries you about applying agents to real Java systems.</p>
+<p>Use <a href="https://github.com/jabrena/plinth/discussions">GitHub Discussions</a> to post what is working, where the workflow feels unclear, which doubts you have, and what worries you about applying agents to real Java systems.</p>
 <p>Those conversations help improve the skills, the documentation, and the project workflow itself.</p>
 
 </article>
@@ -251,7 +251,7 @@
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/blog/2026/06/introduction-to-eu-regulations-part-i.html
+++ b/docs/blog/2026/06/introduction-to-eu-regulations-part-i.html
@@ -288,7 +288,7 @@ Goal: produce an engineering review report with gaps, owner handoffs, release de
 </code></pre>
 <p>Compliance is a qualified governance decision. These skills help engineering teams prepare the evidence that makes that decision possible.</p>
 <h2>Example: ecommerce CI/CD PR model</h2>
-<p>As a practical example, consider <a href="https://github.com/jabrena/cursor-rules-java/blob/main/examples/diagrams/deployment/system-example-cicd-pr-model.md">system-example-cicd-pr-model.md</a>.</p>
+<p>As a practical example, consider <a href="https://github.com/jabrena/plinth/blob/main/examples/diagrams/deployment/system-example-cicd-pr-model.md">system-example-cicd-pr-model.md</a>.</p>
 <pre><code class="language-text">                           +----------------------+
                            |       Shopper        |
                            | Web browser / mobile |
@@ -461,7 +461,7 @@ Goal: produce an engineering review report with gaps, owner handoffs, release de
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/blog/2026/06/release-0.15.0.html
+++ b/docs/blog/2026/06/release-0.15.0.html
@@ -128,23 +128,23 @@
 <li><strong>Social engineering and trigger abuse:</strong> A skill can use misleading names, vague triggers, or urgent instructions to make agents or users invoke it in the wrong context. Covered by <code>Cisco AI Skill Scanner</code> and <code>SkillSpector</code>.</li>
 </ul>
 <p>The project provides scanners, and when you use <code>Skills.sh</code>, a popular skills registry, every entry must pass three validations.</p>
-<p><strong>Example:</strong> <a href="https://www.skills.sh/jabrena/cursor-rules-java/110-java-maven-best-practices">https://www.skills.sh/jabrena/cursor-rules-java/110-java-maven-best-practices</a></p>
+<p><strong>Example:</strong> <a href="https://www.skills.sh/jabrena/plinth/110-java-maven-best-practices">https://www.skills.sh/jabrena/plinth/110-java-maven-best-practices</a></p>
 <h3>Improvements in Java Enterprise frameworks</h3>
 <p>In this release, the project continues to add new features to improve support for <code>Spring Boot</code>, <code>Quarkus</code> &amp; <code>Micronaut</code>. The new skills added for all frameworks cover the following aspects:</p>
 <ul>
-<li><strong>Data Validation:</strong> <a href="https://www.skills.sh/jabrena/cursor-rules-java/303-frameworks-spring-boot-validation"><code>@303-frameworks-spring-boot-validation</code></a>, <a href="https://www.skills.sh/jabrena/cursor-rules-java/403-frameworks-quarkus-validation"><code>@403-frameworks-quarkus-validation</code></a> &amp; <a href="https://www.skills.sh/jabrena/cursor-rules-java/503-frameworks-micronaut-validation"><code>@503-frameworks-micronaut-validation</code></a></li>
-<li><strong>Security:</strong> <a href="https://www.skills.sh/jabrena/cursor-rules-java/304-frameworks-spring-boot-security"><code>@304-frameworks-spring-boot-security</code></a>, <a href="https://www.skills.sh/jabrena/cursor-rules-java/404-frameworks-quarkus-security"><code>@404-frameworks-quarkus-security</code></a> &amp; <a href="https://www.skills.sh/jabrena/cursor-rules-java/504-frameworks-micronaut-security"><code>@504-frameworks-micronaut-security</code></a></li>
-<li><strong>Kafka:</strong> <a href="https://www.skills.sh/jabrena/cursor-rules-java/314-frameworks-spring-kafka"><code>@314-frameworks-spring-kafka</code></a>, <a href="https://www.skills.sh/jabrena/cursor-rules-java/414-frameworks-quarkus-kafka"><code>@414-frameworks-quarkus-kafka</code></a> &amp; <a href="https://www.skills.sh/jabrena/cursor-rules-java/514-frameworks-micronaut-kafka"><code>@514-frameworks-micronaut-kafka</code></a></li>
-<li><strong>MongoDB:</strong> <a href="https://www.skills.sh/jabrena/cursor-rules-java/315-frameworks-spring-mongodb"><code>@315-frameworks-spring-mongodb</code></a>, <a href="https://www.skills.sh/jabrena/cursor-rules-java/415-frameworks-quarkus-mongodb"><code>@415-frameworks-quarkus-mongodb</code></a> &amp; <a href="https://www.skills.sh/jabrena/cursor-rules-java/515-frameworks-micronaut-mongodb"><code>@515-frameworks-micronaut-mongodb</code></a></li>
+<li><strong>Data Validation:</strong> <a href="https://www.skills.sh/jabrena/plinth/303-frameworks-spring-boot-validation"><code>@303-frameworks-spring-boot-validation</code></a>, <a href="https://www.skills.sh/jabrena/plinth/403-frameworks-quarkus-validation"><code>@403-frameworks-quarkus-validation</code></a> &amp; <a href="https://www.skills.sh/jabrena/plinth/503-frameworks-micronaut-validation"><code>@503-frameworks-micronaut-validation</code></a></li>
+<li><strong>Security:</strong> <a href="https://www.skills.sh/jabrena/plinth/304-frameworks-spring-boot-security"><code>@304-frameworks-spring-boot-security</code></a>, <a href="https://www.skills.sh/jabrena/plinth/404-frameworks-quarkus-security"><code>@404-frameworks-quarkus-security</code></a> &amp; <a href="https://www.skills.sh/jabrena/plinth/504-frameworks-micronaut-security"><code>@504-frameworks-micronaut-security</code></a></li>
+<li><strong>Kafka:</strong> <a href="https://www.skills.sh/jabrena/plinth/314-frameworks-spring-kafka"><code>@314-frameworks-spring-kafka</code></a>, <a href="https://www.skills.sh/jabrena/plinth/414-frameworks-quarkus-kafka"><code>@414-frameworks-quarkus-kafka</code></a> &amp; <a href="https://www.skills.sh/jabrena/plinth/514-frameworks-micronaut-kafka"><code>@514-frameworks-micronaut-kafka</code></a></li>
+<li><strong>MongoDB:</strong> <a href="https://www.skills.sh/jabrena/plinth/315-frameworks-spring-mongodb"><code>@315-frameworks-spring-mongodb</code></a>, <a href="https://www.skills.sh/jabrena/plinth/415-frameworks-quarkus-mongodb"><code>@415-frameworks-quarkus-mongodb</code></a> &amp; <a href="https://www.skills.sh/jabrena/plinth/515-frameworks-micronaut-mongodb"><code>@515-frameworks-micronaut-mongodb</code></a></li>
 </ul>
 <h3>Improvements in observability</h3>
 <p>Observability is an essential aspect of any application:</p>
 <p><a href="https://developers.redhat.com/blog/2016/12/09/spring-cloud-for-microservices-compared-to-kubernetes"><img src="/plintch/images/2026/6/ms-concerns.webp" alt="" /></a></p>
 <p>In this release, we completed support for the main concepts related to observability: <code>Logging</code>, <code>Metrics</code> &amp; <code>Tracing</code>:</p>
 <ul>
-<li><strong>Logging:</strong> <a href="https://www.skills.sh/jabrena/cursor-rules-java/181-java-observability-logging"><code>@181-java-observability-logging</code></a></li>
-<li><strong>Metrics:</strong> <a href="https://www.skills.sh/jabrena/cursor-rules-java/182-java-observability-metrics-micrometer"><code>@182-java-observability-metrics-micrometer</code></a></li>
-<li><strong>Tracing:</strong> <a href="https://www.skills.sh/jabrena/cursor-rules-java/183-java-observability-tracing-opentelemetry"><code>@183-java-observability-tracing-opentelemetry</code></a></li>
+<li><strong>Logging:</strong> <a href="https://www.skills.sh/jabrena/plinth/181-java-observability-logging"><code>@181-java-observability-logging</code></a></li>
+<li><strong>Metrics:</strong> <a href="https://www.skills.sh/jabrena/plinth/182-java-observability-metrics-micrometer"><code>@182-java-observability-metrics-micrometer</code></a></li>
+<li><strong>Tracing:</strong> <a href="https://www.skills.sh/jabrena/plinth/183-java-observability-tracing-opentelemetry"><code>@183-java-observability-tracing-opentelemetry</code></a></li>
 </ul>
 <p>Now, using any supported framework with OTEL, you can easily send continuous profiling data to Grafana:</p>
 <p><img src="/plintch/images/2026/6/piroscope-demo.png" alt="" /></p>
@@ -156,9 +156,9 @@
 <h3>Better documentation</h3>
 <p>The project now provides documentation in three languages:</p>
 <ul>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/README.md"><code>English</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/README_ZH.md"><code>Chinese</code></a></li>
-<li><a href="https://github.com/jabrena/cursor-rules-java/blob/main/README_ES.md"><code>Spanish</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/README.md"><code>English</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/README_ZH.md"><code>Chinese</code></a></li>
+<li><a href="https://github.com/jabrena/plinth/blob/main/README_ES.md"><code>Spanish</code></a></li>
 </ul>
 <h2>Evolution of this project in Vercel's Skills registry</h2>
 <p>The ecosystem is large, so you will need your own criteria beyond whether this project fits your preferences.</p>
@@ -184,7 +184,7 @@
 <h3>The experience in Codemotion Madrid 2026</h3>
 <p>Last month, the project was presented and used at the tech conference <code>Codemotion Madrid 2026</code>. The workshop had sold out a few weeks before, and participants rated the session 4.5/5.</p>
 <p><a href="https://conferences.codemotion.com/madrid/"><img src="/plintch/images/2026/6/codemotion-madrid-workshop.jpg" alt="" /></a></p>
-<p><strong>Slides:</strong> <a href="https://jabrena.github.io/cursor-rules-java/codemotion-madrid-2026/index.html">https://jabrena.github.io/cursor-rules-java/codemotion-madrid-2026/index.html</a></p>
+<p><strong>Slides:</strong> <a href="https://github.com/jabrena/plinth">jabrena/plinth</a></p>
 <h3>The experience in JMad 2026</h3>
 <p>Every year, <code>MadridJUG</code> organizes <code>JMad</code>, a Java tech event based on <code>OpenSpace</code>.</p>
 <p><a href="https://jmad.madridjug.es/"><img src="/plintch/images/2026/6/IMG_8268.jpg" alt="" /></a></p>
@@ -213,7 +213,7 @@
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/blog/2026/06/release-0.15.0.html
+++ b/docs/blog/2026/06/release-0.15.0.html
@@ -104,9 +104,9 @@
 <h2>What is the purpose?</h2>
 <p>An opinionated, AI-native workflow for evolving modern Java Enterprise <code>SDLC</code> practices through reusable <code>Skills</code>, <code>Agents</code>, and <code>MCP servers</code>.</p>
 <p>It helps you answer the <code>Five Whys</code> when your team needs to evolve a Java-based product or service:</p>
-<p><img src="/plintch/images/2026/6/scope.png" alt="" /></p>
+<p><img src="/plinth/images/2026/6/scope.png" alt="" /></p>
 <p>Once the idea is clear, you can implement it in a structured way:</p>
-<p><img src="/plintch/images/2026/6/workflow.png" alt="" /></p>
+<p><img src="/plinth/images/2026/6/workflow.png" alt="" /></p>
 <p>Thanks to our community members in <code>Singapore</code>, <code>Hanoi</code>, <code>Hong Kong</code>, <code>Milan</code>, and <code>New York</code>. 👋👋👋</p>
 <p><strong>Note:</strong> <a href="https://github.com/sponsors/jabrena">If you love this project and use it, you can support it to help pay the token bills.</a></p>
 <h2>What's new in this release?</h2>
@@ -139,7 +139,7 @@
 </ul>
 <h3>Improvements in observability</h3>
 <p>Observability is an essential aspect of any application:</p>
-<p><a href="https://developers.redhat.com/blog/2016/12/09/spring-cloud-for-microservices-compared-to-kubernetes"><img src="/plintch/images/2026/6/ms-concerns.webp" alt="" /></a></p>
+<p><a href="https://developers.redhat.com/blog/2016/12/09/spring-cloud-for-microservices-compared-to-kubernetes"><img src="/plinth/images/2026/6/ms-concerns.webp" alt="" /></a></p>
 <p>In this release, we completed support for the main concepts related to observability: <code>Logging</code>, <code>Metrics</code> &amp; <code>Tracing</code>:</p>
 <ul>
 <li><strong>Logging:</strong> <a href="https://www.skills.sh/jabrena/plinth/181-java-observability-logging"><code>@181-java-observability-logging</code></a></li>
@@ -147,11 +147,11 @@
 <li><strong>Tracing:</strong> <a href="https://www.skills.sh/jabrena/plinth/183-java-observability-tracing-opentelemetry"><code>@183-java-observability-tracing-opentelemetry</code></a></li>
 </ul>
 <p>Now, using any supported framework with OTEL, you can easily send continuous profiling data to Grafana:</p>
-<p><img src="/plintch/images/2026/6/piroscope-demo.png" alt="" /></p>
+<p><img src="/plinth/images/2026/6/piroscope-demo.png" alt="" /></p>
 <p><a href="https://grafana.com/oss/pyroscope/">https://grafana.com/oss/pyroscope/</a></p>
 <h3>Improvements in testing</h3>
 <p>In this release, fuzz testing was improved to make it easier to use: <code>@703-technologies-fuzzing-testing</code>.</p>
-<p><img src="/plintch/images/2026/6/cats.png" alt="" /></p>
+<p><img src="/plinth/images/2026/6/cats.png" alt="" /></p>
 <p><a href="https://github.com/Endava/cats">https://github.com/Endava/cats</a></p>
 <h3>Better documentation</h3>
 <p>The project now provides documentation in three languages:</p>
@@ -173,24 +173,24 @@
 </ul>
 <h2>Using the project in IDEs</h2>
 <h3>Codex</h3>
-<p><img src="/plintch/images/2026/6/codex.png" alt="" /></p>
+<p><img src="/plinth/images/2026/6/codex.png" alt="" /></p>
 <p>Recently, I tested Codex running in <code>VS Code</code>, and the experience was fantastic. Codex understands <code>AGENTS.md</code> and skills located in <code>.agents/skills</code>.</p>
 <p>Using Codex, you can run the <code>Agents</code> provided by the project without any changes.</p>
 <h3>Magic Quadrant update</h3>
 <p>Recently, Gartner updated the Magic Quadrant.</p>
-<p><img src="/plintch/images/2026/6/magic-cuadrant-agents.jpg" alt="" /></p>
+<p><img src="/plinth/images/2026/6/magic-cuadrant-agents.jpg" alt="" /></p>
 <p><a href="https://cursor.com/lp/2026-gartner-mq">https://cursor.com/lp/2026-gartner-mq</a></p>
 <h2>The project in events</h2>
 <h3>The experience in Codemotion Madrid 2026</h3>
 <p>Last month, the project was presented and used at the tech conference <code>Codemotion Madrid 2026</code>. The workshop had sold out a few weeks before, and participants rated the session 4.5/5.</p>
-<p><a href="https://conferences.codemotion.com/madrid/"><img src="/plintch/images/2026/6/codemotion-madrid-workshop.jpg" alt="" /></a></p>
+<p><a href="https://conferences.codemotion.com/madrid/"><img src="/plinth/images/2026/6/codemotion-madrid-workshop.jpg" alt="" /></a></p>
 <p><strong>Slides:</strong> <a href="https://github.com/jabrena/plinth">jabrena/plinth</a></p>
 <h3>The experience in JMad 2026</h3>
 <p>Every year, <code>MadridJUG</code> organizes <code>JMad</code>, a Java tech event based on <code>OpenSpace</code>.</p>
-<p><a href="https://jmad.madridjug.es/"><img src="/plintch/images/2026/6/IMG_8268.jpg" alt="" /></a></p>
+<p><a href="https://jmad.madridjug.es/"><img src="/plinth/images/2026/6/IMG_8268.jpg" alt="" /></a></p>
 <p><code>JMad</code> is a nice opportunity to exchange ideas and have good debates about the topics Java developers want to discuss.</p>
 <p>This year's agenda was:</p>
-<p><img src="/plintch/images/2026/6/IMG_2584.webp" alt="" /></p>
+<p><img src="/plinth/images/2026/6/IMG_2584.webp" alt="" /></p>
 <p>This year, several AI topics were discussed, including <code>AI Governance</code> and how to manage <code>Skills</code> in your team, unit, or company.</p>
 <p>Further information: <a href="https://jmad.madridjug.es/">https://jmad.madridjug.es/</a></p>
 

--- a/docs/blog/2026/06/release-0.16.0.html
+++ b/docs/blog/2026/06/release-0.16.0.html
@@ -134,11 +134,11 @@
 <li><a href="#next-steps">Next steps</a></li>
 </ul>
 <p>Thanks to our community members in <code>Singapore</code>, <code>Hong Kong</code>, <code>Hanoi</code>, <code>London</code>, and <code>New York</code>. 👋👋👋</p>
-<p>If you have questions about the project, how to customize it for your team, how to use the skills in daily work, or how to solve tooling issues, use <a href="https://github.com/jabrena/cursor-rules-java/discussions"><code>GitHub Discussions</code></a>.</p>
+<p>If you have questions about the project, how to customize it for your team, how to use the skills in daily work, or how to solve tooling issues, use <a href="https://github.com/jabrena/plinth/discussions"><code>GitHub Discussions</code></a>.</p>
 <p><strong>Help this project grow:</strong> <a href="https://github.com/sponsors/jabrena">If this project helps your team, become a sponsor.</a></p>
 <h2>Enriching the workflow with Commands and Agents, not only Skills</h2>
 <p><a id="enriching-the-workflow-with-commands-and-agents-not-only-skills"></a></p>
-<p>The project started more than a year ago with a set of reusable <code>rules / system prompts</code>. That approach worked well after removing the restriction that associated rules with particular files, as described in <a href="https://github.com/jabrena/cursor-rules-java/blob/main/documentation/adr/ADR-002-configure-cursor-rules-manual-scope.md"><code>ADR-002</code></a>. With the rise of <code>Skills</code>, it was a good decision to convert that material into skills and use the new capabilities provided by <code>Skill registries</code> like <a href="https://www.skills.sh/">https://www.skills.sh/</a> and other registries.</p>
+<p>The project started more than a year ago with a set of reusable <code>rules / system prompts</code>. That approach worked well after removing the restriction that associated rules with particular files, as described in <a href="https://github.com/jabrena/plinth/blob/main/documentation/adr/ADR-002-configure-cursor-rules-manual-scope.md"><code>ADR-002</code></a>. With the rise of <code>Skills</code>, it was a good decision to convert that material into skills and use the new capabilities provided by <code>Skill registries</code> like <a href="https://www.skills.sh/">https://www.skills.sh/</a> and other registries.</p>
 <p>In this release, we go further by adding new semantics for expressing the actions a software engineer performs while solving a problem.</p>
 <p>That model is organized around three delivery paths:</p>
 <pre><code class="language-text">Plan
@@ -201,20 +201,20 @@ Operate
 <p>In other projects, you can find useful <code>Skills</code>, <code>Agents</code>, or <code>Commands</code>, but not always a fully connected workflow designed with <code>Java</code> in mind.</p>
 <h2>What are the Top 10 Skills from this project in Skills.sh?</h2>
 <p><a id="what-are-the-top-10-skills-from-this-project-in-skillssh"></a></p>
-<p>The project has <code>106 skills</code> and uses <a href="https://www.skills.sh/jabrena/cursor-rules-java">Skills.sh</a> as its main skill registry. It has served <code>11.0K</code> installs in total. These are the current top 10 skills used by users there:</p>
+<p>The project has <code>106 skills</code> and uses <a href="https://www.skills.sh/jabrena/plinth">Skills.sh</a> as its main skill registry. It has served <code>11.0K</code> installs in total. These are the current top 10 skills used by users there:</p>
 <ol>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/110-java-maven-best-practices"><code>110-java-maven-best-practices</code></a> - search query: <a href="https://www.skills.sh/search?q=maven">maven</a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/121-java-object-oriented-design"><code>121-java-object-oriented-design</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20object%20oriented">java object oriented</a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/124-java-secure-coding"><code>124-java-secure-coding</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20security">java security</a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/131-java-testing-unit-testing"><code>131-java-testing-unit-testing</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20unit%20testing">java unit testing</a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/142-java-functional-programming"><code>142-java-functional-programming</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20functional%20programming">java functional programming</a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/128-java-generics"><code>128-java-generics</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20generics">java generics</a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/111-java-maven-dependencies"><code>111-java-maven-dependencies</code></a> - search query: <a href="https://www.skills.sh/search?q=maven">maven</a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/141-java-refactoring-with-modern-features"><code>141-java-refactoring-with-modern-features</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/125-java-concurrency"><code>125-java-concurrency</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20concurrency">java concurrency</a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/143-java-functional-exception-handling"><code>143-java-functional-exception-handling</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20functional%20programming">java functional programming</a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/110-java-maven-best-practices"><code>110-java-maven-best-practices</code></a> - search query: <a href="https://www.skills.sh/search?q=maven">maven</a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/121-java-object-oriented-design"><code>121-java-object-oriented-design</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20object%20oriented">java object oriented</a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/124-java-secure-coding"><code>124-java-secure-coding</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20security">java security</a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/131-java-testing-unit-testing"><code>131-java-testing-unit-testing</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20unit%20testing">java unit testing</a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/142-java-functional-programming"><code>142-java-functional-programming</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20functional%20programming">java functional programming</a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/128-java-generics"><code>128-java-generics</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20generics">java generics</a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/111-java-maven-dependencies"><code>111-java-maven-dependencies</code></a> - search query: <a href="https://www.skills.sh/search?q=maven">maven</a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/141-java-refactoring-with-modern-features"><code>141-java-refactoring-with-modern-features</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/125-java-concurrency"><code>125-java-concurrency</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20concurrency">java concurrency</a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/143-java-functional-exception-handling"><code>143-java-functional-exception-handling</code></a> - search query: <a href="https://www.skills.sh/search?q=java%20functional%20programming">java functional programming</a></li>
 </ol>
-<p><strong>What is your favorite <code>Skill</code> from this project?</strong> You can share it here: <a href="https://github.com/jabrena/cursor-rules-java/discussions/804">https://github.com/jabrena/cursor-rules-java/discussions/804</a></p>
+<p><strong>What is your favorite <code>Skill</code> from this project?</strong> You can share it here: <a href="https://github.com/jabrena/plinth/discussions/804">https://github.com/jabrena/plinth/discussions/804</a></p>
 <h2>Applying Zero Trust with your Agent skills</h2>
 <p><a id="applying-zero-trust-with-your-agent-skills"></a></p>
 <p><code>Skills</code> are not ordinary Markdown files. They are executable guidance for AI agents. A skill can tell an agent how to read code, run commands, inspect evidence, write files, install tools, or make a technical recommendation.</p>
@@ -241,7 +241,7 @@ Operate
 <li>Untrusted content and indirect prompt injection</li>
 <li>Tool poisoning and tool shadowing</li>
 </ul>
-<p><strong>Note:</strong> The project runs an analysis for all skills on every commit using the tools described above. <a href="https://github.com/jabrena/cursor-rules-java/blob/main/.github/workflows/maven.yaml">https://github.com/jabrena/cursor-rules-java/blob/main/.github/workflows/maven.yaml</a></p>
+<p><strong>Note:</strong> The project runs an analysis for all skills on every commit using the tools described above. <a href="https://github.com/jabrena/plinth/blob/main/.github/workflows/maven.yaml">https://github.com/jabrena/plinth/blob/main/.github/workflows/maven.yaml</a></p>
 <p>If you are interested in this kind of validation, I recommend reading the following article: <a href="/cursor-rules-java/blog/2026/06/skill-validators-pipeline.html">How to validate skills?</a></p>
 <h2>Improving the approach to test the behavior of Agent Skills</h2>
 <p><a id="improving-the-approach-to-test-the-behavior-of-an-agent-skills"></a></p>
@@ -308,7 +308,7 @@ Scenario: Add JSpecify and Error Prone + NullAway to Maven demo
   - Roman API: https://my-json-server.typicode.com/jabrena/latency-problems/roman
   - Nordic API: https://my-json-server.typicode.com/jabrena/latency-problems/nordic
 </code></pre>
-<p>Given this <code>User story</code> and the <code>OpenSpec</code> change defined here: <a href="https://github.com/jabrena/cursor-rules-java/tree/main/examples/openspec">https://github.com/jabrena/cursor-rules-java/tree/main/examples/openspec</a>, you can implement it using the new <code>/implement-issue</code> command. Let's see how to do it and how to validate it.</p>
+<p>Given this <code>User story</code> and the <code>OpenSpec</code> change defined here: <a href="https://github.com/jabrena/plinth/tree/main/examples/openspec">https://github.com/jabrena/plinth/tree/main/examples/openspec</a>, you can implement it using the new <code>/implement-issue</code> command. Let's see how to do it and how to validate it.</p>
 <p><strong>/implement-issue:</strong></p>
 <p>Using this prompt:</p>
 <pre><code class="language-bash">execute @skills-generator/src/test/resources/gherkin/commands/implement-issue.feature
@@ -388,11 +388,11 @@ Implement it using Micronaut, not Spring Boot, as the default requirement.
 <p>With the rise of <code>Skills</code>, there is a need for public registries for them. But what happens to <code>Agents</code>, <code>Commands</code>, or other files? The reality is that <code>Agents</code> and <code>Commands</code> are often treated as second-class citizens.</p>
 <p>To take advantage of the public registry and the process for generating skills from <code>XML</code> sources, it is relatively easy to embed commands and agents in a <code>Meta Skill</code>. Once you have installed the skills, you can use the following inventory and installation workflows:</p>
 <ul>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/001-commands-inventory"><code>@001-commands-inventory</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/002-agents-inventory"><code>@002-agents-inventory</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/003-skills-inventory"><code>@003-skills-inventory</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/004-commands-installation"><code>@004-commands-installation</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/005-agents-installation"><code>@005-agents-installation</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/001-commands-inventory"><code>@001-commands-inventory</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/002-agents-inventory"><code>@002-agents-inventory</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/003-skills-inventory"><code>@003-skills-inventory</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/004-commands-installation"><code>@004-commands-installation</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/005-agents-installation"><code>@005-agents-installation</code></a></li>
 </ul>
 <p>Then you can use them to install assets or generate the inventory files.</p>
 <p><strong>Example:</strong></p>
@@ -413,55 +413,55 @@ install @004-commands-installation github-copilot
 <p>The value is that teams can pick the framework lane first, then apply the matching skills for project creation, REST APIs, validation, security, persistence, messaging, migrations, MongoDB, and tests. If you use one of the main Java frameworks, you can review the following skills:</p>
 <p><strong>Spring Boot skills:</strong></p>
 <ul>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/300-frameworks-spring-boot-create-project"><code>@300-frameworks-spring-boot-create-project</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/301-frameworks-spring-boot-core"><code>@301-frameworks-spring-boot-core</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/302-frameworks-spring-boot-rest"><code>@302-frameworks-spring-boot-rest</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/303-frameworks-spring-boot-validation"><code>@303-frameworks-spring-boot-validation</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/304-frameworks-spring-boot-security"><code>@304-frameworks-spring-boot-security</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/305-frameworks-spring-boot-modulith"><code>@305-frameworks-spring-boot-modulith</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/311-frameworks-spring-jdbc"><code>@311-frameworks-spring-jdbc</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/312-frameworks-spring-data-jdbc"><code>@312-frameworks-spring-data-jdbc</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/313-frameworks-spring-db-migrations-flyway"><code>@313-frameworks-spring-db-migrations-flyway</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/314-frameworks-spring-kafka"><code>@314-frameworks-spring-kafka</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/315-frameworks-spring-mongodb"><code>@315-frameworks-spring-mongodb</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/316-frameworks-spring-mongodb-migrations-mongock"><code>@316-frameworks-spring-mongodb-migrations-mongock</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/321-frameworks-spring-boot-testing-unit-tests"><code>@321-frameworks-spring-boot-testing-unit-tests</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/322-frameworks-spring-boot-testing-integration-tests"><code>@322-frameworks-spring-boot-testing-integration-tests</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/323-frameworks-spring-boot-testing-acceptance-tests"><code>@323-frameworks-spring-boot-testing-acceptance-tests</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/300-frameworks-spring-boot-create-project"><code>@300-frameworks-spring-boot-create-project</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/301-frameworks-spring-boot-core"><code>@301-frameworks-spring-boot-core</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/302-frameworks-spring-boot-rest"><code>@302-frameworks-spring-boot-rest</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/303-frameworks-spring-boot-validation"><code>@303-frameworks-spring-boot-validation</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/304-frameworks-spring-boot-security"><code>@304-frameworks-spring-boot-security</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/305-frameworks-spring-boot-modulith"><code>@305-frameworks-spring-boot-modulith</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/311-frameworks-spring-jdbc"><code>@311-frameworks-spring-jdbc</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/312-frameworks-spring-data-jdbc"><code>@312-frameworks-spring-data-jdbc</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/313-frameworks-spring-db-migrations-flyway"><code>@313-frameworks-spring-db-migrations-flyway</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/314-frameworks-spring-kafka"><code>@314-frameworks-spring-kafka</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/315-frameworks-spring-mongodb"><code>@315-frameworks-spring-mongodb</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/316-frameworks-spring-mongodb-migrations-mongock"><code>@316-frameworks-spring-mongodb-migrations-mongock</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/321-frameworks-spring-boot-testing-unit-tests"><code>@321-frameworks-spring-boot-testing-unit-tests</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/322-frameworks-spring-boot-testing-integration-tests"><code>@322-frameworks-spring-boot-testing-integration-tests</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/323-frameworks-spring-boot-testing-acceptance-tests"><code>@323-frameworks-spring-boot-testing-acceptance-tests</code></a></li>
 </ul>
 <p><strong>Quarkus skills:</strong></p>
 <ul>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/400-frameworks-quarkus-create-project"><code>@400-frameworks-quarkus-create-project</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/401-frameworks-quarkus-core"><code>@401-frameworks-quarkus-core</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/402-frameworks-quarkus-rest"><code>@402-frameworks-quarkus-rest</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/403-frameworks-quarkus-validation"><code>@403-frameworks-quarkus-validation</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/404-frameworks-quarkus-security"><code>@404-frameworks-quarkus-security</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/411-frameworks-quarkus-jdbc"><code>@411-frameworks-quarkus-jdbc</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/412-frameworks-quarkus-panache"><code>@412-frameworks-quarkus-panache</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/413-frameworks-quarkus-db-migrations-flyway"><code>@413-frameworks-quarkus-db-migrations-flyway</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/414-frameworks-quarkus-kafka"><code>@414-frameworks-quarkus-kafka</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/415-frameworks-quarkus-mongodb"><code>@415-frameworks-quarkus-mongodb</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/416-frameworks-quarkus-mongodb-migrations-mongock"><code>@416-frameworks-quarkus-mongodb-migrations-mongock</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/421-frameworks-quarkus-testing-unit-tests"><code>@421-frameworks-quarkus-testing-unit-tests</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/422-frameworks-quarkus-testing-integration-tests"><code>@422-frameworks-quarkus-testing-integration-tests</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/423-frameworks-quarkus-testing-acceptance-tests"><code>@423-frameworks-quarkus-testing-acceptance-tests</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/400-frameworks-quarkus-create-project"><code>@400-frameworks-quarkus-create-project</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/401-frameworks-quarkus-core"><code>@401-frameworks-quarkus-core</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/402-frameworks-quarkus-rest"><code>@402-frameworks-quarkus-rest</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/403-frameworks-quarkus-validation"><code>@403-frameworks-quarkus-validation</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/404-frameworks-quarkus-security"><code>@404-frameworks-quarkus-security</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/411-frameworks-quarkus-jdbc"><code>@411-frameworks-quarkus-jdbc</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/412-frameworks-quarkus-panache"><code>@412-frameworks-quarkus-panache</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/413-frameworks-quarkus-db-migrations-flyway"><code>@413-frameworks-quarkus-db-migrations-flyway</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/414-frameworks-quarkus-kafka"><code>@414-frameworks-quarkus-kafka</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/415-frameworks-quarkus-mongodb"><code>@415-frameworks-quarkus-mongodb</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/416-frameworks-quarkus-mongodb-migrations-mongock"><code>@416-frameworks-quarkus-mongodb-migrations-mongock</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/421-frameworks-quarkus-testing-unit-tests"><code>@421-frameworks-quarkus-testing-unit-tests</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/422-frameworks-quarkus-testing-integration-tests"><code>@422-frameworks-quarkus-testing-integration-tests</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/423-frameworks-quarkus-testing-acceptance-tests"><code>@423-frameworks-quarkus-testing-acceptance-tests</code></a></li>
 </ul>
 <p><strong>Micronaut skills:</strong></p>
 <ul>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/500-frameworks-micronaut-create-project"><code>@500-frameworks-micronaut-create-project</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/501-frameworks-micronaut-core"><code>@501-frameworks-micronaut-core</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/502-frameworks-micronaut-rest"><code>@502-frameworks-micronaut-rest</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/503-frameworks-micronaut-validation"><code>@503-frameworks-micronaut-validation</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/504-frameworks-micronaut-security"><code>@504-frameworks-micronaut-security</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/511-frameworks-micronaut-jdbc"><code>@511-frameworks-micronaut-jdbc</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/512-frameworks-micronaut-data"><code>@512-frameworks-micronaut-data</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/513-frameworks-micronaut-db-migrations-flyway"><code>@513-frameworks-micronaut-db-migrations-flyway</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/514-frameworks-micronaut-kafka"><code>@514-frameworks-micronaut-kafka</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/515-frameworks-micronaut-mongodb"><code>@515-frameworks-micronaut-mongodb</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/516-frameworks-micronaut-mongodb-migrations-mongock"><code>@516-frameworks-micronaut-mongodb-migrations-mongock</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/521-frameworks-micronaut-testing-unit-tests"><code>@521-frameworks-micronaut-testing-unit-tests</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/522-frameworks-micronaut-testing-integration-tests"><code>@522-frameworks-micronaut-testing-integration-tests</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/523-frameworks-micronaut-testing-acceptance-tests"><code>@523-frameworks-micronaut-testing-acceptance-tests</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/500-frameworks-micronaut-create-project"><code>@500-frameworks-micronaut-create-project</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/501-frameworks-micronaut-core"><code>@501-frameworks-micronaut-core</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/502-frameworks-micronaut-rest"><code>@502-frameworks-micronaut-rest</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/503-frameworks-micronaut-validation"><code>@503-frameworks-micronaut-validation</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/504-frameworks-micronaut-security"><code>@504-frameworks-micronaut-security</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/511-frameworks-micronaut-jdbc"><code>@511-frameworks-micronaut-jdbc</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/512-frameworks-micronaut-data"><code>@512-frameworks-micronaut-data</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/513-frameworks-micronaut-db-migrations-flyway"><code>@513-frameworks-micronaut-db-migrations-flyway</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/514-frameworks-micronaut-kafka"><code>@514-frameworks-micronaut-kafka</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/515-frameworks-micronaut-mongodb"><code>@515-frameworks-micronaut-mongodb</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/516-frameworks-micronaut-mongodb-migrations-mongock"><code>@516-frameworks-micronaut-mongodb-migrations-mongock</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/521-frameworks-micronaut-testing-unit-tests"><code>@521-frameworks-micronaut-testing-unit-tests</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/522-frameworks-micronaut-testing-integration-tests"><code>@522-frameworks-micronaut-testing-integration-tests</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/523-frameworks-micronaut-testing-acceptance-tests"><code>@523-frameworks-micronaut-testing-acceptance-tests</code></a></li>
 </ul>
 <h2>Increasing engineering awareness with EU regulations</h2>
 <p><a id="increasing-the-engineering-awareness-with-eu-regulations"></a></p>
@@ -470,14 +470,14 @@ install @004-commands-installation github-copilot
 <p>This becomes even more important with GenAI tooling. When prompts, embeddings, generated code, agent actions, and tool calls enter the SDLC, teams need a repeatable way to ask what data is being used, what decisions are automated, what evidence is kept, and which legal, security, privacy, risk, or product owners must review the work.</p>
 <p><code>0.16.0</code> introduces a new alpha family of regulation engineering review skills:</p>
 <ul>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/801-regulations-eu-ai-act"><code>@801-regulations-eu-ai-act</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/802-regulations-dora"><code>@802-regulations-dora</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/803-regulations-gdpr"><code>@803-regulations-gdpr</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/804-regulations-eu-nis2"><code>@804-regulations-eu-nis2</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/805-regulations-eu-cyber-resilience-act"><code>@805-regulations-eu-cyber-resilience-act</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/806-regulations-eu-data-act"><code>@806-regulations-eu-data-act</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/807-regulations-eu-digital-services-act"><code>@807-regulations-eu-digital-services-act</code></a></li>
-<li><a href="https://www.skills.sh/jabrena/cursor-rules-java/808-regulations-eu-digital-markets-act"><code>@808-regulations-eu-digital-markets-act</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/801-regulations-eu-ai-act"><code>@801-regulations-eu-ai-act</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/802-regulations-dora"><code>@802-regulations-dora</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/803-regulations-gdpr"><code>@803-regulations-gdpr</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/804-regulations-eu-nis2"><code>@804-regulations-eu-nis2</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/805-regulations-eu-cyber-resilience-act"><code>@805-regulations-eu-cyber-resilience-act</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/806-regulations-eu-data-act"><code>@806-regulations-eu-data-act</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/807-regulations-eu-digital-services-act"><code>@807-regulations-eu-digital-services-act</code></a></li>
+<li><a href="https://www.skills.sh/jabrena/plinth/808-regulations-eu-digital-markets-act"><code>@808-regulations-eu-digital-markets-act</code></a></li>
 </ul>
 <p>These skills are engineering review aids. <strong><em>They do not provide legal advice and they do not replace qualified legal, compliance, privacy, security, risk, product, or governance owners.</em></strong></p>
 <p>For distributed systems using GenAI tools, a practical review set is:</p>
@@ -497,28 +497,28 @@ install @004-commands-installation github-copilot
 <p>The <a href="https://www.thoughtworks.com/radar">Thoughtworks Technology Radar Vol. 34</a> (April 2026) maps the current technology landscape across four rings: Adopt, Trial, Assess, and Caution. Several blips align directly with the direction this project has been taking. Lets review what recommendations matches with this project.</p>
 <p><strong>Adopt</strong></p>
 <ul>
-<li><strong>Curated shared instructions for software teams</strong> — The Radar explicitly calls out <code>AGENTS.md</code> as a distribution mechanism for AI guidance, anchored into service templates so every new repository inherits the latest agent workflows. This project has been doing exactly that from the start. See <a href="https://www.skills.sh/jabrena/cursor-rules-java/200-agents-md"><code>@200-agents-md</code></a>.</li>
+<li><strong>Curated shared instructions for software teams</strong> — The Radar explicitly calls out <code>AGENTS.md</code> as a distribution mechanism for AI guidance, anchored into service templates so every new repository inherits the latest agent workflows. This project has been doing exactly that from the start. See <a href="https://www.skills.sh/jabrena/plinth/200-agents-md"><code>@200-agents-md</code></a>.</li>
 <li><strong>Context engineering</strong> — Treating the context window as a design surface rather than a static text box is now a foundational concern. The skill system in this project is a practical application of that principle: skills are loaded on demand, not front-loaded into a monolithic prompt.</li>
 <li><strong>Zero trust architecture</strong> — The Radar recommends ZTA as a non-negotiable default for agent deployments: never trust, always verify, least-privilege access. The <a href="#applying-zero-trust-with-your-agent-skills">Applying Zero Trust with Agent Skills</a> section in this release directly addresses this applied to skill-based agent workflows.</li>
 </ul>
 <p><strong>Trial</strong></p>
 <ul>
-<li><strong>Agent Skills</strong> — The Radar places Agent Skills in Trial, noting they are an open standard for modularizing context, reducing token consumption and providing a controlled alternative to MCP. This project is one of the early skill registries on <a href="https://www.skills.sh/jabrena/cursor-rules-java">skills.sh</a>, shipping skills for Java Enterprise workflows.</li>
+<li><strong>Agent Skills</strong> — The Radar places Agent Skills in Trial, noting they are an open standard for modularizing context, reducing token consumption and providing a controlled alternative to MCP. This project is one of the early skill registries on <a href="https://www.skills.sh/jabrena/plinth">skills.sh</a>, shipping skills for Java Enterprise workflows.</li>
 <li><strong>Feedback sensors for coding agents</strong> — Deterministic quality gates wired into agent workflows so failures trigger self-correction. This project uses <code>skill-check</code> and <code>skill-scanner</code> as post-generation feedback sensors, and is now expanding coverage with <code>Gherkin</code> acceptance tests for Skills, Agents and Commands.</li>
 <li><strong>Progressive context disclosure</strong> — Agents should load only what is needed for the current task. The <code>001-commands-inventory</code>, <code>002-agents-inventory</code>, and <code>003-skills-inventory</code> skills serve as lightweight discovery indexes before detailed skill content is loaded.</li>
-<li><strong>Mutation testing</strong> — The Radar highlights <code>Pitest</code> for Java as a way to verify that a passing test suite genuinely validates behavior. The Java testing skills in this project include guidance on mutation testing as a quality signal. Use <a href="https://www.skills.sh/jabrena/cursor-rules-java/112-java-maven-plugins"><code>@112-java-maven-plugins</code></a> to add and configure the Pitest Maven plugin.</li>
-<li><strong>Mapping code smells to refactoring techniques</strong> — The Radar recommends Agent Skills and slash commands for mapping legacy patterns to specific refactoring approaches. This project covers this for Java across multiple dimensions: <a href="https://www.skills.sh/jabrena/cursor-rules-java/141-java-refactoring-with-modern-features"><code>@141-java-refactoring-with-modern-features</code></a> for modernising existing code, <a href="https://www.skills.sh/jabrena/cursor-rules-java/121-java-object-oriented-design"><code>@121-java-object-oriented-design</code></a> for OOP principles and code smells, <a href="https://www.skills.sh/jabrena/cursor-rules-java/122-java-type-design"><code>@122-java-type-design</code></a> for type-level design decisions, <a href="https://www.skills.sh/jabrena/cursor-rules-java/142-java-functional-programming"><code>@142-java-functional-programming</code></a> for functional style, and <a href="https://www.skills.sh/jabrena/cursor-rules-java/143-java-functional-exception-handling"><code>@143-java-functional-exception-handling</code></a> for functional error handling patterns.</li>
+<li><strong>Mutation testing</strong> — The Radar highlights <code>Pitest</code> for Java as a way to verify that a passing test suite genuinely validates behavior. The Java testing skills in this project include guidance on mutation testing as a quality signal. Use <a href="https://www.skills.sh/jabrena/plinth/112-java-maven-plugins"><code>@112-java-maven-plugins</code></a> to add and configure the Pitest Maven plugin.</li>
+<li><strong>Mapping code smells to refactoring techniques</strong> — The Radar recommends Agent Skills and slash commands for mapping legacy patterns to specific refactoring approaches. This project covers this for Java across multiple dimensions: <a href="https://www.skills.sh/jabrena/plinth/141-java-refactoring-with-modern-features"><code>@141-java-refactoring-with-modern-features</code></a> for modernising existing code, <a href="https://www.skills.sh/jabrena/plinth/121-java-object-oriented-design"><code>@121-java-object-oriented-design</code></a> for OOP principles and code smells, <a href="https://www.skills.sh/jabrena/plinth/122-java-type-design"><code>@122-java-type-design</code></a> for type-level design decisions, <a href="https://www.skills.sh/jabrena/plinth/142-java-functional-programming"><code>@142-java-functional-programming</code></a> for functional style, and <a href="https://www.skills.sh/jabrena/plinth/143-java-functional-exception-handling"><code>@143-java-functional-exception-handling</code></a> for functional error handling patterns.</li>
 </ul>
 <p><strong>Assess</strong></p>
 <ul>
-<li><strong>Architecture drift reduction with LLMs</strong> — The Radar mentions <code>ArchUnit</code> as a deterministic structural tool to combine with LLM-powered evaluation. Use <a href="https://www.skills.sh/jabrena/cursor-rules-java/111-java-maven-dependencies"><code>@111-java-maven-dependencies</code></a> to add ArchUnit to a Java project.</li>
+<li><strong>Architecture drift reduction with LLMs</strong> — The Radar mentions <code>ArchUnit</code> as a deterministic structural tool to combine with LLM-powered evaluation. Use <a href="https://www.skills.sh/jabrena/plinth/111-java-maven-dependencies"><code>@111-java-maven-dependencies</code></a> to add ArchUnit to a Java project.</li>
 <li><strong>Code intelligence as agentic tooling</strong> — The Radar calls out the Serena MCP server for semantic code retrieval. This project already enables <code>serena</code> as one of its configured MCP servers, giving agents structured access to the codebase rather than relying on text search.</li>
 </ul>
 <p><strong>Cross-cutting theme: Putting coding agents on a leash</strong></p>
 <p>The Radar's editorial theme explicitly names <code>OpenSpec</code> alongside <code>GitHub Spec-Kit</code> as a spec-driven development framework for structuring workflows through planning, design and implementation. It also calls out <code>HITL</code> as a necessary counterweight to agent autonomy, and <code>Agent Skills</code> as a safer alternative to unrestricted MCP access. All three are central to this project.</p>
 <h2>Next steps</h2>
 <p><a id="next-steps"></a></p>
-<p>The next phase is already visible in the <a href="https://github.com/jabrena/cursor-rules-java/milestone/11"><code>v0.17.0</code> milestone</a>. The backlog continues the same direction as <code>0.16.0</code>: make agent workflows more useful, more deterministic, and easier to adopt in real teams.</p>
+<p>The next phase is already visible in the <a href="https://github.com/jabrena/plinth/milestone/11"><code>v0.17.0</code> milestone</a>. The backlog continues the same direction as <code>0.16.0</code>: make agent workflows more useful, more deterministic, and easier to adopt in real teams.</p>
 <p>Functionally, the next workstreams are:</p>
 <ul>
 <li>Expand executable acceptance coverage for <code>Skills</code>, <code>Agents</code>, and <code>Commands</code>, so important behavior is checked with stable <code>Gherkin</code> scenarios instead of relying only on package shape or manual review.</li>
@@ -549,7 +549,7 @@ install @004-commands-installation github-copilot
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/blog/2026/06/release-0.16.0.html
+++ b/docs/blog/2026/06/release-0.16.0.html
@@ -363,7 +363,7 @@ Scenario: Implement God Analysis API from a validated OpenSpec change
 <p>In this case, the command internally uses the agent <code>@robot-tech-lead</code>, which redirects to the specific agent <code>@robot-java-spring-boot-coder</code> based on the analysis of the specification. That agent handles specific <code>Java skills</code> and specific <code>Spring Boot skills</code>. This is the result for a <code>Spring Boot</code> implementation:</p>
 <p><a href="https://asciinema.org/a/1257803"><img src="https://asciinema.org/a/1257803.svg" alt="asciicast" /></a></p>
 <p><em>Running the test with Codex CLI for the Spring Boot variant</em></p>
-<p><img src="/plintch/images/2026/6/vscode-codex.png" alt="" /></p>
+<p><img src="/plinth/images/2026/6/vscode-codex.png" alt="" /></p>
 <p><em>Running the test with VS Code + Codex plugin</em></p>
 <p>But if you refine the prompt a bit, you can implement the requirement in <code>Quarkus</code>:</p>
 <pre><code class="language-bash">execute @skills-generator/src/test/resources/gherkin/commands/implement-issue.feature

--- a/docs/blog/2026/06/skill-validators-pipeline.html
+++ b/docs/blog/2026/06/skill-validators-pipeline.html
@@ -237,7 +237,7 @@ skillspector scan .agents/skills \
 <li>Source changes happen in XML, generated output is reviewed, and promotion requires validation.</li>
 </ul>
 <p>The more capable AI agent workflows become, the more important it is to make those checks explicit, repeatable, and visible in the pipeline.</p>
-<p><strong>Example pipeline:</strong> <a href="https://github.com/jabrena/cursor-rules-java/blob/main/.github/workflows/maven.yaml">maven.yaml</a></p>
+<p><strong>Example pipeline:</strong> <a href="https://github.com/jabrena/plinth/blob/main/.github/workflows/maven.yaml">maven.yaml</a></p>
 
 </article>
 </div>
@@ -258,7 +258,7 @@ skillspector scan .agents/skills \
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/blog/2026/07/introduction-to-eu-regulations-part-ii.html
+++ b/docs/blog/2026/07/introduction-to-eu-regulations-part-ii.html
@@ -274,7 +274,7 @@
 <p>The common theme is evidence. Each skill helps Java teams turn regulatory or standard concerns into reviewable architecture notes, OpenSpec assumptions, tests, logs, runbooks, release gates, and owner handoffs.</p>
 <h2>Share your experience</h2>
 <p>If you are using these workflows, experimenting with OpenSpec, or trying to introduce regulation skills into AI-assisted delivery, share your experience with the project.</p>
-<p>Use <a href="https://github.com/jabrena/cursor-rules-java/discussions">GitHub Discussions</a> to post what is working, where the workflow feels unclear, which doubts you have, and what worries you about applying agents to real Java systems.</p>
+<p>Use <a href="https://github.com/jabrena/plinth/discussions">GitHub Discussions</a> to post what is working, where the workflow feels unclear, which doubts you have, and what worries you about applying agents to real Java systems.</p>
 <p>Those conversations help improve the skills, the documentation, and the project workflow itself.</p>
 
 </article>
@@ -296,7 +296,7 @@
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/blog/2026/07/why-do-i-need-to-use-the-parallel-change-pattern.html
+++ b/docs/blog/2026/07/why-do-i-need-to-use-the-parallel-change-pattern.html
@@ -226,7 +226,7 @@ WHERE display_name IS NULL AND full_name IS NOT NULL;
 <p>That tiny pause can prevent a clean-looking patch from becoming a production incident.</p>
 <h2>Share your experience</h2>
 <p>If you are using AI agents for migrations, refactoring, API evolution, or compatibility-sensitive Java work, share what you are learning with the project.</p>
-<p>Use <a href="https://github.com/jabrena/cursor-rules-java/discussions">GitHub Discussions</a> to post where parallel change helps, where the workflow feels heavy, and which compatibility risks agents still miss.</p>
+<p>Use <a href="https://github.com/jabrena/plinth/discussions">GitHub Discussions</a> to post where parallel change helps, where the workflow feels heavy, and which compatibility risks agents still miss.</p>
 
 </article>
 </div>
@@ -247,7 +247,7 @@ WHERE display_name IS NULL AND full_name IS NOT NULL;
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/codemotion-madrid-2026/index.html
+++ b/docs/codemotion-madrid-2026/index.html
@@ -508,7 +508,7 @@ ventana de contexto, maneja tipos de trabajo específicos y devuelve su resultad
                             <a href="https://skills.sh/" target="_blank">https://skills.sh/</a>
                         </li>
                         <li>
-                            <a href="https://github.com/jabrena/cursor-rules-java" target="_blank">
+                            <a href="https://github.com/jabrena/plinth" target="_blank">
                                 Cursor Rules Java @ jabrena
                             </a>
                         </li>

--- a/docs/courses/java-generics/index.html
+++ b/docs/courses/java-generics/index.html
@@ -212,7 +212,7 @@
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/java-generics/module-1-foundations.html
+++ b/docs/courses/java-generics/module-1-foundations.html
@@ -749,7 +749,7 @@ class EmptyStackException extends RuntimeException {
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/java-generics/module-2-wildcards.html
+++ b/docs/courses/java-generics/module-2-wildcards.html
@@ -1002,7 +1002,7 @@ class GenericAlgorithmsTest {
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/java-generics/module-3-advanced.html
+++ b/docs/courses/java-generics/module-3-advanced.html
@@ -1195,7 +1195,7 @@ class AdvancedConfigurationTest {
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/java-generics/module-4-realworld.html
+++ b/docs/courses/java-generics/module-4-realworld.html
@@ -1573,7 +1573,7 @@ class EnterpriseEventSystemTest {
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/java-generics/module-5-assessment.html
+++ b/docs/courses/java-generics/module-5-assessment.html
@@ -1415,7 +1415,7 @@ A complete event sourcing system would include:<br />
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/profile-memory-leak/index.html
+++ b/docs/courses/profile-memory-leak/index.html
@@ -234,13 +234,13 @@
 <hr />
 <h2>🛠️ System Prompts Integration</h2>
 <p>This course demonstrates practical usage of three key system prompts:</p>
-<h3><strong><a href="https://github.com/jabrena/cursor-rules-java/tree/main/.cursor/rules/161-java-profiling-detect.md">@161-java-profiling-detect</a></strong></h3>
+<h3><strong><a href="https://github.com/jabrena/plinth/tree/main/.cursor/rules/161-java-profiling-detect.md">@161-java-profiling-detect</a></strong></h3>
 <p><strong>Purpose:</strong> Data collection and problem identification<br />
 <strong>Usage:</strong> My Java application has performance issues - help me set up comprehensive profiling process using @161-java-profiling-detect and use the location examples/spring-boot-memory-leak-demo/profiler</p>
-<h3><strong><a href="https://github.com/jabrena/cursor-rules-java/tree/main/.cursor/rules/162-java-profiling-analyze.md">@162-java-profiling-analyze</a></strong></h3>
+<h3><strong><a href="https://github.com/jabrena/plinth/tree/main/.cursor/rules/162-java-profiling-analyze.md">@162-java-profiling-analyze</a></strong></h3>
 <p><strong>Purpose:</strong> Systematic analysis and solution development<br />
 <strong>Usage:</strong> Analyze the results located in examples/spring-boot-memory-leak-demo/profiler and use the cursor rule @162-java-profiling-analyze</p>
-<h3><strong><a href="https://github.com/jabrena/cursor-rules-java/tree/main/.cursor/rules/164-java-profiling-compare.md">@164-java-profiling-compare</a></strong></h3>
+<h3><strong><a href="https://github.com/jabrena/plinth/tree/main/.cursor/rules/164-java-profiling-compare.md">@164-java-profiling-compare</a></strong></h3>
 <p><strong>Purpose:</strong> Before/after validation and improvement measurement<br />
 <strong>Usage:</strong> Review if the problems was solved with last refactoring using the reports located in @/results with the cursor rule @164-java-profiling-compare</p>
 <hr />
@@ -350,7 +350,7 @@
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/profile-memory-leak/module-1-foundations.html
+++ b/docs/courses/profile-memory-leak/module-1-foundations.html
@@ -455,7 +455,7 @@ chmod +x custom-load-test.sh
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/profile-memory-leak/module-2-profiling.html
+++ b/docs/courses/profile-memory-leak/module-2-profiling.html
@@ -596,7 +596,7 @@ chmod +x measure-flamegraph.sh
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/profile-memory-leak/module-3-analysis.html
+++ b/docs/courses/profile-memory-leak/module-3-analysis.html
@@ -668,7 +668,7 @@ echo &quot;Final analysis package created in reports/final-analysis-package/&quo
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/profile-memory-leak/module-4-refactoring.html
+++ b/docs/courses/profile-memory-leak/module-4-refactoring.html
@@ -637,7 +637,7 @@ public class SafeCache&lt;K, V&gt; {
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/profile-memory-leak/module-5-validation.html
+++ b/docs/courses/profile-memory-leak/module-5-validation.html
@@ -679,7 +679,7 @@ echo &quot;Final results summary created: profiling-final-results-${DATE_SUFFIX}
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/system-prompts-java/index.html
+++ b/docs/courses/system-prompts-java/index.html
@@ -137,8 +137,8 @@
 <ol>
 <li><strong>Clone the Repository</strong>:</li>
 </ol>
-<pre><code class="language-bash">git clone https://github.com/jabrena/cursor-rules-java.git
-cd cursor-rules-java
+<pre><code class="language-bash">git clone https://github.com/jabrena/plinth.git
+cd plinth
 </code></pre>
 <ol>
 <li><strong>Setup Development Environment</strong>:</li>
@@ -163,7 +163,7 @@ java --version
 <p><strong>Ready to transform your Java development workflow?</strong></p>
 <p>👉 <strong><a href="module-1-foundations.html">Start with Module 1: Foundations →</a></strong></p>
 <hr />
-<p><em>This course is part of the <a href="https://github.com/jabrena/cursor-rules-java">Cursor Rules Java</a> project - a comprehensive collection of AI-powered system prompts for Java enterprise development.</em></p>
+<p><em>This course is part of the <a href="https://github.com/jabrena/plinth">Cursor Rules Java</a> project - a comprehensive collection of AI-powered system prompts for Java enterprise development.</em></p>
 
 
 </article>
@@ -185,7 +185,7 @@ java --version
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/system-prompts-java/module-1-foundations.html
+++ b/docs/courses/system-prompts-java/module-1-foundations.html
@@ -355,7 +355,7 @@ Use: <code>Generate developer documentation with essential Maven commands using 
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/system-prompts-java/module-2-code-quality.html
+++ b/docs/courses/system-prompts-java/module-2-code-quality.html
@@ -511,7 +511,7 @@ Use system prompts to create comprehensive test coverage.</p>
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/system-prompts-java/module-3-secure-coding.html
+++ b/docs/courses/system-prompts-java/module-3-secure-coding.html
@@ -603,7 +603,7 @@ public class FileProcessingException extends Exception {
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/system-prompts-java/module-4-modern-java.html
+++ b/docs/courses/system-prompts-java/module-4-modern-java.html
@@ -799,7 +799,7 @@ public class PaymentProcessor {
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/system-prompts-java/module-5-performance.html
+++ b/docs/courses/system-prompts-java/module-5-performance.html
@@ -501,7 +501,7 @@ Use: <code>Review if the problems was solved with last refactoring using the rep
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/system-prompts-java/module-6-documentation.html
+++ b/docs/courses/system-prompts-java/module-6-documentation.html
@@ -578,7 +578,7 @@ jbang puml-to-png@jabrena --watch .
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/courses/system-prompts-java/module-7-advanced-patterns.html
+++ b/docs/courses/system-prompts-java/module-7-advanced-patterns.html
@@ -699,10 +699,10 @@ Team: Uses @behaviour-progressive-learning for knowledge sharing
 - <strong>Research</strong>: Explore emerging AI tools and integration patterns</p>
 <h3>📚 Continued Learning Resources</h3>
 <ul>
-<li><strong><a href="https://github.com/jabrena/cursor-rules-java">Cursor Rules Java Repository</a></strong></li>
-<li><strong><a href="https://github.com/jabrena/cursor-rules-java/discussions">Community Discussions</a></strong></li>
+<li><strong><a href="https://github.com/jabrena/plinth">Cursor Rules Java Repository</a></strong></li>
+<li><strong><a href="https://github.com/jabrena/plinth/discussions">Community Discussions</a></strong></li>
 <li><strong><a href="https://openjdk.java.net/">Latest Java Features</a></strong></li>
-<li><strong><a href="https://jabrena.github.io/cursor-rules-java/">AI-Powered Development Blog</a></strong></li>
+<li><strong><a href="https://github.com/jabrena/plinth">jabrena/plinth</a></strong></li>
 </ul>
 <hr />
 <h2>🌟 Final Reflection</h2>
@@ -737,7 +737,7 @@ Team: Uses @behaviour-progressive-learning for knowledge sharing
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/dvbe25/index.html
+++ b/docs/dvbe25/index.html
@@ -251,9 +251,9 @@
                             <strong>Examples:</strong>
                         </p>
                         <p>
-                            <a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/128-java-generics.md" target="_blank">128-java-generics.md</a>
+                            <a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/128-java-generics.md" target="_blank">128-java-generics.md</a>
                             <br />
-                            <a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/131-java-unit-testing.md" target="_blank">131-java-unit-testing.md</a>
+                            <a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/131-java-unit-testing.md" target="_blank">131-java-unit-testing.md</a>
                             <br />
                             <a href="https://github.com/jabrena/cursor-rules-agile/blob/main/.cursor/rules/2003-agile-create-user-story.mdc" target="_blank">2003-agile-create-user-story.mdc</a>
                             <br />
@@ -311,7 +311,7 @@
                         </p>
                         <hr />
                         <p>
-                            <strong>Latest review:</strong> <a href="https://github.com/jabrena/cursor-rules-java/blob/main/documentation/reviews/review-20250829.md" target="_blank">https://github.com/jabrena/cursor-rules-java/blob/main/documentation/reviews/review-20250829.md</a>
+                            <strong>Latest review:</strong> <a href="https://github.com/jabrena/plinth/blob/main/documentation/reviews/review-20250829.md" target="_blank">https://github.com/jabrena/plinth/blob/main/documentation/reviews/review-20250829.md</a>
                         </p>
                     </section>
                     <section>
@@ -356,7 +356,7 @@
                     <h2>References</h2>
                     <ul>
                         <li>
-                            <a href="https://github.com/jabrena/cursor-rules-java" target="_blank">
+                            <a href="https://github.com/jabrena/plinth" target="_blank">
                                 Cursor Rules Java @ jabrena
                             </a>
                         </li>

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/cursor-rules-java/</id>
   <title>Skills & Agents for Java</title>
-  <updated>2026-07-07T21:32:54+0200</updated>
+  <updated>2026-07-07T21:41:37+0200</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/cursor-rules-java/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/cursor-rules-java//feed.xml' />
   <entry>

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/cursor-rules-java/</id>
   <title>Skills & Agents for Java</title>
-  <updated>2026-07-03T22:32:03+0200</updated>
+  <updated>2026-07-07T20:58:17+0200</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/cursor-rules-java/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/cursor-rules-java//feed.xml' />
   <entry>

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/cursor-rules-java/</id>
   <title>Skills & Agents for Java</title>
-  <updated>2026-07-07T20:58:17+0200</updated>
+  <updated>2026-07-07T21:32:54+0200</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/cursor-rules-java/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/cursor-rules-java//feed.xml' />
   <entry>

--- a/docs/index.html
+++ b/docs/index.html
@@ -295,7 +295,7 @@ That power is useful, but it also means a generated skill should not be treated 
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/agents.html
+++ b/docs/tags/agents.html
@@ -197,7 +197,7 @@ Starting with this release, the project introduces a simple way to describe any 
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/blog.html
+++ b/docs/tags/blog.html
@@ -597,7 +597,7 @@ In the previous release, the project added interactive behavior to a few complex
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/ci.html
+++ b/docs/tags/ci.html
@@ -132,7 +132,7 @@ That power is useful, but it also means a generated skill should not be treated 
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/commands.html
+++ b/docs/tags/commands.html
@@ -134,7 +134,7 @@ Starting with this release, the project introduces a simple way to describe any 
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/compliance.html
+++ b/docs/tags/compliance.html
@@ -134,7 +134,7 @@ This second article explains the remaining regulation and ISO skills added for t
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/design.html
+++ b/docs/tags/design.html
@@ -166,7 +166,7 @@ Software engineering is not only the ability to produce code. It is the ability 
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/eu.html
+++ b/docs/tags/eu.html
@@ -164,7 +164,7 @@ That means engineering teams need a practical way to translate reg...
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/generics.html
+++ b/docs/tags/generics.html
@@ -259,7 +259,7 @@ Applied all generics co...
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/java-25.html
+++ b/docs/tags/java-25.html
@@ -134,7 +134,7 @@ With JFR, production evidence replaces g...
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/java.html
+++ b/docs/tags/java.html
@@ -803,7 +803,7 @@ Applied all generics co...
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/jfr.html
+++ b/docs/tags/jfr.html
@@ -134,7 +134,7 @@ With JFR, production evidence replaces g...
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/performance.html
+++ b/docs/tags/performance.html
@@ -134,7 +134,7 @@ With JFR, production evidence replaces g...
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/profiling.html
+++ b/docs/tags/profiling.html
@@ -294,7 +294,7 @@ Module 3:...
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/regulations.html
+++ b/docs/tags/regulations.html
@@ -195,7 +195,7 @@ That means engineering teams need a practical way to translate reg...
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/security.html
+++ b/docs/tags/security.html
@@ -132,7 +132,7 @@ That power is useful, but it also means a generated skill should not be treated 
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/skills.html
+++ b/docs/tags/skills.html
@@ -287,7 +287,7 @@ That means engineering teams need a practical way to translate reg...
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/software-engineering.html
+++ b/docs/tags/software-engineering.html
@@ -166,7 +166,7 @@ Software engineering is not only the ability to produce code. It is the ability 
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/docs/tags/system-prompts.html
+++ b/docs/tags/system-prompts.html
@@ -332,7 +332,7 @@ Difficulty:...
     </a>
   </li>
   <li>
-    <a href="https://github.com/jabrena/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>

--- a/documentation/MAINTENANCE.md
+++ b/documentation/MAINTENANCE.md
@@ -39,7 +39,7 @@ Can you update the current changelog for 0.17.0 comparing git commits in relatio
 
 - [ ] Update CHANGELOG.md
 - [ ] Remove SNAPSHOT from .xml, .md & pom.xml
-- [ ] Review git changes for hidden issues (Manual) https://github.com/jabrena/cursor-rules-java/compare/0.16.0...feature/release-0170
+- [ ] Review git changes for hidden issues (Manual) https://github.com/jabrena/plinth/compare/0.16.0...feature/release-0170
 - [ ] Verify if all features were tested propertly
 - [ ] Review if Agents need to add more Skills
 - [ ] Review Skill validation output
@@ -60,10 +60,10 @@ Can you update the current changelog for 0.17.0 comparing git commits in relatio
 
 ```bash
 # Review Skill registries
-https://github.com/jabrena/cursor-rules-java
+https://github.com/jabrena/plinth
 https://tessl.io/registry/skills/submit
 npx tessl skill review ./skills/xxx
-cd target && npx skills add jabrena/cursor-rules-java --all --agent cursor && cd ..
+cd target && npx skills add jabrena/plinth --all --agent cursor && cd ..
 ```
 
 ---

--- a/documentation/adr/ADR-006-separate-local-skill-generation-from-release-publishing.md
+++ b/documentation/adr/ADR-006-separate-local-skill-generation-from-release-publishing.md
@@ -84,5 +84,5 @@ The implementation is confirmed when:
 
 ## More Information
 
-* Issue: https://github.com/jabrena/cursor-rules-java/issues/751
+* Issue: https://github.com/jabrena/plinth/issues/751
 * Prior decisions: [ADR-004](./ADR-004-skill-generation.md), [ADR-005](./ADR-005-drop-cursor-rules-support-in-favor-of-agent-skills.md)

--- a/documentation/conferences/codemotion-madrid-2026/index.html
+++ b/documentation/conferences/codemotion-madrid-2026/index.html
@@ -508,7 +508,7 @@ ventana de contexto, maneja tipos de trabajo específicos y devuelve su resultad
                             <a href="https://skills.sh/" target="_blank">https://skills.sh/</a>
                         </li>
                         <li>
-                            <a href="https://github.com/jabrena/cursor-rules-java" target="_blank">
+                            <a href="https://github.com/jabrena/plinth" target="_blank">
                                 Cursor Rules Java @ jabrena
                             </a>
                         </li>

--- a/documentation/conferences/dvbe25/index.html
+++ b/documentation/conferences/dvbe25/index.html
@@ -251,9 +251,9 @@
                             <strong>Examples:</strong>
                         </p>
                         <p>
-                            <a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/128-java-generics.md" target="_blank">128-java-generics.md</a>
+                            <a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/128-java-generics.md" target="_blank">128-java-generics.md</a>
                             <br />
-                            <a href="https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/131-java-unit-testing.md" target="_blank">131-java-unit-testing.md</a>
+                            <a href="https://github.com/jabrena/plinth/blob/main/.cursor/rules/131-java-unit-testing.md" target="_blank">131-java-unit-testing.md</a>
                             <br />
                             <a href="https://github.com/jabrena/cursor-rules-agile/blob/main/.cursor/rules/2003-agile-create-user-story.mdc" target="_blank">2003-agile-create-user-story.mdc</a>
                             <br />
@@ -311,7 +311,7 @@
                         </p>
                         <hr />
                         <p>
-                            <strong>Latest review:</strong> <a href="https://github.com/jabrena/cursor-rules-java/blob/main/documentation/reviews/review-20250829.md" target="_blank">https://github.com/jabrena/cursor-rules-java/blob/main/documentation/reviews/review-20250829.md</a>
+                            <strong>Latest review:</strong> <a href="https://github.com/jabrena/plinth/blob/main/documentation/reviews/review-20250829.md" target="_blank">https://github.com/jabrena/plinth/blob/main/documentation/reviews/review-20250829.md</a>
                         </p>
                     </section>
                     <section>
@@ -356,7 +356,7 @@
                     <h2>References</h2>
                     <ul>
                         <li>
-                            <a href="https://github.com/jabrena/cursor-rules-java" target="_blank">
+                            <a href="https://github.com/jabrena/plinth" target="_blank">
                                 Cursor Rules Java @ jabrena
                             </a>
                         </li>

--- a/documentation/guides/GETTING-STARTED-IN-5-MINUTES.md
+++ b/documentation/guides/GETTING-STARTED-IN-5-MINUTES.md
@@ -17,32 +17,32 @@ If either command is missing, install Node.js with your operating system package
 
 ## 2. Choose your agent and download the Skills
 
-Install every skill from the [Skills.sh registry entry](https://skills.sh/jabrena/cursor-rules-java) for this project into the agent you use most often:
+Install every skill from the [Skills.sh registry entry](https://skills.sh/jabrena/plinth) for this project into the agent you use most often:
 
 ```bash
 # Cursor
-npx skills add jabrena/cursor-rules-java --skill '*' --agent cursor -y
+npx skills add jabrena/plinth --skill '*' --agent cursor -y
 
 # Claude Code
-npx skills add jabrena/cursor-rules-java --skill '*' --agent claude-code -y
+npx skills add jabrena/plinth --skill '*' --agent claude-code -y
 
 # Codex
-npx skills add jabrena/cursor-rules-java --skill '*' --agent codex -y
+npx skills add jabrena/plinth --skill '*' --agent codex -y
 
 # GitHub Copilot
-npx skills add jabrena/cursor-rules-java --skill '*' --agent github-copilot -y
+npx skills add jabrena/plinth --skill '*' --agent github-copilot -y
 ```
 
 To install for every supported agent, use the CLI's all-agent mode:
 
 ```bash
-npx skills add jabrena/cursor-rules-java --skill '*' --agent '*' -y
+npx skills add jabrena/plinth --skill '*' --agent '*' -y
 ```
 
 To inspect the available skills first:
 
 ```bash
-npx skills add jabrena/cursor-rules-java --list
+npx skills add jabrena/plinth --list
 ```
 
 ## 3. Install the project commands

--- a/documentation/guides/GETTING-STARTED-IN-5-MINUTES_ES.md
+++ b/documentation/guides/GETTING-STARTED-IN-5-MINUTES_ES.md
@@ -17,32 +17,32 @@ Si falta alguno de los comandos, instala Node.js con el gestor de paquetes de tu
 
 ## 2. Elige tu agente y descarga los Skills
 
-Instala todos los skills desde la [entrada del registry de Skills.sh](https://skills.sh/jabrena/cursor-rules-java) de este proyecto en el agente que uses con más frecuencia:
+Instala todos los skills desde la [entrada del registry de Skills.sh](https://skills.sh/jabrena/plinth) de este proyecto en el agente que uses con más frecuencia:
 
 ```bash
 # Cursor
-npx skills add jabrena/cursor-rules-java --skill '*' --agent cursor -y
+npx skills add jabrena/plinth --skill '*' --agent cursor -y
 
 # Claude Code
-npx skills add jabrena/cursor-rules-java --skill '*' --agent claude-code -y
+npx skills add jabrena/plinth --skill '*' --agent claude-code -y
 
 # Codex
-npx skills add jabrena/cursor-rules-java --skill '*' --agent codex -y
+npx skills add jabrena/plinth --skill '*' --agent codex -y
 
 # GitHub Copilot
-npx skills add jabrena/cursor-rules-java --skill '*' --agent github-copilot -y
+npx skills add jabrena/plinth --skill '*' --agent github-copilot -y
 ```
 
 Para instalar en todos los agentes soportados, usa el modo multiagente de la CLI:
 
 ```bash
-npx skills add jabrena/cursor-rules-java --skill '*' --agent '*' -y
+npx skills add jabrena/plinth --skill '*' --agent '*' -y
 ```
 
 Para revisar primero los skills disponibles:
 
 ```bash
-npx skills add jabrena/cursor-rules-java --list
+npx skills add jabrena/plinth --list
 ```
 
 ## 3. Instala los commands del proyecto

--- a/documentation/guides/GETTING-STARTED-IN-5-MINUTES_ZH.md
+++ b/documentation/guides/GETTING-STARTED-IN-5-MINUTES_ZH.md
@@ -17,32 +17,32 @@ npx --version
 
 ## 2. 选择你的 agent 并下载 Skills
 
-从本项目的 [Skills.sh registry 条目](https://skills.sh/jabrena/cursor-rules-java) 将所有 skills 安装到你最常用的 agent：
+从本项目的 [Skills.sh registry 条目](https://skills.sh/jabrena/plinth) 将所有 skills 安装到你最常用的 agent：
 
 ```bash
 # Cursor
-npx skills add jabrena/cursor-rules-java --skill '*' --agent cursor -y
+npx skills add jabrena/plinth --skill '*' --agent cursor -y
 
 # Claude Code
-npx skills add jabrena/cursor-rules-java --skill '*' --agent claude-code -y
+npx skills add jabrena/plinth --skill '*' --agent claude-code -y
 
 # Codex
-npx skills add jabrena/cursor-rules-java --skill '*' --agent codex -y
+npx skills add jabrena/plinth --skill '*' --agent codex -y
 
 # GitHub Copilot
-npx skills add jabrena/cursor-rules-java --skill '*' --agent github-copilot -y
+npx skills add jabrena/plinth --skill '*' --agent github-copilot -y
 ```
 
 如果要安装到所有受支持的 agent，请使用 CLI 的全 agent 模式：
 
 ```bash
-npx skills add jabrena/cursor-rules-java --skill '*' --agent '*' -y
+npx skills add jabrena/plinth --skill '*' --agent '*' -y
 ```
 
 如果想先查看可用 skills：
 
 ```bash
-npx skills add jabrena/cursor-rules-java --list
+npx skills add jabrena/plinth --list
 ```
 
 ## 3. 安装项目 commands

--- a/documentation/guides/GETTING-STARTED-SKILLS.md
+++ b/documentation/guides/GETTING-STARTED-SKILLS.md
@@ -22,25 +22,25 @@ brew install node
 sudo apt install nodejs npm
 
 # Install at User level
-npx skills add jabrena/cursor-rules-java --global --agent cursor --all
-npx skills add jabrena/cursor-rules-java --global --agent claude-code --skill '*' -y
+npx skills add jabrena/plinth --global --agent cursor --all
+npx skills add jabrena/plinth --global --agent claude-code --skill '*' -y
 
 npx skills remove --global --agent cursor -y
 npx skills remove --global --agent claude-code --skill '*' -y
 npx skills remove --global -y \
-  $(jq -r '.skills | to_entries[] | select(.value.source == "jabrena/cursor-rules-java") | .key' ~/.agents/.skill-lock.json)
+  $(jq -r '.skills | to_entries[] | select(.value.source == "jabrena/plinth") | .key' ~/.agents/.skill-lock.json)
 
 # Install at project level
 npx skills --help
-npx skills add jabrena/cursor-rules-java --list
-npx skills add jabrena/cursor-rules-java --agent cursor --all
-npx skills add jabrena/cursor-rules-java --agent claude-code --all
+npx skills add jabrena/plinth --list
+npx skills add jabrena/plinth --agent cursor --all
+npx skills add jabrena/plinth --agent claude-code --all
 ```
 
 ### Using Claude plugins
 
 ```bash
-claude plugin marketplace add https://github.com/jabrena/cursor-rules-java
+claude plugin marketplace add https://github.com/jabrena/plinth
 ```
 
 ### Using Skillsjars

--- a/documentation/guides/GETTING-STARTED-SKILLS_ES.md
+++ b/documentation/guides/GETTING-STARTED-SKILLS_ES.md
@@ -22,25 +22,25 @@ brew install node
 sudo apt install nodejs npm
 
 # Install at User level
-npx skills add jabrena/cursor-rules-java --global --agent cursor --all
-npx skills add jabrena/cursor-rules-java --global --agent claude-code --skill '*' -y
+npx skills add jabrena/plinth --global --agent cursor --all
+npx skills add jabrena/plinth --global --agent claude-code --skill '*' -y
 
 npx skills remove --global --agent cursor -y
 npx skills remove --global --agent claude-code --skill '*' -y
 npx skills remove --global -y \
-  $(jq -r '.skills | to_entries[] | select(.value.source == "jabrena/cursor-rules-java") | .key' ~/.agents/.skill-lock.json)
+  $(jq -r '.skills | to_entries[] | select(.value.source == "jabrena/plinth") | .key' ~/.agents/.skill-lock.json)
 
 # Install at project level
 npx skills --help
-npx skills add jabrena/cursor-rules-java --list
-npx skills add jabrena/cursor-rules-java --agent cursor --all
-npx skills add jabrena/cursor-rules-java --agent claude-code --all
+npx skills add jabrena/plinth --list
+npx skills add jabrena/plinth --agent cursor --all
+npx skills add jabrena/plinth --agent claude-code --all
 ```
 
 ### Usando Claude plugins
 
 ```bash
-claude plugin marketplace add https://github.com/jabrena/cursor-rules-java
+claude plugin marketplace add https://github.com/jabrena/plinth
 ```
 
 ### Usando Skillsjars

--- a/documentation/guides/GETTING-STARTED-SKILLS_ZH.md
+++ b/documentation/guides/GETTING-STARTED-SKILLS_ZH.md
@@ -22,25 +22,25 @@ brew install node
 sudo apt install nodejs npm
 
 # Install at User level
-npx skills add jabrena/cursor-rules-java --global --agent cursor --all
-npx skills add jabrena/cursor-rules-java --global --agent claude-code --skill '*' -y
+npx skills add jabrena/plinth --global --agent cursor --all
+npx skills add jabrena/plinth --global --agent claude-code --skill '*' -y
 
 npx skills remove --global --agent cursor -y
 npx skills remove --global --agent claude-code --skill '*' -y
 npx skills remove --global -y \
-  $(jq -r '.skills | to_entries[] | select(.value.source == "jabrena/cursor-rules-java") | .key' ~/.agents/.skill-lock.json)
+  $(jq -r '.skills | to_entries[] | select(.value.source == "jabrena/plinth") | .key' ~/.agents/.skill-lock.json)
 
 # Install at project level
 npx skills --help
-npx skills add jabrena/cursor-rules-java --list
-npx skills add jabrena/cursor-rules-java --agent cursor --all
-npx skills add jabrena/cursor-rules-java --agent claude-code --all
+npx skills add jabrena/plinth --list
+npx skills add jabrena/plinth --agent cursor --all
+npx skills add jabrena/plinth --agent claude-code --all
 ```
 
 ### 使用 Claude plugins
 
 ```bash
-claude plugin marketplace add https://github.com/jabrena/cursor-rules-java
+claude plugin marketplace add https://github.com/jabrena/plinth
 ```
 
 ### 使用 Skillsjars

--- a/documentation/guides/GETTING-STARTED-SYSTEM-PROMPTS.md
+++ b/documentation/guides/GETTING-STARTED-SYSTEM-PROMPTS.md
@@ -36,7 +36,7 @@ Once you have downloaded it, go to the `Downloads` folder in your system and you
 
 ### Using the latest tagged zipped rules
 
-Downloading the zipped release is the safest approach if you are interested in using the latest well-tested release. Go to [the latest release](https://github.com/jabrena/cursor-rules-java/releases) and download the zip assets included in the latest release. As in the previous case, download the zip, unzip it and copy the folder `.cursor` into the Java repository where you want to use these Cursor rules.
+Downloading the zipped release is the safest approach if you are interested in using the latest well-tested release. Go to [the latest release](https://github.com/jabrena/plinth/releases) and download the zip assets included in the latest release. As in the previous case, download the zip, unzip it and copy the folder `.cursor` into the Java repository where you want to use these Cursor rules.
 
 ### Using a JBang CLI program specialized in this task
 
@@ -49,7 +49,7 @@ Execute the following commands to use it:
 ```bash
 sdk install jbang
 # Add System Prompts for Java in .cursor/rules
-jbang --fresh setup@jabrena init --cursor https://github.com/jabrena/cursor-rules-java
+jbang --fresh setup@jabrena init --cursor https://github.com/jabrena/plinth
 ```
 
 ## Using your first System prompt in your Java repository
@@ -70,4 +70,4 @@ Create a document with all System prompts for Java using @000-system-prompt-list
 
 ## Do you want to learn more?
 
-For a full understanding of this project, follow the course [Mastering System Prompts for Java](https://jabrena.github.io/cursor-rules-java/courses/system-prompts-java/index.html).
+For a full understanding of this project, follow [jabrena/plinth](https://github.com/jabrena/plinth).

--- a/documentation/guides/PROJECT-REFERENCES.md
+++ b/documentation/guides/PROJECT-REFERENCES.md
@@ -53,9 +53,9 @@ This page collects talks, articles, reference links, skill portals, and related 
 
 ### Skill Portals
 
-- [skills.sh cursor-rules-java](https://skills.sh/jabrena/cursor-rules-java)
+- [skills.sh cursor-rules-java](https://skills.sh/jabrena/plinth)
 - [Vercel Labs skills issues](https://github.com/vercel-labs/skills/issues)
-- [Tessl skill registry](https://tessl.io/registry/skills/github/jabrena/cursor-rules-java)
+- [Tessl skill registry](https://tessl.io/registry/skills/github/jabrena/plinth)
 - [ClaudSkills author page](https://claudskills.com/author/jabrena/)
 - [Claude Marketplaces Java skills category](https://claudemarketplaces.com/skills/category/java)
 - [Agent Skills Chinese portal](https://agent-skills.cc/zh/skills/jabrena-cursor-rules-java)
@@ -68,7 +68,7 @@ This page collects talks, articles, reference links, skill portals, and related 
 - [SkillsLLM cursor-rules-java](https://skillsllm.com/skill/cursor-rules-java)
 - [911 Fund cursor-rules-java tool page](https://skills.911fund.io/tools/jabrena-cursor-rules-java)
 - [SkillsLLM cursor-rules-java vs superpowers comparison](https://skillsllm.com/compare/cursor-rules-java-vs-superpowers)
-- [Cross AI Tools cursor-rules-java skill page](https://crossaitools.com/skills/jabrena/cursor-rules-java)
+- [Cross AI Tools cursor-rules-java skill page](https://crossaitools.com/skills/jabrena/plinth)
 - [77taoletao cursor-rules-java skill page](https://77taoletao.com/skills/83)
 - [Open Claw directory rules](https://open-claw.directory/rules)
 
@@ -81,6 +81,6 @@ This page collects talks, articles, reference links, skill portals, and related 
 ## Other Developments
 
 - [PML](https://github.com/jabrena/pml)
-- [cursor-rules-java](https://github.com/jabrena/cursor-rules-java)
+- [cursor-rules-java](https://github.com/jabrena/plinth)
 - [AI Agent Harness Monitor CLI](https://github.com/jabrena/ai-agent-harness-monitor-cli)
 - [setup-cli](https://github.com/jabrena/setup-cli)

--- a/documentation/guides/PROJECT-REFERENCES_ES.md
+++ b/documentation/guides/PROJECT-REFERENCES_ES.md
@@ -53,9 +53,9 @@ Esta página reúne charlas, artículos, enlaces de referencia, portales de skil
 
 ### Portales de Skills
 
-- [skills.sh cursor-rules-java](https://skills.sh/jabrena/cursor-rules-java)
+- [skills.sh cursor-rules-java](https://skills.sh/jabrena/plinth)
 - [Issues de Vercel Labs skills](https://github.com/vercel-labs/skills/issues)
-- [Registro de skills de Tessl](https://tessl.io/registry/skills/github/jabrena/cursor-rules-java)
+- [Registro de skills de Tessl](https://tessl.io/registry/skills/github/jabrena/plinth)
 - [Página de autor en ClaudSkills](https://claudskills.com/author/jabrena/)
 - [Categoría de skills Java en Claude Marketplaces](https://claudemarketplaces.com/skills/category/java)
 - [Portal chino de Agent Skills](https://agent-skills.cc/zh/skills/jabrena-cursor-rules-java)
@@ -68,7 +68,7 @@ Esta página reúne charlas, artículos, enlaces de referencia, portales de skil
 - [SkillsLLM cursor-rules-java](https://skillsllm.com/skill/cursor-rules-java)
 - [Página de herramienta cursor-rules-java en 911 Fund](https://skills.911fund.io/tools/jabrena-cursor-rules-java)
 - [Comparativa de SkillsLLM entre cursor-rules-java y superpowers](https://skillsllm.com/compare/cursor-rules-java-vs-superpowers)
-- [Página de skill cursor-rules-java en Cross AI Tools](https://crossaitools.com/skills/jabrena/cursor-rules-java)
+- [Página de skill cursor-rules-java en Cross AI Tools](https://crossaitools.com/skills/jabrena/plinth)
 - [Página de skill cursor-rules-java en 77taoletao](https://77taoletao.com/skills/83)
 - [Reglas del directorio Open Claw](https://open-claw.directory/rules)
 
@@ -81,6 +81,6 @@ Esta página reúne charlas, artículos, enlaces de referencia, portales de skil
 ## Otros Desarrollos
 
 - [PML](https://github.com/jabrena/pml)
-- [cursor-rules-java](https://github.com/jabrena/cursor-rules-java)
+- [cursor-rules-java](https://github.com/jabrena/plinth)
 - [AI Agent Harness Monitor CLI](https://github.com/jabrena/ai-agent-harness-monitor-cli)
 - [setup-cli](https://github.com/jabrena/setup-cli)

--- a/documentation/guides/PROJECT-REFERENCES_ZH.md
+++ b/documentation/guides/PROJECT-REFERENCES_ZH.md
@@ -53,9 +53,9 @@
 
 ### Skill 门户
 
-- [skills.sh cursor-rules-java](https://skills.sh/jabrena/cursor-rules-java)
+- [skills.sh cursor-rules-java](https://skills.sh/jabrena/plinth)
 - [Vercel Labs skills issues](https://github.com/vercel-labs/skills/issues)
-- [Tessl skill registry](https://tessl.io/registry/skills/github/jabrena/cursor-rules-java)
+- [Tessl skill registry](https://tessl.io/registry/skills/github/jabrena/plinth)
 - [ClaudSkills 作者页](https://claudskills.com/author/jabrena/)
 - [Claude Marketplaces Java skills 分类](https://claudemarketplaces.com/skills/category/java)
 - [Agent Skills 中文门户](https://agent-skills.cc/zh/skills/jabrena-cursor-rules-java)
@@ -68,7 +68,7 @@
 - [SkillsLLM cursor-rules-java](https://skillsllm.com/skill/cursor-rules-java)
 - [911 Fund cursor-rules-java 工具页面](https://skills.911fund.io/tools/jabrena-cursor-rules-java)
 - [SkillsLLM cursor-rules-java 与 superpowers 对比](https://skillsllm.com/compare/cursor-rules-java-vs-superpowers)
-- [Cross AI Tools cursor-rules-java skill 页面](https://crossaitools.com/skills/jabrena/cursor-rules-java)
+- [Cross AI Tools cursor-rules-java skill 页面](https://crossaitools.com/skills/jabrena/plinth)
 - [77taoletao cursor-rules-java skill 页面](https://77taoletao.com/skills/83)
 - [Open Claw directory 规则页](https://open-claw.directory/rules)
 
@@ -81,6 +81,6 @@
 ## 其他项目
 
 - [PML](https://github.com/jabrena/pml)
-- [cursor-rules-java](https://github.com/jabrena/cursor-rules-java)
+- [cursor-rules-java](https://github.com/jabrena/plinth)
 - [AI Agent Harness Monitor CLI](https://github.com/jabrena/ai-agent-harness-monitor-cli)
 - [setup-cli](https://github.com/jabrena/setup-cli)

--- a/documentation/guides/THIRD-PARTIES.md
+++ b/documentation/guides/THIRD-PARTIES.md
@@ -4,6 +4,9 @@ This repository develop System Prompts, Skills & Agents but in the ecosystem exi
 
 ## Skills
 
+- https://agentskillshub.top/skill/jabrena/plinth/
+- https://mcpapp-store.com/skills?q=Mongock+
+- https://jvmskills.com/
 - https://skills.sh/teachingai/agent-skills/maven-search
 - https://github.com/making/claude-skills
 - https://github.com/levnikolaevich/claude-code-skills/tree/master/skills-catalog

--- a/documentation/openspec/changes/archive/2026-04-07-add-701-technologies-openapi/proposal.md
+++ b/documentation/openspec/changes/archive/2026-04-07-add-701-technologies-openapi/proposal.md
@@ -2,7 +2,7 @@
 
 ## Problem Statement
 
-Issue [#537](https://github.com/jabrena/cursor-rules-java/issues/537) requests OpenAPI best-practices support. Today, OpenAPI guidance is embedded primarily in framework REST skills (`302`, `402`, `502`). There is no **framework-agnostic** skill under a dedicated **technologies** band for API contracts, so agents lack a single trigger for spec quality, validation, lifecycle, and codegen handoffs without choosing Spring, Quarkus, or Micronaut first.
+Issue [#537](https://github.com/jabrena/plinth/issues/537) requests OpenAPI best-practices support. Today, OpenAPI guidance is embedded primarily in framework REST skills (`302`, `402`, `502`). There is no **framework-agnostic** skill under a dedicated **technologies** band for API contracts, so agents lack a single trigger for spec quality, validation, lifecycle, and codegen handoffs without choosing Spring, Quarkus, or Micronaut first.
 
 Without a structured OpenSpec change, numbering (`701`), scope boundaries, and verification expectations can drift.
 

--- a/documentation/openspec/changes/archive/2026-04-07-add-701-technologies-openapi/specs/technologies-openapi/spec.md
+++ b/documentation/openspec/changes/archive/2026-04-07-add-701-technologies-openapi/specs/technologies-openapi/spec.md
@@ -11,7 +11,7 @@ The repository SHALL define the framework-agnostic OpenAPI guidance skill identi
 - **Given** maintainers implement OpenAPI best-practices guidance in generator sources
 - **When** they create or reference the skill in XML, inventories, or documentation
 - **Then** the identifier used is `701-technologies-openapi`
-- **And** references are consistent across OpenSpec artifacts and GitHub issue [#537](https://github.com/jabrena/cursor-rules-java/issues/537)
+- **And** references are consistent across OpenSpec artifacts and GitHub issue [#537](https://github.com/jabrena/plinth/issues/537)
 
 ### Requirement: Framework-Agnostic Scope
 

--- a/documentation/openspec/changes/archive/2026-04-07-add-702-technologies-wiremock/proposal.md
+++ b/documentation/openspec/changes/archive/2026-04-07-add-702-technologies-wiremock/proposal.md
@@ -2,7 +2,7 @@
 
 ## Problem Statement
 
-Issue [#544](https://github.com/jabrena/cursor-rules-java/issues/544) requests WireMock best-practices support. Today, WireMock guidance is embedded primarily in integration-test–oriented skills (`132`, `322`, `422`, `522`). There is no **framework-agnostic** skill under the **technologies** band (`700`–`799`) for HTTP stubbing, mapping lifecycle, and verification patterns, so agents lack a single trigger for portable WireMock work without choosing Spring Boot, Quarkus, or Micronaut first.
+Issue [#544](https://github.com/jabrena/plinth/issues/544) requests WireMock best-practices support. Today, WireMock guidance is embedded primarily in integration-test–oriented skills (`132`, `322`, `422`, `522`). There is no **framework-agnostic** skill under the **technologies** band (`700`–`799`) for HTTP stubbing, mapping lifecycle, and verification patterns, so agents lack a single trigger for portable WireMock work without choosing Spring Boot, Quarkus, or Micronaut first.
 
 Without a structured OpenSpec change, numbering (`702`), scope boundaries, and verification expectations can drift.
 

--- a/documentation/openspec/changes/archive/2026-04-07-add-702-technologies-wiremock/specs/technologies-wiremock/spec.md
+++ b/documentation/openspec/changes/archive/2026-04-07-add-702-technologies-wiremock/specs/technologies-wiremock/spec.md
@@ -11,7 +11,7 @@ The repository SHALL define the framework-agnostic WireMock guidance skill ident
 - **Given** maintainers implement WireMock best-practices guidance in generator sources
 - **When** they create or reference the skill in XML, inventories, or documentation
 - **Then** the identifier used is `702-technologies-wiremock`
-- **And** references are consistent across OpenSpec artifacts and GitHub issue [#544](https://github.com/jabrena/cursor-rules-java/issues/544)
+- **And** references are consistent across OpenSpec artifacts and GitHub issue [#544](https://github.com/jabrena/plinth/issues/544)
 
 ### Requirement: Framework-Agnostic Scope
 

--- a/documentation/openspec/changes/archive/2026-04-07-add-invest-criteria-user-story-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-04-07-add-invest-criteria-user-story-skill/proposal.md
@@ -2,7 +2,7 @@
 
 ## Problem Statement
 
-Issue [#540](https://github.com/jabrena/cursor-rules-java/issues/540) identifies a quality gap in the `014-agile-user-story` skill: the guidance does not explicitly require validating stories with the INVEST criteria.
+Issue [#540](https://github.com/jabrena/plinth/issues/540) identifies a quality gap in the `014-agile-user-story` skill: the guidance does not explicitly require validating stories with the INVEST criteria.
 
 Without an explicit INVEST checkpoint, generated stories can be incomplete or weak in quality dimensions such as independence, estimability, and testability.
 

--- a/documentation/openspec/changes/archive/2026-06-06-add-cats-fuzz-testing/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-06-add-cats-fuzz-testing/proposal.md
@@ -2,7 +2,7 @@
 
 ## Problem Statement
 
-Issue [#496](https://github.com/jabrena/cursor-rules-java/issues/496) requests fuzz testing support with CATS, but there is no structured OpenSpec change that defines expected behavior, quality gates, and contributor workflow.
+Issue [#496](https://github.com/jabrena/plinth/issues/496) requests fuzz testing support with CATS, but there is no structured OpenSpec change that defines expected behavior, quality gates, and contributor workflow.
 
 Without a formalized change, the implementation can drift across CI, documentation, and API validation expectations.
 

--- a/documentation/openspec/changes/archive/2026-06-06-package-skill-runtime-resources/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-06-package-skill-runtime-resources/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-Issue [#801](https://github.com/jabrena/cursor-rules-java/issues/801) identifies five runtime resources that are currently expanded into generated reference Markdown instead of being packaged as standalone Agent Skills files. Packaging them in `scripts/` and `assets/` keeps references concise and lets agents inspect, copy, or execute the original resources directly.
+Issue [#801](https://github.com/jabrena/plinth/issues/801) identifies five runtime resources that are currently expanded into generated reference Markdown instead of being packaged as standalone Agent Skills files. Packaging them in `scripts/` and `assets/` keeps references concise and lets agents inspect, copy, or execute the original resources directly.
 
 ## What Changes
 

--- a/documentation/openspec/changes/archive/2026-06-07-add-analysis-design-agents/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-07-add-analysis-design-agents/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-Issue [#806](https://github.com/jabrena/cursor-rules-java/issues/806) requires clear ownership for analysis, architecture, planning, and delivery. Agent work can proceed independently when it owns only canonical agent assets, the agent installer/inventory, migration behavior, and focused tests.
+Issue [#806](https://github.com/jabrena/plinth/issues/806) requires clear ownership for analysis, architecture, planning, and delivery. Agent work can proceed independently when it owns only canonical agent assets, the agent installer/inventory, migration behavior, and focused tests.
 
 ## What Changes
 

--- a/documentation/openspec/changes/archive/2026-06-07-add-analysis-design-commands/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-07-add-analysis-design-commands/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-Issue [#806](https://github.com/jabrena/cursor-rules-java/issues/806) requires clear command entry points for the analysis and design phase. Command work can be delivered independently from agent-role and planning-skill changes when ownership remains limited to embedded command assets, their installer, inventory, and focused tests.
+Issue [#806](https://github.com/jabrena/plinth/issues/806) requires clear command entry points for the analysis and design phase. Command work can be delivered independently from agent-role and planning-skill changes when ownership remains limited to embedded command assets, their installer, inventory, and focused tests.
 
 ## What Changes
 

--- a/documentation/openspec/changes/archive/2026-06-07-add-analysis-design-workflows/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-07-add-analysis-design-workflows/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-Issue [#806](https://github.com/jabrena/cursor-rules-java/issues/806) spans commands, agents, planning skills, migration documentation, and validation. This parent change coordinates four smaller changes so source work can proceed in parallel without duplicating ownership or creating conflicting task lists.
+Issue [#806](https://github.com/jabrena/plinth/issues/806) spans commands, agents, planning skills, migration documentation, and validation. This parent change coordinates four smaller changes so source work can proceed in parallel without duplicating ownership or creating conflicting task lists.
 
 ## What Changes
 

--- a/documentation/openspec/changes/archive/2026-06-07-add-composable-planning-workflows/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-07-add-composable-planning-workflows/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-Issue [#806](https://github.com/jabrena/cursor-rules-java/issues/806) requires design discovery and planning/OpenSpec workflows that can start independently from the artifacts a team already uses. This behavior belongs in XML skill sources and can be developed independently from command and agent asset changes.
+Issue [#806](https://github.com/jabrena/plinth/issues/806) requires design discovery and planning/OpenSpec workflows that can start independently from the artifacts a team already uses. This behavior belongs in XML skill sources and can be developed independently from command and agent asset changes.
 
 ## What Changes
 

--- a/documentation/openspec/changes/archive/2026-06-07-document-analysis-design-lifecycle/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-07-document-analysis-design-lifecycle/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-The command, agent, and planning-skill changes for issue [#806](https://github.com/jabrena/cursor-rules-java/issues/806) need one integration change to synchronize English, Spanish, and Chinese documentation, explain migration, and run final repository-wide validation after the parallel source changes are integrated.
+The command, agent, and planning-skill changes for issue [#806](https://github.com/jabrena/plinth/issues/806) need one integration change to synchronize English, Spanish, and Chinese documentation, explain migration, and run final repository-wide validation after the parallel source changes are integrated.
 
 ## What Changes
 

--- a/documentation/openspec/changes/archive/2026-06-08-add-bounded-context-plantuml-diagrams/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-08-add-bounded-context-plantuml-diagrams/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#817](https://github.com/jabrena/cursor-rules-java/issues/817) requests bounded-context diagrams for `033-architecture-diagrams` based on PlantUML guidance from Context Mapper. The current skill supports UML sequence, UML class, C4 Context/Container/Component, UML state-machine, and ER diagrams, but it does not offer a dedicated Domain-Driven Design bounded-context diagram path.
+GitHub issue [#817](https://github.com/jabrena/plinth/issues/817) requests bounded-context diagrams for `033-architecture-diagrams` based on PlantUML guidance from Context Mapper. The current skill supports UML sequence, UML class, C4 Context/Container/Component, UML state-machine, and ER diagrams, but it does not offer a dedicated Domain-Driven Design bounded-context diagram path.
 
 Users who want context-map style diagrams currently have to approximate them with C4 or class diagrams. That makes bounded contexts, upstream/downstream relationships, shared kernels, partnerships, anticorruption layers, and other DDD relationship concepts less explicit than they should be.
 
@@ -26,7 +26,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#817](https://github.com/jabrena/cursor-rules-java/issues/817), milestone `v0.16.0`.
+- Source artifact: GitHub issue [#817](https://github.com/jabrena/plinth/issues/817), milestone `v0.16.0`.
 - Source clarification: bounded-context diagrams may need multiple repositories as input so the generated context map can represent all bounded contexts in scope.
 - External reference: Context Mapper PlantUML generator documentation, https://contextmapper.org/docs/plant-uml/.
 - Related existing capability: `architecture-diagram-skill-references`.

--- a/documentation/openspec/changes/archive/2026-06-08-add-performance-operation-workflows/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-08-add-performance-operation-workflows/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#808](https://github.com/jabrena/cursor-rules-java/issues/808) identifies profiling and performance testing as the next operation lifecycle workflow after the analysis/design work delivered by issues #806 and #807. The repository already has performance and profiling skills, but users need concise commands and a coordinating agent that keep baselines, measurements, optimization delegation, and result evidence traceable.
+GitHub issue [#808](https://github.com/jabrena/plinth/issues/808) identifies profiling and performance testing as the next operation lifecycle workflow after the analysis/design work delivered by issues #806 and #807. The repository already has performance and profiling skills, but users need concise commands and a coordinating agent that keep baselines, measurements, optimization delegation, and result evidence traceable.
 
 ## What Changes
 
@@ -22,7 +22,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#808](https://github.com/jabrena/cursor-rules-java/issues/808), milestone `v0.16.0`.
+- Source artifact: GitHub issue [#808](https://github.com/jabrena/plinth/issues/808), milestone `v0.16.0`.
 - Related context: parent lifecycle gap issue #794 and completed analysis/design issues #806 and #807.
 - Derivation direction: issue #808 -> OpenSpec change artifacts -> implementation tasks. The issue remains the source for problem, scope, acceptance criteria, and out-of-scope boundaries.
 

--- a/documentation/openspec/changes/archive/2026-06-08-align-implement-issue-command/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-08-align-implement-issue-command/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#809](https://github.com/jabrena/cursor-rules-java/issues/809) identifies that `/implement` is a generic TDD prompt rather than a controlled route from an approved plan or OpenSpec task list to delegated implementation. Renaming it to `/implement-issue` makes the issue-driven lifecycle explicit while requiring an executable artifact before code delivery begins.
+GitHub issue [#809](https://github.com/jabrena/plinth/issues/809) identifies that `/implement` is a generic TDD prompt rather than a controlled route from an approved plan or OpenSpec task list to delegated implementation. Renaming it to `/implement-issue` makes the issue-driven lifecycle explicit while requiring an executable artifact before code delivery begins.
 
 ## What Changes
 

--- a/documentation/openspec/changes/archive/2026-06-08-split-architecture-diagrams-references/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-08-split-architecture-diagrams-references/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#818](https://github.com/jabrena/cursor-rules-java/issues/818) identifies that `033-architecture-diagrams` still relies on one large reference source for question flow, diagram-family implementation guidance, examples, constraints, and output organization rules. This makes the skill harder to maintain and easier to drift from its entry-point constraints, including the current C4 mismatch where the skill forbids Code/Level 4 diagrams while the generated reference still offers them.
+GitHub issue [#818](https://github.com/jabrena/plinth/issues/818) identifies that `033-architecture-diagrams` still relies on one large reference source for question flow, diagram-family implementation guidance, examples, constraints, and output organization rules. This makes the skill harder to maintain and easier to drift from its entry-point constraints, including the current C4 mismatch where the skill forbids Code/Level 4 diagrams while the generated reference still offers them.
 
 ## What Changes
 
@@ -23,7 +23,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#818](https://github.com/jabrena/cursor-rules-java/issues/818), milestone `v0.16.0`.
+- Source artifact: GitHub issue [#818](https://github.com/jabrena/plinth/issues/818), milestone `v0.16.0`.
 - Related source pattern: `111-java-maven-dependencies` and `112-java-maven-plugins` source-level split of question assets, skill orchestration, `skills.xml` reference registration, and focused references.
 - Derivation direction: issue #818 -> OpenSpec change artifacts -> implementation tasks. The issue remains the source for problem, scope, acceptance criteria, and implementation constraints.
 

--- a/documentation/openspec/changes/archive/2026-06-13-add-deployment-plantuml-diagrams/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-13-add-deployment-plantuml-diagrams/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#847](https://github.com/jabrena/cursor-rules-java/issues/847) requests UML Deployment Diagram support for `033-architecture-diagrams` using PlantUML. The current skill supports UML sequence, UML class, C4 Context/Container/Component, UML state-machine, ER, and bounded-context diagrams, but it does not offer a dedicated deployment topology path.
+GitHub issue [#847](https://github.com/jabrena/plinth/issues/847) requests UML Deployment Diagram support for `033-architecture-diagrams` using PlantUML. The current skill supports UML sequence, UML class, C4 Context/Container/Component, UML state-machine, ER, and bounded-context diagrams, but it does not offer a dedicated deployment topology path.
 
 Users who need to document deployed Java enterprise systems currently have to approximate runtime infrastructure with C4 or component diagrams. That makes runtime nodes, execution environments, deployed artifacts, infrastructure boundaries, external systems, and communication protocols less explicit than they should be.
 
@@ -27,7 +27,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#847](https://github.com/jabrena/cursor-rules-java/issues/847), milestone `v0.16.0`.
+- Source artifact: GitHub issue [#847](https://github.com/jabrena/plinth/issues/847), milestone `v0.16.0`.
 - External reference: [PlantUML Deployment Diagram](https://plantuml.com/es/deployment-diagram).
 - Related existing capability: `architecture-diagram-skill-references`.
 - Derivation direction: issue #847 plus PlantUML reference link -> OpenSpec change artifacts -> implementation tasks. The issue remains the source for problem, scope, acceptance criteria, and implementation constraints; the PlantUML reference informs syntax-oriented deployment diagram guidance.

--- a/documentation/openspec/changes/archive/2026-06-14-add-eu-cyber-resilience-act-regulation-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-14-add-eu-cyber-resilience-act-regulation-skill/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#855](https://github.com/jabrena/cursor-rules-java/issues/855) identifies the Cyber Resilience Act (CRA) as a pending part of the GenAI Regulatory Stack (EU). CRA guidance should be planned separately because security-by-design duties for products with digital elements have a different engineering focus than AI governance, privacy, financial ICT resilience, or critical-sector cybersecurity operations.
+GitHub issue [#855](https://github.com/jabrena/plinth/issues/855) identifies the Cyber Resilience Act (CRA) as a pending part of the GenAI Regulatory Stack (EU). CRA guidance should be planned separately because security-by-design duties for products with digital elements have a different engineering focus than AI governance, privacy, financial ICT resilience, or critical-sector cybersecurity operations.
 
 Java enterprise teams shipping libraries, services, agents, plugins, connected products, APIs, or platform components need CRA-aware guidance for secure-by-design development, vulnerability handling, update mechanisms, SBOM and dependency evidence, product security documentation, and coordinated disclosure workflows.
 
@@ -23,7 +23,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#855](https://github.com/jabrena/cursor-rules-java/issues/855), comment listing the GenAI Regulatory Stack (EU).
+- Source artifact: GitHub issue [#855](https://github.com/jabrena/plinth/issues/855), comment listing the GenAI Regulatory Stack (EU).
 - Existing implementation models: `801-regulations-eu-ai-act`, `802-regulations-dora`, and `803-regulations-gdpr`.
 - External reference: [Regulation (EU) 2024/2847](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32024R2847).
 - Derivation direction: issue #855 EU regulatory stack plus official EUR-Lex reference plus existing regulation skill pattern -> OpenSpec change artifacts -> XML skill source implementation -> local generated skill validation.

--- a/documentation/openspec/changes/archive/2026-06-14-add-eu-data-act-regulation-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-14-add-eu-data-act-regulation-skill/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#855](https://github.com/jabrena/cursor-rules-java/issues/855) identifies the Data Act as a pending part of the GenAI Regulatory Stack (EU). Data Act guidance should be planned separately because data access, portability, sharing, cloud switching, and non-personal data governance have a different engineering focus than AI Act, DORA, GDPR, NIS2, CRA, DSA, or DMA concerns.
+GitHub issue [#855](https://github.com/jabrena/plinth/issues/855) identifies the Data Act as a pending part of the GenAI Regulatory Stack (EU). Data Act guidance should be planned separately because data access, portability, sharing, cloud switching, and non-personal data governance have a different engineering focus than AI Act, DORA, GDPR, NIS2, CRA, DSA, or DMA concerns.
 
 Java enterprise teams building APIs, data platforms, SaaS products, connected-device integrations, AI data pipelines, or cloud services need Data Act-aware engineering guidance for data access controls, portability workflows, interoperability, contract/evidence handoffs, logging, non-personal data safeguards, and cloud-switching support.
 
@@ -23,7 +23,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#855](https://github.com/jabrena/cursor-rules-java/issues/855), comment listing the GenAI Regulatory Stack (EU).
+- Source artifact: GitHub issue [#855](https://github.com/jabrena/plinth/issues/855), comment listing the GenAI Regulatory Stack (EU).
 - Existing implementation models: `801-regulations-eu-ai-act`, `802-regulations-dora`, and `803-regulations-gdpr`.
 - External reference: [Regulation (EU) 2023/2854](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32023R2854).
 - Derivation direction: issue #855 EU regulatory stack plus official EUR-Lex reference plus existing regulation skill pattern -> OpenSpec change artifacts -> XML skill source implementation -> local generated skill validation.

--- a/documentation/openspec/changes/archive/2026-06-14-add-eu-digital-markets-act-regulation-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-14-add-eu-digital-markets-act-regulation-skill/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#855](https://github.com/jabrena/cursor-rules-java/issues/855) identifies the Digital Markets Act (DMA) as a pending part of the GenAI Regulatory Stack (EU). DMA guidance should be planned separately because gatekeeper obligations, interoperability, data access, self-preferencing, consent, and business-user controls have a different engineering focus than AI Act, DORA, GDPR, NIS2, CRA, Data Act, or DSA concerns.
+GitHub issue [#855](https://github.com/jabrena/plinth/issues/855) identifies the Digital Markets Act (DMA) as a pending part of the GenAI Regulatory Stack (EU). DMA guidance should be planned separately because gatekeeper obligations, interoperability, data access, self-preferencing, consent, and business-user controls have a different engineering focus than AI Act, DORA, GDPR, NIS2, CRA, Data Act, or DSA concerns.
 
 Java enterprise teams building platform services, marketplaces, app stores, advertising systems, identity services, ranking systems, or data access APIs need DMA-aware engineering guidance for gatekeeper-scope handoff, interoperability, data portability, audit evidence, business-user controls, and compliance-owner escalation.
 
@@ -23,7 +23,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#855](https://github.com/jabrena/cursor-rules-java/issues/855), comment listing the GenAI Regulatory Stack (EU).
+- Source artifact: GitHub issue [#855](https://github.com/jabrena/plinth/issues/855), comment listing the GenAI Regulatory Stack (EU).
 - Existing implementation models: `801-regulations-eu-ai-act`, `802-regulations-dora`, and `803-regulations-gdpr`.
 - External reference: [Regulation (EU) 2022/1925](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R1925).
 - Derivation direction: issue #855 EU regulatory stack plus official EUR-Lex reference plus existing regulation skill pattern -> OpenSpec change artifacts -> XML skill source implementation -> local generated skill validation.

--- a/documentation/openspec/changes/archive/2026-06-14-add-eu-digital-services-act-regulation-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-14-add-eu-digital-services-act-regulation-skill/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#855](https://github.com/jabrena/cursor-rules-java/issues/855) identifies the Digital Services Act (DSA) as a pending part of the GenAI Regulatory Stack (EU). DSA guidance should be planned separately because intermediary-service, platform, recommender, content moderation, transparency, and systemic-risk controls have a different engineering focus than AI Act, DORA, GDPR, NIS2, CRA, Data Act, or DMA concerns.
+GitHub issue [#855](https://github.com/jabrena/plinth/issues/855) identifies the Digital Services Act (DSA) as a pending part of the GenAI Regulatory Stack (EU). DSA guidance should be planned separately because intermediary-service, platform, recommender, content moderation, transparency, and systemic-risk controls have a different engineering focus than AI Act, DORA, GDPR, NIS2, CRA, Data Act, or DMA concerns.
 
 Java enterprise teams building online platforms, marketplaces, moderation tooling, ranking systems, recommender systems, ad delivery, complaint workflows, or transparency reporting pipelines need DSA-aware engineering guidance for traceability, explanation, audit evidence, risk mitigation, user controls, and escalation to platform governance owners.
 
@@ -23,7 +23,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#855](https://github.com/jabrena/cursor-rules-java/issues/855), comment listing the GenAI Regulatory Stack (EU).
+- Source artifact: GitHub issue [#855](https://github.com/jabrena/plinth/issues/855), comment listing the GenAI Regulatory Stack (EU).
 - Existing implementation models: `801-regulations-eu-ai-act`, `802-regulations-dora`, and `803-regulations-gdpr`.
 - External reference: [Regulation (EU) 2022/2065](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2065).
 - Derivation direction: issue #855 EU regulatory stack plus official EUR-Lex reference plus existing regulation skill pattern -> OpenSpec change artifacts -> XML skill source implementation -> local generated skill validation.

--- a/documentation/openspec/changes/archive/2026-06-14-add-eu-nis2-regulation-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-14-add-eu-nis2-regulation-skill/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#855](https://github.com/jabrena/cursor-rules-java/issues/855) adds a GenAI Regulatory Stack (EU) comment that extends the existing EU regulation skills beyond `801-regulations-eu-ai-act`, `802-regulations-dora`, and `803-regulations-gdpr`. NIS2 remains pending from that stack and needs its own reviewable OpenSpec change because cybersecurity obligations for critical and important entities differ from AI governance, financial ICT resilience, and privacy controls.
+GitHub issue [#855](https://github.com/jabrena/plinth/issues/855) adds a GenAI Regulatory Stack (EU) comment that extends the existing EU regulation skills beyond `801-regulations-eu-ai-act`, `802-regulations-dora`, and `803-regulations-gdpr`. NIS2 remains pending from that stack and needs its own reviewable OpenSpec change because cybersecurity obligations for critical and important entities differ from AI governance, financial ICT resilience, and privacy controls.
 
 Java enterprise teams building AI-enabled services, platform tooling, CI/CD automation, operational systems, or critical-sector integrations need NIS2-aware engineering guidance for cybersecurity risk management, incident handling, supply-chain security, vulnerability management, and audit-ready operational evidence.
 
@@ -24,7 +24,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#855](https://github.com/jabrena/cursor-rules-java/issues/855), comment listing the GenAI Regulatory Stack (EU).
+- Source artifact: GitHub issue [#855](https://github.com/jabrena/plinth/issues/855), comment listing the GenAI Regulatory Stack (EU).
 - Existing implementation models: `801-regulations-eu-ai-act`, `802-regulations-dora`, and `803-regulations-gdpr`.
 - External reference: [Directive (EU) 2022/2555](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022L2555).
 - Recent implementation evidence: commit `9bd50c97` (`feat(skills): add EU NIS2 regulation skill (#862)`), NIS2 Gherkin acceptance scenarios, and the generated example reports under `examples/regulations/nis2`.

--- a/documentation/openspec/changes/archive/2026-06-14-add-eu-regulation-skills/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-14-add-eu-regulation-skills/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#848](https://github.com/jabrena/cursor-rules-java/issues/848) requests regulation support for AI-related Java enterprise work. The first regulation skill in this area, `801-regulations-eu-ai-act`, already translates EU AI Act concerns into engineering controls for Java AI systems and agents, but the EU regulation set is incomplete without operational resilience and personal-data protection guidance.
+GitHub issue [#848](https://github.com/jabrena/plinth/issues/848) requests regulation support for AI-related Java enterprise work. The first regulation skill in this area, `801-regulations-eu-ai-act`, already translates EU AI Act concerns into engineering controls for Java AI systems and agents, but the EU regulation set is incomplete without operational resilience and personal-data protection guidance.
 
 Java enterprise teams building AI systems, AI agents, RAG workflows, integrations, and regulated business applications need separate guidance for DORA and GDPR because those regulations create different engineering review questions: ICT risk and operational resilience for DORA, and lawful personal-data processing and data-subject rights for GDPR.
 
@@ -26,7 +26,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#848](https://github.com/jabrena/cursor-rules-java/issues/848), milestone `v0.16.0`.
+- Source artifact: GitHub issue [#848](https://github.com/jabrena/plinth/issues/848), milestone `v0.16.0`.
 - Existing implementation model and structural baseline: `801-regulations-eu-ai-act`.
 - External reference: [DORA Regulation (EU) 2022/2554](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R2554).
 - External reference: [GDPR Regulation (EU) 2016/679](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32016R0679).

--- a/documentation/openspec/changes/archive/2026-06-25-improve-flyway-migration-guidance/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-25-improve-flyway-migration-guidance/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#895](https://github.com/jabrena/cursor-rules-java/issues/895) requests stronger Flyway guidance across the framework-specific skills. The current Spring Boot, Quarkus, and Micronaut Flyway skills cover dependency setup, script locations, naming, configuration, and basic verification, but they need more explicit advice about migration antipatterns, production data safety, branch-ordering risks, and incremental database-change techniques.
+GitHub issue [#895](https://github.com/jabrena/plinth/issues/895) requests stronger Flyway guidance across the framework-specific skills. The current Spring Boot, Quarkus, and Micronaut Flyway skills cover dependency setup, script locations, naming, configuration, and basic verification, but they need more explicit advice about migration antipatterns, production data safety, branch-ordering risks, and incremental database-change techniques.
 
 Maintainers need these skills to help users avoid subtle schema and data migration failures such as destructive renames, unsafe defaults, broad updates, repeatable migration surprises, and out-of-order branch migrations.
 
@@ -23,7 +23,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#895](https://github.com/jabrena/cursor-rules-java/issues/895).
+- Source artifact: GitHub issue [#895](https://github.com/jabrena/plinth/issues/895).
 - Existing implementation targets:
   - `skills-generator/src/main/resources/skill-references/313-frameworks-spring-db-migrations-flyway.xml`
   - `skills-generator/src/main/resources/skill-references/413-frameworks-quarkus-db-migrations-flyway.xml`

--- a/documentation/openspec/changes/archive/2026-06-25-improve-mongock-migration-guidance/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-25-improve-mongock-migration-guidance/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#902](https://github.com/jabrena/cursor-rules-java/issues/902) requests richer Mongock guidance across the framework-specific MongoDB migration skills. The current Spring Boot, Quarkus, and Micronaut Mongock skills cover runner setup, `@ChangeUnit` classes, lock behavior, and basic MongoDB-backed verification, but they need more explicit NoSQL migration-safety guidance and more examples focused on document-shape evolution.
+GitHub issue [#902](https://github.com/jabrena/plinth/issues/902) requests richer Mongock guidance across the framework-specific MongoDB migration skills. The current Spring Boot, Quarkus, and Micronaut Mongock skills cover runner setup, `@ChangeUnit` classes, lock behavior, and basic MongoDB-backed verification, but they need more explicit NoSQL migration-safety guidance and more examples focused on document-shape evolution.
 
 Maintainers need these skills to help users avoid subtle MongoDB data migration failures such as non-idempotent updates, unsafe document reshaping, domain-model coupling inside old migrations, long startup backfills, hidden lock failures, and unverified runner compatibility.
 
@@ -23,9 +23,9 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#902](https://github.com/jabrena/cursor-rules-java/issues/902).
+- Source artifact: GitHub issue [#902](https://github.com/jabrena/plinth/issues/902).
 - Supporting source artifact: maintainer-authored issue comment with MongoDB-oriented improvement ideas.
-- Related pattern source: GitHub issue [#895](https://github.com/jabrena/cursor-rules-java/issues/895) and OpenSpec change `improve-flyway-migration-guidance`, used as a structural precedent only.
+- Related pattern source: GitHub issue [#895](https://github.com/jabrena/plinth/issues/895) and OpenSpec change `improve-flyway-migration-guidance`, used as a structural precedent only.
 - Existing implementation targets:
   - `skills-generator/src/main/resources/skill-references/316-frameworks-spring-mongodb-migrations-mongock.xml`
   - `skills-generator/src/main/resources/skill-references/416-frameworks-quarkus-mongodb-migrations-mongock.xml`

--- a/documentation/openspec/changes/archive/2026-06-26-add-design-parallel-change-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-26-add-design-parallel-change-skill/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#932](https://github.com/jabrena/cursor-rules-java/issues/932) requests a dedicated `055-design-parallel-change` skill for database migration scenarios. The repository already contains framework-specific Flyway parallel-change references for Spring Boot, Quarkus, and Micronaut, and the archived `flyway-migration-skill-guidance` specification requires those Flyway skills to explain Parallel Change as an expand, migrate, contract technique.
+GitHub issue [#932](https://github.com/jabrena/plinth/issues/932) requests a dedicated `055-design-parallel-change` skill for database migration scenarios. The repository already contains framework-specific Flyway parallel-change references for Spring Boot, Quarkus, and Micronaut, and the archived `flyway-migration-skill-guidance` specification requires those Flyway skills to explain Parallel Change as an expand, migrate, contract technique.
 
 Java Enterprise developers need a cross-framework design skill because Parallel Change is a broader database evolution pattern, not only a Flyway framework detail. A dedicated design skill gives agents a reusable place to explain the pattern, identify when it applies, sequence safe database changes, and direct users back to framework-specific Flyway skills when implementation details are needed.
 
@@ -24,7 +24,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#932](https://github.com/jabrena/cursor-rules-java/issues/932).
+- Source artifact: GitHub issue [#932](https://github.com/jabrena/plinth/issues/932).
 - External reference: [Martin Fowler: Parallel Change](https://martinfowler.com/bliki/ParallelChange.html).
 - External reference: [DORA: Database Change Management](https://dora.dev/capabilities/database-change-management/).
 - Existing source reference: `skills-generator/src/main/resources/skill-references/313-frameworks-spring-db-migrations-flyway-parallel-change.xml`.

--- a/documentation/openspec/changes/archive/2026-06-26-add-design-two-steps-methods-skill/design.md
+++ b/documentation/openspec/changes/archive/2026-06-26-add-design-two-steps-methods-skill/design.md
@@ -50,7 +50,7 @@ The skill should discourage mixing broad refactoring and behavior changes in the
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#877](https://github.com/jabrena/cursor-rules-java/issues/877).
+- Source artifact: GitHub issue [#877](https://github.com/jabrena/plinth/issues/877).
 - Local issue cache read for this workflow: `.codex/issue/title.txt`, `.codex/issue/body.md`, and `.codex/issue/url.txt`.
 - Derivation direction: local issue cache -> sanitized maintainer-style planning summary -> this OpenSpec design -> XML generator implementation and validation.
 

--- a/documentation/openspec/changes/archive/2026-06-26-add-design-two-steps-methods-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-26-add-design-two-steps-methods-skill/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#877](https://github.com/jabrena/cursor-rules-java/issues/877) requests a dedicated skill named `051-design-two-steps-methods` for Kent Beck's two-step change method: make the change easy, then make the easy change.
+GitHub issue [#877](https://github.com/jabrena/plinth/issues/877) requests a dedicated skill named `051-design-two-steps-methods` for Kent Beck's two-step change method: make the change easy, then make the easy change.
 
 Java Enterprise practitioners need concise guidance for complex or risky code changes where preparatory refactoring should be separated from the intended behavior change. The skill should help agents and users plan changes in two explicit steps instead of mixing design preparation and behavior modification in one pass.
 
@@ -35,7 +35,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#877](https://github.com/jabrena/cursor-rules-java/issues/877).
+- Source artifact: GitHub issue [#877](https://github.com/jabrena/plinth/issues/877).
 - Local issue cache read for this workflow: `.codex/issue/title.txt`, `.codex/issue/body.md`, and `.codex/issue/url.txt`.
 - Trust basis: the `/create-spec` issue label is treated as maintainer approval to read the full issue body in this non-interactive workflow.
 - Derivation direction: local issue cache -> sanitized maintainer-style planning summary -> OpenSpec change artifacts -> XML skill source implementation -> local generated skill validation.

--- a/documentation/openspec/changes/archive/2026-06-26-add-design-two-steps-methods-skill/specs/design-two-steps-methods-skill-reference/spec.md
+++ b/documentation/openspec/changes/archive/2026-06-26-add-design-two-steps-methods-skill/specs/design-two-steps-methods-skill-reference/spec.md
@@ -72,6 +72,6 @@ The implementation MUST edit XML sources and validate generated local skill outp
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#877](https://github.com/jabrena/cursor-rules-java/issues/877).
+- Source artifact: GitHub issue [#877](https://github.com/jabrena/plinth/issues/877).
 - Local issue cache read for this workflow: `.codex/issue/title.txt`, `.codex/issue/body.md`, and `.codex/issue/url.txt`.
 - Derivation direction: local issue cache -> sanitized maintainer-style planning summary -> OpenSpec requirement delta -> XML skill source implementation -> local generated skill and acceptance validation.

--- a/documentation/openspec/changes/archive/2026-06-26-add-design-two-steps-methods-skill/tasks.md
+++ b/documentation/openspec/changes/archive/2026-06-26-add-design-two-steps-methods-skill/tasks.md
@@ -23,5 +23,5 @@
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#877](https://github.com/jabrena/cursor-rules-java/issues/877).
+- Source artifact: GitHub issue [#877](https://github.com/jabrena/plinth/issues/877).
 - Derivation direction: local issue cache -> sanitized maintainer-style planning summary -> OpenSpec task checklist -> XML skill source implementation and validation.

--- a/documentation/openspec/changes/archive/2026-06-26-add-hamburger-method-design-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-26-add-hamburger-method-design-skill/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#874](https://github.com/jabrena/cursor-rules-java/issues/874) requests a new `052-design-hamburger-method` skill for applying the Hamburger Method to large features, stories, plans, and OpenSpec changes.
+GitHub issue [#874](https://github.com/jabrena/plinth/issues/874) requests a new `052-design-hamburger-method` skill for applying the Hamburger Method to large features, stories, plans, and OpenSpec changes.
 
 Planning work can become too large when teams split by technical layer rather than by user-visible value. The Hamburger Method gives agents a structured way to identify workflow layers, compare quality options per layer, trim overbuilt choices, and compose small vertical slices that still deliver observable value.
 
@@ -25,7 +25,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#874](https://github.com/jabrena/cursor-rules-java/issues/874).
+- Source artifact: GitHub issue [#874](https://github.com/jabrena/plinth/issues/874).
 - External source: [Gojko Adzic, "Splitting user stories -- the hamburger method"](https://gojko.net/2012/01/23/splitting-user-stories-the-hamburger-method/).
 - External reference implementation: [skill-factory hamburger-method skill](https://github.com/eferro/skill-factory/tree/main/output_skills/practices/hamburger-method).
 - Existing implementation model: `051-design-two-steps-methods`.

--- a/documentation/openspec/changes/archive/2026-06-26-add-javamoney-guidance-to-maven-dependencies-skill/design.md
+++ b/documentation/openspec/changes/archive/2026-06-26-add-javamoney-guidance-to-maven-dependencies-skill/design.md
@@ -61,7 +61,7 @@ The existing `111-java-maven-dependencies` acceptance prompt is listed in `skill
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#875](https://github.com/jabrena/cursor-rules-java/issues/875).
+- Source artifact: GitHub issue [#875](https://github.com/jabrena/plinth/issues/875).
 - Derivation direction: GitHub issue #875 -> sanitized planning summary -> this OpenSpec design -> XML generator implementation and validation.
 
 ## Open Questions

--- a/documentation/openspec/changes/archive/2026-06-26-add-javamoney-guidance-to-maven-dependencies-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-26-add-javamoney-guidance-to-maven-dependencies-skill/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#875](https://github.com/jabrena/cursor-rules-java/issues/875) requests adding `javamoney.github.io` dependency guidance to `111-java-maven-dependencies`.
+GitHub issue [#875](https://github.com/jabrena/plinth/issues/875) requests adding `javamoney.github.io` dependency guidance to `111-java-maven-dependencies`.
 
 The Maven dependencies skill currently guides users through selected dependency families such as JSpecify, Error Prone with NullAway, VAVR, and ArchUnit. Maintainers need JavaMoney guidance available from the skill so agents can recognize when a Maven project needs Money and Currency API support and can direct users to the JavaMoney resource without editing generated output directly.
 
@@ -34,7 +34,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#875](https://github.com/jabrena/cursor-rules-java/issues/875).
+- Source artifact: GitHub issue [#875](https://github.com/jabrena/plinth/issues/875).
 - Source authority: issue #875 provides the user story, acceptance criteria, implementation notes, and INVEST validation for this OpenSpec change.
 - Derivation direction: GitHub issue #875 -> sanitized planning summary -> OpenSpec change artifacts -> XML skill source implementation -> local generated skill validation.
 

--- a/documentation/openspec/changes/archive/2026-06-26-add-javamoney-guidance-to-maven-dependencies-skill/specs/java-maven-dependencies-javamoney-guidance/spec.md
+++ b/documentation/openspec/changes/archive/2026-06-26-add-javamoney-guidance-to-maven-dependencies-skill/specs/java-maven-dependencies-javamoney-guidance/spec.md
@@ -52,5 +52,5 @@ The implementation MUST follow the repository acceptance prompt policy for regen
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#875](https://github.com/jabrena/cursor-rules-java/issues/875).
+- Source artifact: GitHub issue [#875](https://github.com/jabrena/plinth/issues/875).
 - Derivation direction: GitHub issue #875 -> sanitized planning summary -> OpenSpec requirement delta -> XML skill source implementation -> local generated skill and acceptance validation.

--- a/documentation/openspec/changes/archive/2026-06-26-add-javamoney-guidance-to-maven-dependencies-skill/tasks.md
+++ b/documentation/openspec/changes/archive/2026-06-26-add-javamoney-guidance-to-maven-dependencies-skill/tasks.md
@@ -22,5 +22,5 @@
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#875](https://github.com/jabrena/cursor-rules-java/issues/875).
+- Source artifact: GitHub issue [#875](https://github.com/jabrena/plinth/issues/875).
 - Derivation direction: GitHub issue #875 -> sanitized planning summary -> OpenSpec task checklist -> XML skill source implementation and validation.

--- a/documentation/openspec/changes/archive/2026-06-26-add-simple-design-rules-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-26-add-simple-design-rules-skill/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#903](https://github.com/jabrena/cursor-rules-java/issues/903) requests a new `053-design-simple-rules` skill for applying Kent Beck's simple design rules to Java design and refactoring decisions.
+GitHub issue [#903](https://github.com/jabrena/plinth/issues/903) requests a new `053-design-simple-rules` skill for applying Kent Beck's simple design rules to Java design and refactoring decisions.
 
 Java enterprise teams and agents need a compact design heuristic that keeps implementation work anchored in observable correctness before optimizing for clarity, duplication reduction, or minimal structure. A dedicated skill gives agents a consistent way to evaluate design tradeoffs without turning the rules into broad, speculative refactoring.
 
@@ -29,7 +29,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#903](https://github.com/jabrena/cursor-rules-java/issues/903).
+- Source artifact: GitHub issue [#903](https://github.com/jabrena/plinth/issues/903).
 - Issue source status: maintainer-authored user story and Gherkin acceptance criteria in the issue body.
 - External references:
   - [Why do the 4 rules of simple design have that order?](https://medium.com/dan-the-dev/why-do-the-4-rules-of-simple-design-have-that-order-b5f62bfe96fc)

--- a/documentation/openspec/changes/archive/2026-06-26-add-tdd-design-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-26-add-tdd-design-skill/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#931](https://github.com/jabrena/cursor-rules-java/issues/931) requests a new `054-design-tdd` skill for Test-Driven Development.
+GitHub issue [#931](https://github.com/jabrena/plinth/issues/931) requests a new `054-design-tdd` skill for Test-Driven Development.
 
 Java enterprise teams and agents need focused TDD guidance that starts from the next behavior, writes a failing test first, implements only enough production code to pass, and then refactors new and existing code while preserving the verification signal. A dedicated skill gives agents a consistent way to apply TDD without folding it into generic testing or design guidance.
 
@@ -30,7 +30,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#931](https://github.com/jabrena/cursor-rules-java/issues/931).
+- Source artifact: GitHub issue [#931](https://github.com/jabrena/plinth/issues/931).
 - Issue source status: maintainer-authored user story and Gherkin acceptance criteria in the issue body.
 - External reference:
   - [Martin Fowler, "Test Driven Development"](https://www.martinfowler.com/bliki/TestDrivenDevelopment.html)

--- a/documentation/openspec/changes/archive/2026-06-27-add-eu-market-abuse-regulation-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-27-add-eu-market-abuse-regulation-skill/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#876](https://github.com/jabrena/cursor-rules-java/issues/876) scopes the next EU regulation-skill batch to three explicit deliverables. This change covers the second deliverable: `811-regulations-eu-market-abuse-regulation`.
+GitHub issue [#876](https://github.com/jabrena/plinth/issues/876) scopes the next EU regulation-skill batch to three explicit deliverables. This change covers the second deliverable: `811-regulations-eu-market-abuse-regulation`.
 
 Java enterprise teams that build trading systems, surveillance platforms, suspicious order/transaction monitoring, disclosure workflows, insider-list support, or AI-assisted market-abuse detection need MAR-aware engineering guidance. The guidance must help teams produce reviewable evidence for compliance owners without turning the skill into legal advice.
 
@@ -23,7 +23,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#876](https://github.com/jabrena/cursor-rules-java/issues/876).
+- Source artifact: GitHub issue [#876](https://github.com/jabrena/plinth/issues/876).
 - Existing implementation model: `801-regulations-eu-ai-act`, `802-regulations-dora`, and `807-regulations-eu-digital-services-act`.
 - Official source: [Regulation (EU) No 596/2014 (Market Abuse Regulation), EUR-Lex](https://eur-lex.europa.eu/eli/reg/2014/596/oj/eng).
 - Derivation direction: issue #876 plus official MAR reference plus existing regulation skill pattern -> OpenSpec change artifacts -> XML skill source implementation -> local generated skill validation.

--- a/documentation/openspec/changes/archive/2026-06-27-add-eu-mifid-ii-regulation-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-27-add-eu-mifid-ii-regulation-skill/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#876](https://github.com/jabrena/cursor-rules-java/issues/876) scopes the next EU regulation-skill batch to three explicit deliverables. This change covers the first deliverable: `810-regulations-eu-mifid-ii`.
+GitHub issue [#876](https://github.com/jabrena/plinth/issues/876) scopes the next EU regulation-skill batch to three explicit deliverables. This change covers the first deliverable: `810-regulations-eu-mifid-ii`.
 
 Java enterprise teams that build investment-service systems, algorithmic trading workflows, order handling, client classification, suitability, appropriateness, or AI-assisted investment decision support need MiFID II-aware engineering guidance. The guidance must help teams produce reviewable evidence for compliance owners without turning the skill into legal advice.
 
@@ -23,7 +23,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#876](https://github.com/jabrena/cursor-rules-java/issues/876).
+- Source artifact: GitHub issue [#876](https://github.com/jabrena/plinth/issues/876).
 - Existing implementation model: `801-regulations-eu-ai-act`, `802-regulations-dora`, and `803-regulations-gdpr`.
 - Official source: [Directive 2014/65/EU (MiFID II), EUR-Lex](https://eur-lex.europa.eu/eli/dir/2014/65/oj/eng).
 - Derivation direction: issue #876 plus official MiFID II reference plus existing regulation skill pattern -> OpenSpec change artifacts -> XML skill source implementation -> local generated skill validation.

--- a/documentation/openspec/changes/archive/2026-06-27-add-eu-product-liability-directive-regulation-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-27-add-eu-product-liability-directive-regulation-skill/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#876](https://github.com/jabrena/cursor-rules-java/issues/876) scopes the next EU regulation-skill batch to three explicit deliverables. This change covers the third deliverable: `812-regulations-eu-product-liability-directive`.
+GitHub issue [#876](https://github.com/jabrena/plinth/issues/876) scopes the next EU regulation-skill batch to three explicit deliverables. This change covers the third deliverable: `812-regulations-eu-product-liability-directive`.
 
 Java enterprise teams that build AI-enabled software products, SaaS products, embedded software, GenAI assistants, RAG workflows, AI agents, generated instructions, automated updates, or cybersecurity-sensitive product features need Product Liability Directive-aware engineering guidance. The guidance must help teams produce reviewable product-liability evidence for qualified owners without turning the skill into legal advice.
 
@@ -23,7 +23,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#876](https://github.com/jabrena/cursor-rules-java/issues/876).
+- Source artifact: GitHub issue [#876](https://github.com/jabrena/plinth/issues/876).
 - Existing implementation model: `801-regulations-eu-ai-act`, `805-regulations-eu-cyber-resilience-act`, and `804-regulations-eu-nis2`.
 - Official source: [Directive (EU) 2024/2853, EUR-Lex](https://eur-lex.europa.eu/eli/dir/2024/2853/oj/eng).
 - Derivation direction: issue #876 plus official Product Liability Directive reference plus existing regulation skill pattern -> OpenSpec change artifacts -> XML skill source implementation -> local generated skill validation.

--- a/documentation/openspec/changes/archive/2026-06-27-add-iso-42001-genai-java-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-27-add-iso-42001-genai-java-skill/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#939](https://github.com/jabrena/cursor-rules-java/issues/939) asks for a skill that explains ISO/IEC 42001 in the same practical style as the existing EU AI Act skill, with emphasis on GenAI development with Java.
+GitHub issue [#939](https://github.com/jabrena/plinth/issues/939) asks for a skill that explains ISO/IEC 42001 in the same practical style as the existing EU AI Act skill, with emphasis on GenAI development with Java.
 
 Java enterprise teams using AI-assisted development, LLM integrations, RAG workflows, agents, generated code, external model providers, and AI-enabled business logic need source-first guidance that translates ISO/IEC 42001 AI management system concerns into reviewable engineering controls. The skill must help teams identify actionable evidence and escalation points without presenting legal, certification, or audit advice.
 
@@ -24,7 +24,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#939](https://github.com/jabrena/cursor-rules-java/issues/939).
+- Source artifact: GitHub issue [#939](https://github.com/jabrena/plinth/issues/939).
 - Official source references from issue #939:
   - [ISO - ISO/IEC 42001 explained](https://www.iso.org/home/insights-news/resources/iso-42001-explained-what-it-is.html)
   - [ISO/IEC 42001 standard page](https://www.iso.org/standard/42001)

--- a/documentation/openspec/changes/archive/2026-06-27-add-onion-architecture-technology-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-27-add-onion-architecture-technology-skill/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#940](https://github.com/jabrena/cursor-rules-java/issues/940) requests a dedicated `707-technologies-onion-architecture` skill. The issue identifies ArchUnit's architecture support as the source reference and frames the outcome as framework-agnostic Onion architecture guidance for Java enterprise developers and architects.
+GitHub issue [#940](https://github.com/jabrena/plinth/issues/940) requests a dedicated `707-technologies-onion-architecture` skill. The issue identifies ArchUnit's architecture support as the source reference and frames the outcome as framework-agnostic Onion architecture guidance for Java enterprise developers and architects.
 
 Java teams need focused guidance for reviewing and improving dependency direction between domain, application/use-case, adapter, and infrastructure concerns. The repository already has technology skills for framework-agnostic topics such as OpenAPI, WireMock, fuzz testing, SQL, MongoDB, and Docker; Onion architecture belongs in that same technology guidance family rather than inside Spring Boot, Quarkus, or Micronaut-specific skills.
 
@@ -25,7 +25,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#940](https://github.com/jabrena/cursor-rules-java/issues/940).
+- Source artifact: GitHub issue [#940](https://github.com/jabrena/plinth/issues/940).
 - External reference from issue: [ArchUnit architectures user guide](https://www.archunit.org/userguide/html/000_Index.html#_architectures).
 - Existing technology skill patterns: `701-technologies-openapi`, `702-technologies-wiremock`, and `706-technologies-containers-docker`.
 - Local command workflow: `.cursor/commands/create-spec.md`.

--- a/documentation/openspec/changes/archive/2026-06-27-convert-breaking-change-review-to-skill/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-27-convert-breaking-change-review-to-skill/proposal.md
@@ -1,8 +1,8 @@
 ## Why
 
-GitHub issue [#954](https://github.com/jabrena/cursor-rules-java/issues/954) requests converting the `/review-breaking-changes` command concept into a generated skill named `056-design-avoid-breaking-changes`.
+GitHub issue [#954](https://github.com/jabrena/plinth/issues/954) requests converting the `/review-breaking-changes` command concept into a generated skill named `056-design-avoid-breaking-changes`.
 
-The original command request in issue [#886](https://github.com/jabrena/cursor-rules-java/issues/886) asked for a way to review OpenSpec plans or specs for compatibility risks before implementation or release work proceeds. That value still matters, but the workflow should live in the skill system so breaking-change review guidance can evolve without creating another command-level contract to maintain.
+The original command request in issue [#886](https://github.com/jabrena/plinth/issues/886) asked for a way to review OpenSpec plans or specs for compatibility risks before implementation or release work proceeds. That value still matters, but the workflow should live in the skill system so breaking-change review guidance can evolve without creating another command-level contract to maintain.
 
 ## What Changes
 
@@ -24,8 +24,8 @@ The original command request in issue [#886](https://github.com/jabrena/cursor-r
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#954](https://github.com/jabrena/cursor-rules-java/issues/954).
-- Related source artifact: GitHub issue [#886](https://github.com/jabrena/cursor-rules-java/issues/886).
+- Source artifact: GitHub issue [#954](https://github.com/jabrena/plinth/issues/954).
+- Related source artifact: GitHub issue [#886](https://github.com/jabrena/plinth/issues/886).
 - Local command workflow: `.cursor/commands/create-spec.md`.
 - Local OpenSpec guidance: `042-planning-openspec`.
 - Design sequencing guidance: `051-design-two-steps-methods`.

--- a/documentation/openspec/changes/archive/2026-06-27-convert-breaking-change-review-to-skill/specs/analysis-design-commands/spec.md
+++ b/documentation/openspec/changes/archive/2026-06-27-convert-breaking-change-review-to-skill/specs/analysis-design-commands/spec.md
@@ -28,6 +28,6 @@ The generator SHALL provide embedded command assets for `/create-worktree`, `/ex
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#954](https://github.com/jabrena/cursor-rules-java/issues/954).
-- Related source artifact: GitHub issue [#886](https://github.com/jabrena/cursor-rules-java/issues/886).
+- Source artifact: GitHub issue [#954](https://github.com/jabrena/plinth/issues/954).
+- Related source artifact: GitHub issue [#886](https://github.com/jabrena/plinth/issues/886).
 - Derivation direction: command-to-skill conversion decision -> modified command bundle requirements -> command retirement and README update implementation.

--- a/documentation/openspec/changes/archive/2026-06-27-convert-breaking-change-review-to-skill/specs/design-avoid-breaking-changes-skill-reference/spec.md
+++ b/documentation/openspec/changes/archive/2026-06-27-convert-breaking-change-review-to-skill/specs/design-avoid-breaking-changes-skill-reference/spec.md
@@ -116,6 +116,6 @@ The avoid-breaking-changes skill MUST include Gherkin acceptance coverage and a 
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#954](https://github.com/jabrena/cursor-rules-java/issues/954).
-- Related source artifact: GitHub issue [#886](https://github.com/jabrena/cursor-rules-java/issues/886).
+- Source artifact: GitHub issue [#954](https://github.com/jabrena/plinth/issues/954).
+- Related source artifact: GitHub issue [#886](https://github.com/jabrena/plinth/issues/886).
 - Derivation direction: issue story and acceptance criteria -> OpenSpec requirement delta -> XML skill source implementation and validation.

--- a/documentation/openspec/changes/archive/2026-06-27-convert-breaking-change-review-to-skill/tasks.md
+++ b/documentation/openspec/changes/archive/2026-06-27-convert-breaking-change-review-to-skill/tasks.md
@@ -28,6 +28,6 @@
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#954](https://github.com/jabrena/cursor-rules-java/issues/954).
-- Related source artifact: GitHub issue [#886](https://github.com/jabrena/cursor-rules-java/issues/886).
+- Source artifact: GitHub issue [#954](https://github.com/jabrena/plinth/issues/954).
+- Related source artifact: GitHub issue [#886](https://github.com/jabrena/plinth/issues/886).
 - Derivation direction: issue story and acceptance criteria -> OpenSpec task checklist -> XML skill source implementation, command retirement, README update, and validation.

--- a/documentation/openspec/changes/archive/2026-06-27-ensure-skill-trigger-minimum/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-27-ensure-skill-trigger-minimum/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#890](https://github.com/jabrena/cursor-rules-java/issues/890) reports the trigger inventory for generated skills and shows that many skill trigger sections contain fewer than five trigger phrases. Thin trigger lists make skills harder for agents to discover reliably, especially when users describe the same intent with different verbs, frameworks, or workflow language.
+GitHub issue [#890](https://github.com/jabrena/plinth/issues/890) reports the trigger inventory for generated skills and shows that many skill trigger sections contain fewer than five trigger phrases. Thin trigger lists make skills harder for agents to discover reliably, especially when users describe the same intent with different verbs, frameworks, or workflow language.
 
 Each generated skill should expose enough meaningful trigger phrases to cover common user requests without adding duplicate, vague, or unrelated phrases. The first useful outcome is to bring every existing skill below five triggers up to at least five meaningful triggers in the XML source.
 
@@ -24,7 +24,7 @@ None.
 ## Source and Derivation
 
 - Source artifact: maintainer request in chat to create a spec for adding at least five meaningful triggers to skill trigger sections.
-- Source artifact: GitHub issue [#890](https://github.com/jabrena/cursor-rules-java/issues/890), which lists trigger counts for 106 skills.
+- Source artifact: GitHub issue [#890](https://github.com/jabrena/plinth/issues/890), which lists trigger counts for 106 skills.
 - Local command workflow: `.cursor/commands/create-spec.md`.
 - Local OpenSpec guidance: `042-planning-openspec`.
 - Design sequencing guidance: `051-design-two-steps-methods`.

--- a/documentation/openspec/changes/archive/2026-06-27-improve-maven-search-skill-workflow/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-27-improve-maven-search-skill-workflow/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#881](https://github.com/jabrena/cursor-rules-java/issues/881) identifies that `114-java-maven-search` has an unclear purpose because it currently combines two related but operationally different workflows:
+GitHub issue [#881](https://github.com/jabrena/plinth/issues/881) identifies that `114-java-maven-search` has an unclear purpose because it currently combines two related but operationally different workflows:
 
 - Maven project update analysis using maintainer-provided Versions Maven Plugin output.
 - Maven Central artifact discovery using Search API fields and repository URL construction.
@@ -27,7 +27,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#881](https://github.com/jabrena/cursor-rules-java/issues/881).
+- Source artifact: GitHub issue [#881](https://github.com/jabrena/plinth/issues/881).
 - Source summary: User story and acceptance criteria added to issue #881 by the maintainer workflow.
 - Existing generated skill under review: `.agents/skills/114-java-maven-search/SKILL.md`.
 - Existing XML sources: `skills-generator/src/main/resources/skill-indexes/114-skill.xml` and `skills-generator/src/main/resources/skill-references/114-java-maven-search.xml`.

--- a/documentation/openspec/changes/archive/2026-06-27-move-markdown-validator-to-maven-module/proposal.md
+++ b/documentation/openspec/changes/archive/2026-06-27-move-markdown-validator-to-maven-module/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-GitHub issue [#941](https://github.com/jabrena/cursor-rules-java/issues/941) requests moving the Markdown validator from `.github/scripts/MarkdownValidator.java` into a dedicated Maven module.
+GitHub issue [#941](https://github.com/jabrena/plinth/issues/941) requests moving the Markdown validator from `.github/scripts/MarkdownValidator.java` into a dedicated Maven module.
 
 The current validator is a CI-oriented JBang script that has grown beyond a small script. It validates generated and maintained Markdown content, checks remote links, and is invoked by the `validate-markdown` GitHub Actions job. The issue records a CI validation run taking around 40 seconds, which is too slow for this feedback loop.
 
@@ -25,7 +25,7 @@ None.
 
 ## Source and Derivation
 
-- Source artifact: GitHub issue [#941](https://github.com/jabrena/cursor-rules-java/issues/941).
+- Source artifact: GitHub issue [#941](https://github.com/jabrena/plinth/issues/941).
 - Previous implementation: `.github/scripts/MarkdownValidator.java`.
 - New implementation: `markdown-validator/src/main/java/info/jab/markdownvalidator/MarkdownValidator.java`.
 - Current CI call site: `.github/workflows/maven.yaml`.

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <name>cursor-rules-java</name>
     <description>A curated collection of Skills and Agents to be used in modern SDLC workflows for Java Enterprise development.</description>
 
-    <url>https://github.com/jabrena/cursor-rules-java</url>
+    <url>https://github.com/jabrena/plinth</url>
 
     <licenses>
         <license>
@@ -23,9 +23,9 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:https://github.com/jabrena/cursor-rules-java.git</connection>
-        <developerConnection>scm:git:git@github.com:jabrena/cursor-rules-java.git</developerConnection>
-        <url>https://github.com/jabrena/cursor-rules-java</url>
+        <connection>scm:git:https://github.com/jabrena/plinth.git</connection>
+        <developerConnection>scm:git:git@github.com:jabrena/plinth.git</developerConnection>
+        <url>https://github.com/jabrena/plinth</url>
         <tag>HEAD</tag>
     </scm>
 
@@ -38,11 +38,11 @@
     </developers>
     <inceptionYear>2025</inceptionYear>
     <issueManagement>
-        <url>https://github.com/jabrena/cursor-rules-java/issues</url>
+        <url>https://github.com/jabrena/plinth/issues</url>
         <system>GitHub</system>
     </issueManagement>
     <ciManagement>
-        <url>https://github.com/jabrena/cursor-rules-java/actions</url>
+        <url>https://github.com/jabrena/plinth/actions</url>
         <system>GitHub Actions</system>
     </ciManagement>
 

--- a/site-generator/content/blog/2025/07/release-0.8.0.md
+++ b/site-generator/content/blog/2025/07/release-0.8.0.md
@@ -13,9 +13,9 @@ Over this example, add the following user prompt:
 
 > "Review my code for object-oriented design using the cursor rule @121-java-object-oriented-design.md @src/"
 
-![](/plintch/images/2025/7/0.8.0-1.png)
-![](/plintch/images/2025/7/0.8.0-2.png)
-![](/plintch/images/2025/7/0.8.0-3.png)
+![](/plinth/images/2025/7/0.8.0-1.png)
+![](/plinth/images/2025/7/0.8.0-2.png)
+![](/plinth/images/2025/7/0.8.0-3.png)
 
 Now, the software engineer has full control over the suggestion and later refactoring because they are able to interact with the Cursor rule and guide how the solution could be improved. If you like this feature, you can try the following cursor rules included in the release:
 
@@ -80,7 +80,7 @@ Using models & system prompts like this project: https://github.com/jabrena/plin
 
 Join us with more than 600+ users in the last 14 days.
 
-![](/plintch/images/2025/7/0.8.0-4.png)
+![](/plinth/images/2025/7/0.8.0-4.png)
 
 Enjoy
 

--- a/site-generator/content/blog/2025/07/release-0.8.0.md
+++ b/site-generator/content/blog/2025/07/release-0.8.0.md
@@ -8,7 +8,7 @@ status=published
 
 ## New interactive behaviors in the Cursor rules
 
-In the previous release, the project added interactive behavior to a few complex rules to improve the developer experience, but in this release, new rules have evolved to add more interactive behavior regardless of complexity. The motivation behind this change: now the rules suggest alternatives to the software engineer to improve development at the package/class/method level. Maybe you could ask the question: why that change? Every software engineer has a unique way to solve software problems, so why force a suggestion in the code without a preliminary review? Let's explain the idea with an example to show the evolution in the cursor rule. The repository cursor-rules-java has different working examples that can be improved with the rules. Let's use an example based on Spring Boot: https://github.com/jabrena/cursor-rules-java/tree/main/examples/spring-boot-demo/implementation
+In the previous release, the project added interactive behavior to a few complex rules to improve the developer experience, but in this release, new rules have evolved to add more interactive behavior regardless of complexity. The motivation behind this change: now the rules suggest alternatives to the software engineer to improve development at the package/class/method level. Maybe you could ask the question: why that change? Every software engineer has a unique way to solve software problems, so why force a suggestion in the code without a preliminary review? Let's explain the idea with an example to show the evolution in the cursor rule. The repository cursor-rules-java has different working examples that can be improved with the rules. Let's use an example based on Spring Boot: https://github.com/jabrena/plinth/tree/main/examples/spring-boot-demo/implementation
 Over this example, add the following user prompt:
 
 > "Review my code for object-oriented design using the cursor rule @121-java-object-oriented-design.md @src/"
@@ -36,7 +36,7 @@ Remember that models don't answer in a deterministic way, in the same way that i
 
 ## Consistency in the syntax
 
-When the repository is growing and there are 18 rules and counting, consistency is something important to take into account to improve maintenance and accuracy in the way software engineers use natural language to interact with models. With this purpose, in release 0.8.0 I invested effort to convert all Cursor rules from Markdown to XML in order to have the flexibility of this format to have strict rules about the design of the language and the flexibility to convert XML into Markdown with front matter. With this goal, there now exists a new XML Schema dedicated to prompts: https://github.com/jabrena/cursor-rules-java/blob/main/generator/src/main/resources/pml.xsd which was designed with ideas from the main players in the models market (Anthropic, OpenAI, Google) in order to structure a prompt:
+When the repository is growing and there are 18 rules and counting, consistency is something important to take into account to improve maintenance and accuracy in the way software engineers use natural language to interact with models. With this purpose, in release 0.8.0 I invested effort to convert all Cursor rules from Markdown to XML in order to have the flexibility of this format to have strict rules about the design of the language and the flexibility to convert XML into Markdown with front matter. With this goal, there now exists a new XML Schema dedicated to prompts: https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/pml.xsd which was designed with ideas from the main players in the models market (Anthropic, OpenAI, Google) in order to structure a prompt:
 
 ```xml
     <xs:element name="prompt">
@@ -57,7 +57,7 @@ When the repository is growing and there are 18 rules and counting, consistency 
     </xs:element>
 ```
 
-Once all cursor rules are modeled in XML format, it is easy to convert them into the format used by Cursor AI, Markdown with front matter: https://github.com/jabrena/cursor-rules-java/blob/main/generator/src/main/resources/cursor-rules.xsl
+Once all cursor rules are modeled in XML format, it is easy to convert them into the format used by Cursor AI, Markdown with front matter: https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/cursor-rules.xsl
 
 Using a schema and transformation, it is possible to guarantee consistency in the sources and the output format.
 
@@ -76,7 +76,7 @@ When you are working with AI models, safety is a critical aspect that cannot be 
 It's not only that the model changes the code; the model needs to finish the prompt execution with a formal validation of the changes.
 
 ## My 20 Cents
-Using models & system prompts like this project: https://github.com/jabrena/cursor-rules-java could increase your squad velocity and increase squad satisfaction as part of the [SPACE framework](https://queue.acm.org/detail.cfm?id=3454124).
+Using models & system prompts like this project: https://github.com/jabrena/plinth could increase your squad velocity and increase squad satisfaction as part of the [SPACE framework](https://queue.acm.org/detail.cfm?id=3454124).
 
 Join us with more than 600+ users in the last 14 days.
 

--- a/site-generator/content/blog/2025/07/release-0.9.0.md
+++ b/site-generator/content/blog/2025/07/release-0.9.0.md
@@ -26,7 +26,7 @@ Specific rules for Maven Dependencies & Maven plugins
 
 Profiling improvements
 
-For further information about the full CHANGELOG, visit the following link: https://github.com/jabrena/cursor-rules-java/blob/main/CHANGELOG.md#090-2025-07-22
+For further information about the full CHANGELOG, visit the following link: https://github.com/jabrena/plinth/blob/main/CHANGELOG.md#090-2025-07-22
 
 Added Version Control
 If you are one of the thousands of users who at some point in time cloned the Git repository, maybe you don't remember when the system prompt was added to your workspace. In this version, all prompts include in the Markdown Frontmatter section, metadata about the version to track which version you are using and whether you need to update to the latest version.
@@ -56,7 +56,7 @@ Exception handling is a core feature in Java, but that feature didn't have a spe
 ![](/plintch/images/2025/7/java-exceptions-goto.png)
 
 Consultative Interaction Technique
-In the previous release, the project added a way to interact with software engineers. In this release, we externalized the behavior in the following building block: https://github.com/jabrena/cursor-rules-java/blob/main/generator/src/main/resources/fragments/system-prompt-behaviour-consultative-interaction-template.md
+In the previous release, the project added a way to interact with software engineers. In this release, we externalized the behavior in the following building block: https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/fragments/system-prompt-behaviour-consultative-interaction-template.md
 
 Now that solution has been extended to the majority of the provided system prompts,  adding consultative behavior:
 
@@ -69,13 +69,13 @@ Now that solution has been extended to the majority of the provided system promp
 
     </goal>
 ```
-Example: https://github.com/jabrena/cursor-rules-java/blob/main/generator/src/main/resources/110-java-maven-best-practices.xml
+Example: https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/110-java-maven-best-practices.xml
 
 ![](/plintch/images/2025/7/example-rules.png)
 
 ### A better Getting Started documentation
 
-The repository has improved the documentation for new users in order to reduce the Onboarding time for new users: https://github.com/jabrena/cursor-rules-java/blob/main/GETTING-STARTED.md
+The repository has improved the documentation for new users in order to reduce the Onboarding time for new users: https://github.com/jabrena/plinth/blob/main/GETTING-STARTED.md
 
 ### Specific rules for Maven Dependencies & Maven plugins
 
@@ -93,4 +93,4 @@ Bounded Collections Active: Memory retention baseline improved by 55% (49MB→22
 GC Pressure Reduced: More efficient garbage collection with stable retention patterns
 ```
 
-Full sample document: https://github.com/jabrena/cursor-rules-java/blob/main/examples/spring-boot-memory-leak-demo/profiler/docs/profiling-comparison-analysis-20250720.md
+Full sample document: https://github.com/jabrena/plinth/blob/main/examples/spring-boot-memory-leak-demo/profiler/docs/profiling-comparison-analysis-20250720.md

--- a/site-generator/content/blog/2025/07/release-0.9.0.md
+++ b/site-generator/content/blog/2025/07/release-0.9.0.md
@@ -53,7 +53,7 @@ You are a Senior software engineer with extensive experience in Java software de
 
 Exception handling is a core feature in Java, but that feature didn't have a specific system prompt. In this release, a specific rule about exception handling with a functional point of view was added.
 
-![](/plintch/images/2025/7/java-exceptions-goto.png)
+![](/plinth/images/2025/7/java-exceptions-goto.png)
 
 Consultative Interaction Technique
 In the previous release, the project added a way to interact with software engineers. In this release, we externalized the behavior in the following building block: https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/fragments/system-prompt-behaviour-consultative-interaction-template.md
@@ -71,7 +71,7 @@ Now that solution has been extended to the majority of the provided system promp
 ```
 Example: https://github.com/jabrena/plinth/blob/main/generator/src/main/resources/110-java-maven-best-practices.xml
 
-![](/plintch/images/2025/7/example-rules.png)
+![](/plinth/images/2025/7/example-rules.png)
 
 ### A better Getting Started documentation
 

--- a/site-generator/content/blog/2025/09/jfr-modern-java-profiling.md
+++ b/site-generator/content/blog/2025/09/jfr-modern-java-profiling.md
@@ -361,4 +361,4 @@ The future of Java performance optimization is here, and JFR provides the founda
 
 ---
 
-*Ready to dive deeper into JFR? Check out the [java-cursor-rules](https://github.com/jabrena/cursor-rules-java) project for automated JFR profiling workflows and interactive profiling scripts that implement the techniques described in this article.*
+*Ready to dive deeper into JFR? Check out the [java-cursor-rules](https://github.com/jabrena/plinth) project for automated JFR profiling workflows and interactive profiling scripts that implement the techniques described in this article.*

--- a/site-generator/content/blog/2025/09/release-0.10.0.md
+++ b/site-generator/content/blog/2025/09/release-0.10.0.md
@@ -11,7 +11,7 @@ status=published
 The project provides a collection of System prompts for Java that help software engineers in their daily programming work.
 The [available System prompts for Java](https://github.com/jabrena/plinth/blob/main/SYSTEM-PROMPTS-JAVA.md) cover aspects like `Build system based on Maven`, `Design`, `Coding`, `Testing`, `Refactoring & JMH Benchmarking`, `Performance testing with JMeter`, `Profiling with Async profiler/JDK tools` & `Documentation`.
 
-![](/plintch/images/2025/9/workflow.png)
+![](/plinth/images/2025/9/workflow.png)
 
 ## What is new in this release?
 
@@ -62,7 +62,7 @@ Can you explain the JMH results and advise about the best implementation?
 
 This kind of analysis can help the team make decisions about which alternative is better to maintain in the repository.
 
-![](/plintch/images/2025/9/jmh-summary-visualization-sample.png)
+![](/plinth/images/2025/9/jmh-summary-visualization-sample.png)
 
 Further information about JMH:
 
@@ -84,7 +84,7 @@ This system prompt supports:
 
 **UML class diagram sample:**
 
-![](/plintch/images/2025/9/uml-class-diagram-sample.png)
+![](/plinth/images/2025/9/uml-class-diagram-sample.png)
 
 Using `UML Class diagrams`, you can understand how is currently the implementation and if you can improve in some way the code from a high level perspective.
 
@@ -102,7 +102,7 @@ Further information about documentation & diagrams:
 
 Java Generics is not an easy feature in Java. Indeed, if you interact with [Claude](https://claude.ai/new) and ask about `What are the hardest parts in Java to master for a Software engineer?`
 
-![](/plintch/images/2025/9/claude-question.png)
+![](/plinth/images/2025/9/claude-question.png)
 
 `Java Generics` always appears. In this release, the project has added a new system prompt to cover this gap. Now, you can create the following interactive user prompt:
 
@@ -293,4 +293,4 @@ https://github.com/jabrena/plinth/tree/main/.cursor/rules
 
 If you feel stuck using this project or you have any doubts, you could attend the following talk at Devoxx BE in October: https://devoxx.be/app/talk/4715/the-power-of-cursor-rules-in-java-enterprise-development
 
-[![](/plintch/images/2025/9/devoxx-logo.png)](https://devoxx.be/)
+[![](/plinth/images/2025/9/devoxx-logo.png)](https://devoxx.be/)

--- a/site-generator/content/blog/2025/09/release-0.10.0.md
+++ b/site-generator/content/blog/2025/09/release-0.10.0.md
@@ -9,7 +9,7 @@ status=published
 ## What are Cursor rules for Java?
 
 The project provides a collection of System prompts for Java that help software engineers in their daily programming work.
-The [available System prompts for Java](https://github.com/jabrena/cursor-rules-java/blob/main/SYSTEM-PROMPTS-JAVA.md) cover aspects like `Build system based on Maven`, `Design`, `Coding`, `Testing`, `Refactoring & JMH Benchmarking`, `Performance testing with JMeter`, `Profiling with Async profiler/JDK tools` & `Documentation`.
+The [available System prompts for Java](https://github.com/jabrena/plinth/blob/main/SYSTEM-PROMPTS-JAVA.md) cover aspects like `Build system based on Maven`, `Design`, `Coding`, `Testing`, `Refactoring & JMH Benchmarking`, `Performance testing with JMeter`, `Profiling with Async profiler/JDK tools` & `Documentation`.
 
 ![](/plintch/images/2025/9/workflow.png)
 
@@ -254,7 +254,7 @@ This project was originally designed for Cursor (SOTA in the niche of AI tools),
 - GitHub Copilot (Free tier)
 - JetBrains IntelliJ IDEA + JetBrains Junie
 
-If you are interested, you can take a look at the [latest review](https://github.com/jabrena/cursor-rules-java/blob/main/docs/reviews/review-20250829.md).
+If you are interested, you can take a look at the [latest review](https://github.com/jabrena/plinth/blob/main/docs/reviews/review-20250829.md).
 
 **Summary:** Currently the best environments to use this repository are: `Cursor`, `Cursor CLI` & `Claude Code CLI`. If you use `JetBrains IntelliJ IDEA`, you could combine it with `Cursor CLI` or `Claude Code`.
 
@@ -282,12 +282,12 @@ Add Maven Enforcer plugin only from the rule @112-java-maven-plugins without any
 Add tests for the following classes with  @131-java-unit-testing
 ```
 
-Additional examples in the [documentation](https://github.com/jabrena/cursor-rules-java/blob/main/SYSTEM-PROMPTS-JAVA.md).
+Additional examples in the [documentation](https://github.com/jabrena/plinth/blob/main/SYSTEM-PROMPTS-JAVA.md).
 
 ### Improve readability in system prompts
 
 The project has renamed all system prompts from the `.mdc` file extension to the classic Markdown extension `.md`. Now, everyone can read the files easily on `GitHub`:
-https://github.com/jabrena/cursor-rules-java/tree/main/.cursor/rules
+https://github.com/jabrena/plinth/tree/main/.cursor/rules
 
 ## Do you still have doubts about the project?
 

--- a/site-generator/content/blog/2025/09/release-0.11.0.md
+++ b/site-generator/content/blog/2025/09/release-0.11.0.md
@@ -106,7 +106,7 @@ Using specialized behaviours such as `@behaviour-progressive-learning` creativel
 
 Little by little, organizations will evolve current `data pipeline` adding new features combining multiple system prompts for different use cases such as `automatic coding`, `code refactoring`, `continuous profiling`, and more.
 
-![](/plintch/images/2025/9/data-pipeline-workflow.png)
+![](/plinth/images/2025/9/data-pipeline-workflow.png)
 
 ## New UML state machine diagrams for better understanding in complex dependencies.
 
@@ -123,7 +123,7 @@ https://github.com/jabrena/kafka/tree/trunk/clients/src/main/java/org/apache/kaf
 
 **Result:**
 
-![](/plintch/images/2025/9/0.11.0-uml-state-machine-diagram-example.png)
+![](/plinth/images/2025/9/0.11.0-uml-state-machine-diagram-example.png)
 
 With this visualization, you can see whether something is missing in your Java integration.
 
@@ -131,7 +131,7 @@ With this visualization, you can see whether something is missing in your Java i
 
 In this release, the script `profile-java-process.sh`, included in  `@161-java-profiling-detect`, was updated to include the latest release (v4.1) of the popular profiling tool `Async-profiler`. In addition, the script added new `JFR` options available in `Java 25` and earlier.
 
-![](/plintch/images/2025/9/0.11.0-profiling-menu.png)
+![](/plinth/images/2025/9/0.11.0-profiling-menu.png)
 
 In recent months, I have been inspired by the work of outstanding engineers in this field: [Francesco Nigro](https://x.com/forked_franz), [Jaromir Hamala](https://x.com/jerrinot), [Johannes Bechberger](https://x.com/parttimen3rd), [Erik Gahlin](https://x.com/ErikGahlin), [Marcus Hirt](https://x.com/hirt) & [Brendan Gregg](https://x.com/brendangregg). I highly recommend following them.
 
@@ -160,6 +160,6 @@ If you feel stuck using this project or have questions, you can attend the follo
 - https://devoxx.be/app/talk/4715/the-power-of-cursor-rules-in-java-enterprise-development
 - https://devoxx.be/app/talk/4708/101-cursor-ai-learning-to-use-for-java-enterprise-projects/
 
-[![](/plintch/images/2025/9/devoxx-logo.png)](https://devoxx.be/)
+[![](/plinth/images/2025/9/devoxx-logo.png)](https://devoxx.be/)
 
-![](/plintch/images/2025/9/0.11.0-github-stats.png)
+![](/plinth/images/2025/9/0.11.0-github-stats.png)

--- a/site-generator/content/blog/2025/09/release-0.11.0.md
+++ b/site-generator/content/blog/2025/09/release-0.11.0.md
@@ -8,7 +8,7 @@ status=published
 
 ## What are Cursor rules for Java?
 
-The project provides a collection of System prompts for Java Enterprise development that help software engineers in their daily programming work & data pipelines. The [available System prompts for Java](https://github.com/jabrena/cursor-rules-java/blob/main/SYSTEM-PROMPTS-JAVA.md) cover areas such as `Build system based on Maven`, `Design`, `Coding`, `Testing`, `Refactoring & JMH Benchmarking`, `Performance testing with JMeter`, `Profiling with async-profiler/JDK tools`, `Documentation`, and `Diagrams`.
+The project provides a collection of System prompts for Java Enterprise development that help software engineers in their daily programming work & data pipelines. The [available System prompts for Java](https://github.com/jabrena/plinth/blob/main/SYSTEM-PROMPTS-JAVA.md) cover areas such as `Build system based on Maven`, `Design`, `Coding`, `Testing`, `Refactoring & JMH Benchmarking`, `Performance testing with JMeter`, `Profiling with async-profiler/JDK tools`, `Documentation`, and `Diagrams`.
 
 ## What's new in this release?
 
@@ -71,34 +71,34 @@ Improve the classes provided in the context
 by applying the system prompt @128-java-generics
 ```
 
-Further information: https://github.com/jabrena/cursor-rules-java/blob/0.11.0/SYSTEM-PROMPTS-JAVA.md
+Further information: https://github.com/jabrena/plinth/blob/0.11.0/SYSTEM-PROMPTS-JAVA.md
 
 With this evolution, software engineers now can combine pure system prompts and specialized behaviors in `16^3 = 4096` combinations by design.
 
 **Pure system prompts:**
 
-- [`@100-java-system-prompt-java-list`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/100-java-system-prompt-java-list.md)
-- [`@110-java-maven-best-practices`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/110-java-maven-best-practices.md)
-- [`@111-java-maven-dependencies`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/111-java-maven-dependencies.md)
-- [`@113-java-maven-documentation`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/113-java-maven-documentation.md)
-- [`@121-java-object-oriented-design`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/121-java-object-oriented-design.md)
-- [`@122-java-type-design`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/122-java-type-design.md)
-- [`@124-java-secure-coding`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/124-java-secure-coding.md)
-- [`@125-java-concurrency`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/125-java-concurrency.md)
-- [`@126-java-logging`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/126-java-logging.md)
-- [`@127-java-exception-handling`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/127-java-exception-handling.md)
-- [`@128-java-generics`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/128-java-generics.md)
-- [`@131-java-unit-testing`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/131-java-unit-testing.md)
-- [`@141-java-refactoring-with-modern-features`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/141-java-refactoring-with-modern-features.md)
-- [`@142-java-functional-programming`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/142-java-functional-programming.md)
-- [`@143-java-functional-exception-handling`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/143-java-functional-exception-handling.md)
-- [`@144-java-data-oriented-programming`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/144-java-data-oriented-programming.md)
+- [`@100-java-system-prompt-java-list`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/100-java-system-prompt-java-list.md)
+- [`@110-java-maven-best-practices`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/110-java-maven-best-practices.md)
+- [`@111-java-maven-dependencies`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/111-java-maven-dependencies.md)
+- [`@113-java-maven-documentation`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/113-java-maven-documentation.md)
+- [`@121-java-object-oriented-design`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/121-java-object-oriented-design.md)
+- [`@122-java-type-design`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/122-java-type-design.md)
+- [`@124-java-secure-coding`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/124-java-secure-coding.md)
+- [`@125-java-concurrency`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/125-java-concurrency.md)
+- [`@126-java-logging`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/126-java-logging.md)
+- [`@127-java-exception-handling`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/127-java-exception-handling.md)
+- [`@128-java-generics`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/128-java-generics.md)
+- [`@131-java-unit-testing`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/131-java-unit-testing.md)
+- [`@141-java-refactoring-with-modern-features`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/141-java-refactoring-with-modern-features.md)
+- [`@142-java-functional-programming`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/142-java-functional-programming.md)
+- [`@143-java-functional-exception-handling`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/143-java-functional-exception-handling.md)
+- [`@144-java-data-oriented-programming`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/144-java-data-oriented-programming.md)
 
 **Specialized behaviors:**
 
 - Default behavior
-- [`@behaviour-consultative-interaction`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/behaviour-consultative-interaction.md)
-- [`@behaviour-progressive-learning`](https://github.com/jabrena/cursor-rules-java/blob/main/.cursor/rules/behaviour-progressive-learning.md)
+- [`@behaviour-consultative-interaction`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/behaviour-consultative-interaction.md)
+- [`@behaviour-progressive-learning`](https://github.com/jabrena/plinth/blob/main/.cursor/rules/behaviour-progressive-learning.md)
 
 Using specialized behaviours such as `@behaviour-progressive-learning` creatively in your repositories can increase collective ownership and help spread the code standards implemented in the codebase.
 
@@ -141,19 +141,17 @@ If you are interested in the Profiling model `Detect, Analyze, Refactor & Compar
 - `@162-java-profiling-analyze`
 - `@164-java-profiling-compare`
 
-You could review the course about [Detecting memory leaks with System prompts](https://jabrena.github.io/cursor-rules-java/courses/profile-memory-leak/index.html).
+You could review [jabrena/plinth](https://github.com/jabrena/plinth).
 
 ## A new website
 
-In recent releases, the project published an article summarizing its evolution and shared it across channels like Twitter, Reddit, and LinkedIn. To unify the source of truth, and leveraging [GitHub Pages](https://docs.github.com/es/pages), the project now has [a dedicated website](https://jabrena.github.io/cursor-rules-java/index.html).
+In recent releases, the project published an article summarizing its evolution and shared it across channels like Twitter, Reddit, and LinkedIn. To unify the source of truth, and leveraging [GitHub Pages](https://docs.github.com/es/pages), the project now has [jabrena/plinth](https://github.com/jabrena/plinth).
 
-The website includes information about releases, technical articles you can apply in your projects, and courses.
+The project includes information about releases, technical articles you can apply in your projects, and courses.
 
 **What courses were created in this release?**
 
-- [Learn to use System prompts for Java](https://jabrena.github.io/cursor-rules-java/courses/system-prompts-java/index.html)
-- [Learn to improve your development with Java Generics](https://jabrena.github.io/cursor-rules-java/courses/java-generics/index.html)
-- [Learn how to detect memory leaks with System prompts](https://jabrena.github.io/cursor-rules-java/courses/profile-memory-leak/index.html)
+See [jabrena/plinth](https://github.com/jabrena/plinth) for the updated project home.
 
 ## Do you still have questions about the project?
 

--- a/site-generator/content/blog/2025/11/the-tour-in-europe-2025-is-over.md
+++ b/site-generator/content/blog/2025/11/the-tour-in-europe-2025-is-over.md
@@ -24,7 +24,7 @@ Videos about the talks:
 
 and the associated Slides:
 
-- https://jabrena.github.io/cursor-rules-java/dvbe25/index.html
+- [jabrena/plinth](https://github.com/jabrena/plinth)
 - https://jabrena.github.io/101-cursor/
 
 ## Emerging new solutions from the Gemba
@@ -61,7 +61,7 @@ PML project has 2 different schemas, one schema which defines the diferent parts
 </xs:element>
 ```
 
-You can see PML in action [here](https://github.com/jabrena/cursor-rules-java/tree/main/skills-generator/src/main/resources).
+You can see PML in action [here](https://github.com/jabrena/plinth/tree/main/skills-generator/src/main/resources).
 
 Finally, here is a novel Schema dedicated to Workflows:
 
@@ -105,9 +105,9 @@ Recently, this technique was identified in the latest `Thoughtworks Radar #33`: 
 
 **Problem it tries to solve:** Maintain a specialized collection of system prompts for Software development in Java.
 
-This project uses PML under the hood to model all System prompts in homogeneous Markdown syntax. Read the file [CURSOR-RULES-JAVA.md](https://github.com/jabrena/cursor-rules-java/blob/main/CURSOR-RULES-JAVA.md) to understand all possibilities.
+This project uses PML under the hood to model all System prompts in homogeneous Markdown syntax. Read the file [CURSOR-RULES-JAVA.md](https://github.com/jabrena/plinth/blob/main/CURSOR-RULES-JAVA.md) to understand all possibilities.
 
-https://github.com/jabrena/cursor-rules-java
+https://github.com/jabrena/plinth
 
 ### Churrera, tasks like churros!
 

--- a/site-generator/content/blog/2025/11/the-tour-in-europe-2025-is-over.md
+++ b/site-generator/content/blog/2025/11/the-tour-in-europe-2025-is-over.md
@@ -24,7 +24,7 @@ Videos about the talks:
 
 and the associated Slides:
 
-- [jabrena/plinth](https://github.com/jabrena/plinth)
+- https://jabrena.github.io/plinth/dvbe25/index.html
 - https://jabrena.github.io/101-cursor/
 
 ## Emerging new solutions from the Gemba

--- a/site-generator/content/blog/2025/11/the-tour-in-europe-2025-is-over.md
+++ b/site-generator/content/blog/2025/11/the-tour-in-europe-2025-is-over.md
@@ -101,7 +101,7 @@ https://forms.gle/TpNXENjmu45wuXoi6
 
 Recently, this technique was identified in the latest `Thoughtworks Radar #33`: **Curated shared instructions for software teams**
 
-[![](/plintch/images/2025/11/thoughtworks-radar-system-prompts.jpg)](https://www.thoughtworks.com/radar/techniques/curated-shared-instructions-for-software-teams)
+[![](/plinth/images/2025/11/thoughtworks-radar-system-prompts.jpg)](https://www.thoughtworks.com/radar/techniques/curated-shared-instructions-for-software-teams)
 
 **Problem it tries to solve:** Maintain a specialized collection of system prompts for Software development in Java.
 
@@ -113,7 +113,7 @@ https://github.com/jabrena/plinth
 
 Churrera is a CLI tool designed to operate with `Cursor Cloud Agents API` easily. The Cloud Agents API (Beta) allows you to programmatically create and manage AI-powered coding agents that work autonomously on your repositories.
 
-![](/plintch/images/2025/11/churrera-2.png)
+![](/plinth/images/2025/11/churrera-2.png)
 
 **Problem it tries to solve:** Enhance your pipelines with `AI Glue`.
 
@@ -125,11 +125,11 @@ https://github.com/jabrena/churrera
 
 ## Observations in Devoxx 2025
 
-![](/plintch/images/2025/11/devoxx-be-room-4.jpg)
+![](/plinth/images/2025/11/devoxx-be-room-4.jpg)
 
 In 2025, the entire JVM industry is moving around AI and if you attended the different sessions in Devoxx, you may feel it. In the conference, I listened to the different proposals from the most used frameworks `Spring` & `Quarkus` in the Java industry and in this year, I observed that there exists a real parity between Spring ecosystem and Quarkus ecosystem in terms of talks. Congratulations to `Mario Fusco`, `Georgios Andrianakis`, `Clement Escoffier`, `Rod Johnson` & `Christian Tzolov` for their hard work. I would not like to forget the nice proposal from `Akka` which shared the new features oriented to `Agents`.
 
-![](/plintch/images/2025/11/devoxx-quarkus-agentic-talk.png)
+![](/plinth/images/2025/11/devoxx-quarkus-agentic-talk.png)
 
 **Can Spring AI or Langchain4j use PML or Cursor rules for Java?**
 
@@ -161,11 +161,11 @@ Yes, for sure. Happy to talk with `Spring AI` team or `Quarkus` team in the futu
 
 ## Observations in W-JAX-2025
 
-![](/plintch/images/2025/11/wjax-atlanta-room.png)
+![](/plinth/images/2025/11/wjax-atlanta-room.png)
 
 In this case, I visited the conference for a shorter time so my observations were limited, but in the conference the talks put focus on AI also. In the another hand, I observed less presence of Quarkus talks, in Germain Speakers continue with more experience in Spring. Gathering feedback from my talk, many `Java Software engineers` in Germany are starting to use this kind of modern tools but in general, the usage is not massive.
 
-![](/plintch/images/2025/11/crossing-the-chasm.png)
+![](/plinth/images/2025/11/crossing-the-chasm.png)
 
 ### What talks I loved in W-JAX 2025?
 

--- a/site-generator/content/blog/2026/03/release-0.12.0.md
+++ b/site-generator/content/blog/2026/03/release-0.12.0.md
@@ -35,7 +35,7 @@ Let's walk through each feature. You can also review the [CHANGELOG.md](https://
 
 ## Why Skills?
 
-![](/plintch/images/2026/3/skills-everywhere.png)
+![](/plinth/images/2026/3/skills-everywhere.png)
 
 The [AI Assistants](https://aws.amazon.com/en/blogs/devops/aws-named-as-a-leader-in-the-2025-gartner-magic-quadrant-for-ai-code-assistants/) market is reshaping how we build software. A growing number of tools offer similar capabilities, yet until recently there was no standard way to extend them across vendors. `Cursor` pioneered `System prompts`, but that approach lacked a shared specification for others to adopt. A `Skill` fills that gap: it extends AI agents with specialized knowledge and workflows that work across different products.
 
@@ -131,7 +131,7 @@ npx skills install jabrena/plinth --all --agent cursor
 
 One feature I like: Security pipelines that audit Skills for safety.
 
-[![](/plintch/images/2026/3/skill-security-audit.png)](https://skills.sh/jabrena/plinth/110-java-maven-best-practices)
+[![](/plinth/images/2026/3/skill-security-audit.png)](https://skills.sh/jabrena/plinth/110-java-maven-best-practices)
 
 **Source:** https://skills.sh/jabrena/plinth/110-java-maven-best-practices
 
@@ -454,7 +454,7 @@ In 2026, AI tools are essential—but which ones you use depends on your organiz
 
 With Agile (Intents, Epics, User Stories, Tasks), start by reviewing your backlog and ensuring tasks are ready for development.
 
-[![](/plintch/images/2026/3/agile.png)](https://learn.microsoft.com/en-us/azure/devops/boards/backlogs/define-features-epics?view=azure-devops&tabs=agile-process)
+[![](/plinth/images/2026/3/agile.png)](https://learn.microsoft.com/en-us/azure/devops/boards/backlogs/define-features-epics?view=azure-devops&tabs=agile-process)
 
 **Source:** https://learn.microsoft.com/en-us/azure/devops/boards/backlogs/define-features-epics?view=azure-devops&tabs=agile-process
 
@@ -462,7 +462,7 @@ Use [`System prompts for Agile`](https://github.com/jabrena/cursor-rules-agile) 
 
 These tools boost delivery. To keep pace, consider a Double Agile Loop for defining User Stories:
 
-[![](/plintch/images/2026/3/double-agile-loop.png)](https://www.stride.build/blog/what-is-dual-track-agile-and-how-does-it-work)
+[![](/plinth/images/2026/3/double-agile-loop.png)](https://www.stride.build/blog/what-is-dual-track-agile-and-how-does-it-work)
 
 **Source:** https://www.stride.build/blog/what-is-dual-track-agile-and-how-does-it-work
 
@@ -522,7 +522,7 @@ Next, create a Plan. Cursor and Claude both support plan generation.
 
 Review and iterate until the Plan is stable, then hand it to the model. Include design artifacts, OAS files, and Gherkin in the context.
 
-![](/plintch/images/2026/3/workflow.png)
+![](/plinth/images/2026/3/workflow.png)
 
 Expect to iterate. Have the model verify its own changes rather than doing it manually. `AGENTS.md` helps here—it documents the technical details the model needs.
 
@@ -534,7 +534,7 @@ When executing the plan, you can choose:
 
 Depending on your preferences, you can build a plan that includes a task list like this:
 
-![](/plintch/images/2026/3/plan-task-list-example.png)
+![](/plinth/images/2026/3/plan-task-list-example.png)
 
 Read this section carefully and explore this approach. In the following Git repository, you could find other non-trivial problems: https://github.com/jabrena/latency-problems that you could solve with this approach.
 
@@ -542,7 +542,7 @@ Read this section carefully and explore this approach. In the following Git repo
 
 If you are interested in adding `AI Capabilities` to your pipelines:
 
-![](/plintch/images/2026/3/workflow-pipelines.png)
+![](/plinth/images/2026/3/workflow-pipelines.png)
 
 I recommend reading the following article: https://www.javaadvent.com/2025/12/delegating-java-tasks-to-supervised-ai-dev-pipelines.html
 
@@ -578,7 +578,7 @@ Since the previous version, the project has invested time improving the current 
 
 If you followed the article, the project is evolving from `System prompts` to `Skills`—and continues to advance practices such as curated shared instructions for software teams and `AGENTS.md`, both recognized in the [Thoughtworks Technology Radar](https://www.thoughtworks.com/radar/techniques). During the time between [`v0.11.0`](https://github.com/jabrena/plinth/releases/tag/0.11.0) to [`v0.12.0`](https://github.com/jabrena/plinth/releases/tag/0.12.0), new elements have appeared in the market, such as: `Subagents`, `Commands`, `Hooks`, `Plugins`, `Spec-driven`. In the next release, the project will review how to use `Skills` with **Subagents**.
 
-![](/plintch/images/2026/3/subagents.png)
+![](/plinth/images/2026/3/subagents.png)
 
 **Source:** https://code.claude.com/docs/en/agent-teams
 
@@ -598,6 +598,6 @@ Putting this in perspective, this kind of product has improved performance so mu
 
 If you feel stuck using this project or have questions, you can attend the following Workshop at `Codemotion Madrid 2026`:
 
-[![](/plintch/images/2026/3/codemotion-madrid-2026.jpg)](https://conferences.codemotion.com/madrid/)
+[![](/plinth/images/2026/3/codemotion-madrid-2026.jpg)](https://conferences.codemotion.com/madrid/)
 
 https://conferences.codemotion.com/madrid/workshop/

--- a/site-generator/content/blog/2026/03/release-0.12.0.md
+++ b/site-generator/content/blog/2026/03/release-0.12.0.md
@@ -31,7 +31,7 @@ In this release, the project introduces several updates and improvements:
 - Added a new generator to manage `SKILL` generation
 - Added a validator to ensure good quality in `SKILL` validation against the [Skill Specification](https://agentskills.io/specification)
 
-Let's walk through each feature. You can also review the [CHANGELOG.md](https://github.com/jabrena/cursor-rules-java/blob/main/CHANGELOG.md#0120-2026-03-08)
+Let's walk through each feature. You can also review the [CHANGELOG.md](https://github.com/jabrena/plinth/blob/main/CHANGELOG.md#0120-2026-03-08)
 
 ## Why Skills?
 
@@ -108,13 +108,13 @@ Planned for the next release:
 - `@164-java-profiling-compare`
 - `@164-java-profiling-verify`
 
-Plus others tracked in the [`Backlog`](https://github.com/jabrena/cursor-rules-java/issues).
+Plus others tracked in the [`Backlog`](https://github.com/jabrena/plinth/issues).
 
 Previously, the project offered a CLI to install System prompts from this repo or any repo with `.cursor/rules` (or a symlink to it):
 
 ```bash
 jbang setup@jabrena init \
---cursor https://github.com/jabrena/cursor-rules-java
+--cursor https://github.com/jabrena/plinth
 ```
 
 With Skills, [`Vercel`](https://vercel.com/) offers a better option at https://skills.sh/, where you can find and install Skills easily.
@@ -123,17 +123,17 @@ Browse this project's Skills [here](https://skills.sh/?q=jabrena) and install th
 
 ```bash
 brew install node
-npx skills add jabrena/cursor-rules-java --list
-npx skills add https://github.com/jabrena/cursor-rules-java \
+npx skills add jabrena/plinth --list
+npx skills add https://github.com/jabrena/plinth \
 --skill 110-java-maven-best-practices
-npx skills install jabrena/cursor-rules-java --all --agent cursor
+npx skills install jabrena/plinth --all --agent cursor
 ```
 
 One feature I like: Security pipelines that audit Skills for safety.
 
-[![](/plintch/images/2026/3/skill-security-audit.png)](https://skills.sh/jabrena/cursor-rules-java/110-java-maven-best-practices)
+[![](/plintch/images/2026/3/skill-security-audit.png)](https://skills.sh/jabrena/plinth/110-java-maven-best-practices)
 
-**Source:** https://skills.sh/jabrena/cursor-rules-java/110-java-maven-best-practices
+**Source:** https://skills.sh/jabrena/plinth/110-java-maven-best-practices
 
 **Note:** I recommend skills.sh and similar sites—Skills there have passed security audits. Be aware that Skills can include scripts, which may be an attack vector.
 
@@ -153,15 +153,15 @@ A Skill packaged as a JAR has this layout:
 META-INF/
 META-INF/skills/
 META-INF/skills/jabrena/
-META-INF/skills/jabrena/cursor-rules-java/
+META-INF/skills/jabrena/plinth/
 META-INF/maven/
 META-INF/maven/com.skillsjars/
 META-INF/MANIFEST.MF
 META-INF/maven/com.skillsjars/jabrena__cursor-rules-java__111-java-maven-dependencies/pom.xml
 META-INF/maven/com.skillsjars/jabrena__cursor-rules-java__111-java-maven-dependencies/pom.properties
-META-INF/skills/jabrena/cursor-rules-java/111-java-maven-dependencies/SKILL.md
-META-INF/skills/jabrena/cursor-rules-java/111-java-maven-dependencies/references/
-META-INF/skills/jabrena/cursor-rules-java/111-java-maven-dependencies/references/111-java-maven-dependencies.md
+META-INF/skills/jabrena/plinth/111-java-maven-dependencies/SKILL.md
+META-INF/skills/jabrena/plinth/111-java-maven-dependencies/references/
+META-INF/skills/jabrena/plinth/111-java-maven-dependencies/references/111-java-maven-dependencies.md
 ```
 
 **Source:** https://central.sonatype.com/artifact/com.skillsjars/jabrena__cursor-rules-java__111-java-maven-dependencies
@@ -576,7 +576,7 @@ Since the previous version, the project has invested time improving the current 
 
 ## Conclusions
 
-If you followed the article, the project is evolving from `System prompts` to `Skills`—and continues to advance practices such as curated shared instructions for software teams and `AGENTS.md`, both recognized in the [Thoughtworks Technology Radar](https://www.thoughtworks.com/radar/techniques). During the time between [`v0.11.0`](https://github.com/jabrena/cursor-rules-java/releases/tag/0.11.0) to [`v0.12.0`](https://github.com/jabrena/cursor-rules-java/releases/tag/0.12.0), new elements have appeared in the market, such as: `Subagents`, `Commands`, `Hooks`, `Plugins`, `Spec-driven`. In the next release, the project will review how to use `Skills` with **Subagents**.
+If you followed the article, the project is evolving from `System prompts` to `Skills`—and continues to advance practices such as curated shared instructions for software teams and `AGENTS.md`, both recognized in the [Thoughtworks Technology Radar](https://www.thoughtworks.com/radar/techniques). During the time between [`v0.11.0`](https://github.com/jabrena/plinth/releases/tag/0.11.0) to [`v0.12.0`](https://github.com/jabrena/plinth/releases/tag/0.12.0), new elements have appeared in the market, such as: `Subagents`, `Commands`, `Hooks`, `Plugins`, `Spec-driven`. In the next release, the project will review how to use `Skills` with **Subagents**.
 
 ![](/plintch/images/2026/3/subagents.png)
 

--- a/site-generator/content/blog/2026/03/release-0.13.0.md
+++ b/site-generator/content/blog/2026/03/release-0.13.0.md
@@ -115,7 +115,7 @@ In the version `v0.13.0`, the project releases `58 Skills`:
 - `@522-frameworks-micronaut-testing-integration-tests`
 - `@523-frameworks-micronaut-testing-acceptance-tests`
 
-Let's walk through each feature. You can also review the [CHANGELOG](https://github.com/jabrena/cursor-rules-java/blob/main/CHANGELOG.md#0130-2026-03-30).
+Let's walk through each feature. You can also review the [CHANGELOG](https://github.com/jabrena/plinth/blob/main/CHANGELOG.md#0130-2026-03-30).
 
 ## What workflows were updated in this release?
 
@@ -123,13 +123,13 @@ Let's walk through each feature. You can also review the [CHANGELOG](https://git
 
 Now, `Product Owners` and `Business Analysts` have new tools to improve thin, one-line user stories, and `Architects` can take part in development by adding `ADRs` asynchronously. With that context, you can validate those documents for inconsistencies using the new agent. When the documents are aligned, the `Software Engineer` can draft a plan and refine it with the Plan mode skill (`@040-planning-plan-mode`). After the plan is reviewed, you can hand it off to the new `Coordinator Agent`, which owns end-to-end development.
 
-Take a look at the following [Getting Started](https://github.com/jabrena/cursor-rules-java/blob/main/documentation/guides/GETTING-STARTED-SKILLS.md) guide for further details.
+Take a look at the following [Getting Started](https://github.com/jabrena/plinth/blob/main/documentation/guides/GETTING-STARTED-SKILLS.md) guide for further details.
 
 ### CI/CD Pipeline workflows
 
 With the new improvements for architectural tasks, it is now easier to keep architecture diagrams current—including C4 views, data mapping, business glossary documentation, and database ER diagrams.
 
-Take a look at the following [Getting Started](https://github.com/jabrena/cursor-rules-java/blob/main/documentation/guides/GETTING-STARTED-PIPELINES.md) guide for further details.
+Take a look at the following [Getting Started](https://github.com/jabrena/plinth/blob/main/documentation/guides/GETTING-STARTED-PIPELINES.md) guide for further details.
 
 ---
 
@@ -161,8 +161,8 @@ All frameworks have the same skill coverage:
 Currently, there is lively debate about which online Skill registry is best.
 You can find the Skills from this project on several sites.
 
-- https://skills.sh/jabrena/cursor-rules-java
-- https://tessl.io/registry/skills/github/jabrena/cursor-rules-java
+- https://skills.sh/jabrena/plinth
+- https://tessl.io/registry/skills/github/jabrena/plinth
 - https://agent-skills.cc/zh/skills/jabrena-cursor-rules-java
 - https://skillsmp.com/skills/jabrena-cursor-rules-java-skills-014-agile-user-story-skill-md
 

--- a/site-generator/content/blog/2026/03/release-0.13.0.md
+++ b/site-generator/content/blog/2026/03/release-0.13.0.md
@@ -135,7 +135,7 @@ Take a look at the following [Getting Started](https://github.com/jabrena/plinth
 
 Drawing on ideas from others, it is impressive to see the new processes that [Juan Macias](https://x.com/juanmacias) is developing:
 
-[![](/plintch/images/2026/3/juan-macias.png)](https://x.com/juanmacias/status/2037973784674611648?s=20)
+[![](/plinth/images/2026/3/juan-macias.png)](https://x.com/juanmacias/status/2037973784674611648?s=20)
 
 I recommend reading [The broken telephone](https://thebrokentelephone.com/) and the associated [GitHub repository](https://github.com/darkspock/thebrokentelephone_sample).
 
@@ -233,15 +233,15 @@ When the plan is revised and you agree with it, you can invoke the new Agent: `/
 
 This agent will review the plan and repository and, depending on the context, it will delegate the coding tasks to a specific agent. Specialized agents are currently available for Pure Java, Spring Boot, Quarkus, and Micronaut.
 
-![](/plintch/images/2026/3/robot-coordinator-example.jpg)
+![](/plinth/images/2026/3/robot-coordinator-example.jpg)
 
 When you achieve the first milestone, you can review whether the implementation matches the coding standards and continue until the end of all tasks in the task list.
 
-![](/plintch/images/2026/3/robot-quarkus-coder-example.jpg)
+![](/plinth/images/2026/3/robot-quarkus-coder-example.jpg)
 
 Using incremental review, you can minimize potential deviations and commit small parts.
 
-![](/plintch/images/2026/3/robot-coordinator-example2.png)
+![](/plinth/images/2026/3/robot-coordinator-example2.png)
 
 If you have good ADRs and you invested time in a plan, the time spent on refactorings should be minimized. Indeed, I recommend making small commits per milestone.
 
@@ -283,6 +283,6 @@ Some interesting skills to review:
 
 If you feel stuck using this project or have questions, you can attend the following workshop at `Codemotion Madrid 2026`:
 
-[![](/plintch/images/2026/3/codemotion-madrid-2026.jpg)](https://conferences.codemotion.com/madrid/)
+[![](/plinth/images/2026/3/codemotion-madrid-2026.jpg)](https://conferences.codemotion.com/madrid/)
 
 https://conferences.codemotion.com/madrid/workshop/

--- a/site-generator/content/blog/2026/04/release-0.14.0.md
+++ b/site-generator/content/blog/2026/04/release-0.14.0.md
@@ -10,7 +10,7 @@ status=published
 
 A curated and opinionated collection of `Skills` and `Agents` to be used in modern `SDLC` workflows for Java Enterprise development with your favorite AI Agent harness.
 
-![](/plintch/images/2026/4/scope.png)
+![](/plinth/images/2026/4/scope.png)
 
 Thanks to our community members in `Singapore`, `Chengdu`, `Hanoi`, `Copenhagen`, and `Quito`. 👋👋👋
 
@@ -20,7 +20,7 @@ Thanks to our community members in `Singapore`, `Chengdu`, `Hanoi`, `Copenhagen`
 
 Until this release, the project maintained three very different deliverables: Rules, Skills, and Agents. `Rules` and `Skills` both guide model behavior in broadly similar ways, but Rules were Cursor’s approach while `Skills` have recently become the standard, so consolidating on a single solution makes more sense. **On the other hand**, maintaining a single generator (`skills-generator`) made it possible to improve how skills are packaged, which was somewhat constrained when both `rules-generator` and `skills-generator` existed. If you followed the various [ADRs published](https://github.com/jabrena/plinth/tree/main/documentation/adr) in the repository, you could see why the project preserves the same guidance while adopting Skills-based packaging. In previous months, users developed or refactored code using `System prompts/Rules` in this way:
 
-![](/plintch/images/2026/4/manual-trigger.png)
+![](/plinth/images/2026/4/manual-trigger.png)
 
 But now, you can do the same by adding the Skill to the context of your favorite `AI Agent harness`. You can add the Skill you want to the context explicitly, or leave it to the AI tool to use or skip depending on the context—so you can achieve the same outcomes with Skills as you could with system prompts in the past.
 
@@ -47,7 +47,7 @@ It is tedious to copy issue details from your issue tracker into the context of 
 
 Once the information is `ready for development`, you can convert it into a `Change` or `Delta` using `OpenSpec`.
 
-![](/plintch/images/2026/4/issue-to-openspec.png)
+![](/plinth/images/2026/4/issue-to-openspec.png)
 
 #### How does OpenSpec work?
 
@@ -88,7 +88,7 @@ If you pick up a user story from any issue-tracking tool and it relates to a ser
 User story > Create a Change in OpenSpec > Implement with Java Agents
 ```
 
-![](/plintch/images/2026/4/implement-openspec-change.png)
+![](/plinth/images/2026/4/implement-openspec-change.png)
 
 But if you are less sure about the assigned user story, invest more time in the analysis phase:
 
@@ -130,7 +130,7 @@ Now it is easier to update or search for dependencies in your `pom.xml` with the
 
 Now, you can review and harden **OpenAPI 3.x** contracts with `@701-technologies-openapi` when the specification still needs work. As you develop integration tests, you can strengthen them with **HTTP stubs** from **WireMock** using `@702-technologies-wiremock`. Finally, if you want **black-box testing** driven by your OpenAPI specification, `@703-technologies-fuzzing-testing` based on **CATS** can help surface defects through contract-driven negative testing, malformed and boundary inputs, and related edge cases.
 
-[![](/plintch/images/2026/4/cats.png)](https://endava.github.io/cats/)
+[![](/plinth/images/2026/4/cats.png)](https://endava.github.io/cats/)
 
 Further information about CATS: https://github.com/Endava/cats
 
@@ -216,6 +216,6 @@ Separately, the Skills need a few improvements to increase quality, so we will u
 
 If you feel stuck using this project or have questions, you can attend the following workshop at `Codemotion Madrid 2026`:
 
-[![](/plintch/images/2026/3/codemotion-madrid-2026.jpg)](https://conferences.codemotion.com/madrid/)
+[![](/plinth/images/2026/3/codemotion-madrid-2026.jpg)](https://conferences.codemotion.com/madrid/)
 
 https://conferences.codemotion.com/madrid/workshop/

--- a/site-generator/content/blog/2026/04/release-0.14.0.md
+++ b/site-generator/content/blog/2026/04/release-0.14.0.md
@@ -18,7 +18,7 @@ Thanks to our community members in `Singapore`, `Chengdu`, `Hanoi`, `Copenhagen`
 
 ### Rules support dropped in favor of Skills
 
-Until this release, the project maintained three very different deliverables: Rules, Skills, and Agents. `Rules` and `Skills` both guide model behavior in broadly similar ways, but Rules were Cursor’s approach while `Skills` have recently become the standard, so consolidating on a single solution makes more sense. **On the other hand**, maintaining a single generator (`skills-generator`) made it possible to improve how skills are packaged, which was somewhat constrained when both `rules-generator` and `skills-generator` existed. If you followed the various [ADRs published](https://github.com/jabrena/cursor-rules-java/tree/main/documentation/adr) in the repository, you could see why the project preserves the same guidance while adopting Skills-based packaging. In previous months, users developed or refactored code using `System prompts/Rules` in this way:
+Until this release, the project maintained three very different deliverables: Rules, Skills, and Agents. `Rules` and `Skills` both guide model behavior in broadly similar ways, but Rules were Cursor’s approach while `Skills` have recently become the standard, so consolidating on a single solution makes more sense. **On the other hand**, maintaining a single generator (`skills-generator`) made it possible to improve how skills are packaged, which was somewhat constrained when both `rules-generator` and `skills-generator` existed. If you followed the various [ADRs published](https://github.com/jabrena/plinth/tree/main/documentation/adr) in the repository, you could see why the project preserves the same guidance while adopting Skills-based packaging. In previous months, users developed or refactored code using `System prompts/Rules` in this way:
 
 ![](/plintch/images/2026/4/manual-trigger.png)
 
@@ -26,12 +26,12 @@ But now, you can do the same by adding the Skill to the context of your favorite
 
 On the main branch, a few resources about `System-prompts/rules` remain temporarily; we still see web traffic for them:
 
-- All rules from v0.13.0: https://github.com/jabrena/cursor-rules-java/tree/main/.cursor/rules
-- Getting Started: https://github.com/jabrena/cursor-rules-java/blob/main/documentation/guides/GETTING-STARTED-SYSTEM-PROMPTS.md
+- All rules from v0.13.0: https://github.com/jabrena/plinth/tree/main/.cursor/rules
+- Getting Started: https://github.com/jabrena/plinth/blob/main/documentation/guides/GETTING-STARTED-SYSTEM-PROMPTS.md
 
-That usage is `deprecated` in favor of `Skills` and will be removed in the coming months; review [the new documentation](https://github.com/jabrena/cursor-rules-java?tab=readme-ov-file#deliverables) and adapt your process or pipelines.
+That usage is `deprecated` in favor of `Skills` and will be removed in the coming months; review [the new documentation](https://github.com/jabrena/plinth?tab=readme-ov-file#deliverables) and adapt your process or pipelines.
 
-Separately, you can still download the last generated `System prompts/rules` from [release 0.13.0](https://github.com/jabrena/cursor-rules-java/releases/tag/0.13.0) if you need them, but development is frozen in favor of the [Skill Standard](https://agentskills.io/specification).
+Separately, you can still download the last generated `System prompts/rules` from [release 0.13.0](https://github.com/jabrena/plinth/releases/tag/0.13.0) if you need them, but development is frozen in favor of the [Skill Standard](https://agentskills.io/specification).
 
 ### Improvements in the Agile process
 
@@ -147,8 +147,8 @@ In version `v0.14.0`, the project ships `68 Skills`.
 You can install the `Skills` easily with:
 
 ```bash
-npx skills add jabrena/cursor-rules-java --all --agent cursor
-npx skills add jabrena/cursor-rules-java --all --agent claude-code
+npx skills add jabrena/plinth --all --agent cursor
+npx skills add jabrena/plinth --all --agent claude-code
 ```
 
 Once you have the skills installed, you can install the `Agents` with:

--- a/site-generator/content/blog/2026/06/from-code-generation-to-software-engineering.md
+++ b/site-generator/content/blog/2026/06/from-code-generation-to-software-engineering.md
@@ -188,6 +188,6 @@ Breaking-change avoidance makes compatibility surfaces visible:
 
 If you are using these workflows, experimenting with OpenSpec, or trying to introduce design skills into AI-assisted delivery, share your experience with the project.
 
-Use [GitHub Discussions](https://github.com/jabrena/cursor-rules-java/discussions) to post what is working, where the workflow feels unclear, which doubts you have, and what worries you about applying agents to real Java systems.
+Use [GitHub Discussions](https://github.com/jabrena/plinth/discussions) to post what is working, where the workflow feels unclear, which doubts you have, and what worries you about applying agents to real Java systems.
 
 Those conversations help improve the skills, the documentation, and the project workflow itself.

--- a/site-generator/content/blog/2026/06/introduction-to-eu-regulations-part-i.md
+++ b/site-generator/content/blog/2026/06/introduction-to-eu-regulations-part-i.md
@@ -261,7 +261,7 @@ Compliance is a qualified governance decision. These skills help engineering tea
 
 ## Example: ecommerce CI/CD PR model
 
-As a practical example, consider [system-example-cicd-pr-model.md](https://github.com/jabrena/cursor-rules-java/blob/main/examples/diagrams/deployment/system-example-cicd-pr-model.md).
+As a practical example, consider [system-example-cicd-pr-model.md](https://github.com/jabrena/plinth/blob/main/examples/diagrams/deployment/system-example-cicd-pr-model.md).
 
 ```text
                            +----------------------+

--- a/site-generator/content/blog/2026/06/release-0.15.0.md
+++ b/site-generator/content/blog/2026/06/release-0.15.0.md
@@ -44,16 +44,16 @@ The main risks that can remain when generated skills are not scanned before publ
 
 The project provides scanners, and when you use `Skills.sh`, a popular skills registry, every entry must pass three validations.
 
-**Example:** https://www.skills.sh/jabrena/cursor-rules-java/110-java-maven-best-practices
+**Example:** https://www.skills.sh/jabrena/plinth/110-java-maven-best-practices
 
 ### Improvements in Java Enterprise frameworks
 
 In this release, the project continues to add new features to improve support for `Spring Boot`, `Quarkus` & `Micronaut`. The new skills added for all frameworks cover the following aspects:
 
-- **Data Validation:** [`@303-frameworks-spring-boot-validation`](https://www.skills.sh/jabrena/cursor-rules-java/303-frameworks-spring-boot-validation), [`@403-frameworks-quarkus-validation`](https://www.skills.sh/jabrena/cursor-rules-java/403-frameworks-quarkus-validation) & [`@503-frameworks-micronaut-validation`](https://www.skills.sh/jabrena/cursor-rules-java/503-frameworks-micronaut-validation)
-- **Security:** [`@304-frameworks-spring-boot-security`](https://www.skills.sh/jabrena/cursor-rules-java/304-frameworks-spring-boot-security), [`@404-frameworks-quarkus-security`](https://www.skills.sh/jabrena/cursor-rules-java/404-frameworks-quarkus-security) & [`@504-frameworks-micronaut-security`](https://www.skills.sh/jabrena/cursor-rules-java/504-frameworks-micronaut-security)
-- **Kafka:** [`@314-frameworks-spring-kafka`](https://www.skills.sh/jabrena/cursor-rules-java/314-frameworks-spring-kafka), [`@414-frameworks-quarkus-kafka`](https://www.skills.sh/jabrena/cursor-rules-java/414-frameworks-quarkus-kafka) & [`@514-frameworks-micronaut-kafka`](https://www.skills.sh/jabrena/cursor-rules-java/514-frameworks-micronaut-kafka)
-- **MongoDB:** [`@315-frameworks-spring-mongodb`](https://www.skills.sh/jabrena/cursor-rules-java/315-frameworks-spring-mongodb), [`@415-frameworks-quarkus-mongodb`](https://www.skills.sh/jabrena/cursor-rules-java/415-frameworks-quarkus-mongodb) & [`@515-frameworks-micronaut-mongodb`](https://www.skills.sh/jabrena/cursor-rules-java/515-frameworks-micronaut-mongodb)
+- **Data Validation:** [`@303-frameworks-spring-boot-validation`](https://www.skills.sh/jabrena/plinth/303-frameworks-spring-boot-validation), [`@403-frameworks-quarkus-validation`](https://www.skills.sh/jabrena/plinth/403-frameworks-quarkus-validation) & [`@503-frameworks-micronaut-validation`](https://www.skills.sh/jabrena/plinth/503-frameworks-micronaut-validation)
+- **Security:** [`@304-frameworks-spring-boot-security`](https://www.skills.sh/jabrena/plinth/304-frameworks-spring-boot-security), [`@404-frameworks-quarkus-security`](https://www.skills.sh/jabrena/plinth/404-frameworks-quarkus-security) & [`@504-frameworks-micronaut-security`](https://www.skills.sh/jabrena/plinth/504-frameworks-micronaut-security)
+- **Kafka:** [`@314-frameworks-spring-kafka`](https://www.skills.sh/jabrena/plinth/314-frameworks-spring-kafka), [`@414-frameworks-quarkus-kafka`](https://www.skills.sh/jabrena/plinth/414-frameworks-quarkus-kafka) & [`@514-frameworks-micronaut-kafka`](https://www.skills.sh/jabrena/plinth/514-frameworks-micronaut-kafka)
+- **MongoDB:** [`@315-frameworks-spring-mongodb`](https://www.skills.sh/jabrena/plinth/315-frameworks-spring-mongodb), [`@415-frameworks-quarkus-mongodb`](https://www.skills.sh/jabrena/plinth/415-frameworks-quarkus-mongodb) & [`@515-frameworks-micronaut-mongodb`](https://www.skills.sh/jabrena/plinth/515-frameworks-micronaut-mongodb)
 
 ### Improvements in observability
 
@@ -63,9 +63,9 @@ Observability is an essential aspect of any application:
 
 In this release, we completed support for the main concepts related to observability: `Logging`, `Metrics` & `Tracing`:
 
-- **Logging:** [`@181-java-observability-logging`](https://www.skills.sh/jabrena/cursor-rules-java/181-java-observability-logging)
-- **Metrics:** [`@182-java-observability-metrics-micrometer`](https://www.skills.sh/jabrena/cursor-rules-java/182-java-observability-metrics-micrometer)
-- **Tracing:** [`@183-java-observability-tracing-opentelemetry`](https://www.skills.sh/jabrena/cursor-rules-java/183-java-observability-tracing-opentelemetry)
+- **Logging:** [`@181-java-observability-logging`](https://www.skills.sh/jabrena/plinth/181-java-observability-logging)
+- **Metrics:** [`@182-java-observability-metrics-micrometer`](https://www.skills.sh/jabrena/plinth/182-java-observability-metrics-micrometer)
+- **Tracing:** [`@183-java-observability-tracing-opentelemetry`](https://www.skills.sh/jabrena/plinth/183-java-observability-tracing-opentelemetry)
 
 Now, using any supported framework with OTEL, you can easily send continuous profiling data to Grafana:
 
@@ -85,9 +85,9 @@ https://github.com/Endava/cats
 
 The project now provides documentation in three languages:
 
-- [`English`](https://github.com/jabrena/cursor-rules-java/blob/main/README.md)
-- [`Chinese`](https://github.com/jabrena/cursor-rules-java/blob/main/README_ZH.md)
-- [`Spanish`](https://github.com/jabrena/cursor-rules-java/blob/main/README_ES.md)
+- [`English`](https://github.com/jabrena/plinth/blob/main/README.md)
+- [`Chinese`](https://github.com/jabrena/plinth/blob/main/README_ZH.md)
+- [`Spanish`](https://github.com/jabrena/plinth/blob/main/README_ES.md)
 
 ## Evolution of this project in Vercel's Skills registry
 
@@ -128,7 +128,7 @@ Last month, the project was presented and used at the tech conference `Codemotio
 
 [![](/plintch/images/2026/6/codemotion-madrid-workshop.jpg)](https://conferences.codemotion.com/madrid/)
 
-**Slides:** https://jabrena.github.io/cursor-rules-java/codemotion-madrid-2026/index.html
+**Slides:** [jabrena/plinth](https://github.com/jabrena/plinth)
 
 ### The experience in JMad 2026
 

--- a/site-generator/content/blog/2026/06/release-0.15.0.md
+++ b/site-generator/content/blog/2026/06/release-0.15.0.md
@@ -12,11 +12,11 @@ An opinionated, AI-native workflow for evolving modern Java Enterprise `SDLC` pr
 
 It helps you answer the `Five Whys` when your team needs to evolve a Java-based product or service:
 
-![](/plintch/images/2026/6/scope.png)
+![](/plinth/images/2026/6/scope.png)
 
 Once the idea is clear, you can implement it in a structured way:
 
-![](/plintch/images/2026/6/workflow.png)
+![](/plinth/images/2026/6/workflow.png)
 
 Thanks to our community members in `Singapore`, `Hanoi`, `Hong Kong`, `Milan`, and `New York`. 👋👋👋
 
@@ -59,7 +59,7 @@ In this release, the project continues to add new features to improve support fo
 
 Observability is an essential aspect of any application:
 
-[![](/plintch/images/2026/6/ms-concerns.webp)](https://developers.redhat.com/blog/2016/12/09/spring-cloud-for-microservices-compared-to-kubernetes)
+[![](/plinth/images/2026/6/ms-concerns.webp)](https://developers.redhat.com/blog/2016/12/09/spring-cloud-for-microservices-compared-to-kubernetes)
 
 In this release, we completed support for the main concepts related to observability: `Logging`, `Metrics` & `Tracing`:
 
@@ -69,7 +69,7 @@ In this release, we completed support for the main concepts related to observabi
 
 Now, using any supported framework with OTEL, you can easily send continuous profiling data to Grafana:
 
-![](/plintch/images/2026/6/piroscope-demo.png)
+![](/plinth/images/2026/6/piroscope-demo.png)
 
 https://grafana.com/oss/pyroscope/
 
@@ -77,7 +77,7 @@ https://grafana.com/oss/pyroscope/
 
 In this release, fuzz testing was improved to make it easier to use: `@703-technologies-fuzzing-testing`.
 
-![](/plintch/images/2026/6/cats.png)
+![](/plinth/images/2026/6/cats.png)
 
 https://github.com/Endava/cats
 
@@ -106,7 +106,7 @@ This project focuses mainly on the following categories, and that scope continue
 
 ### Codex
 
-![](/plintch/images/2026/6/codex.png)
+![](/plinth/images/2026/6/codex.png)
 
 Recently, I tested Codex running in `VS Code`, and the experience was fantastic. Codex understands `AGENTS.md` and skills located in `.agents/skills`.
 
@@ -116,7 +116,7 @@ Using Codex, you can run the `Agents` provided by the project without any change
 
 Recently, Gartner updated the Magic Quadrant.
 
-![](/plintch/images/2026/6/magic-cuadrant-agents.jpg)
+![](/plinth/images/2026/6/magic-cuadrant-agents.jpg)
 
 https://cursor.com/lp/2026-gartner-mq
 
@@ -126,7 +126,7 @@ https://cursor.com/lp/2026-gartner-mq
 
 Last month, the project was presented and used at the tech conference `Codemotion Madrid 2026`. The workshop had sold out a few weeks before, and participants rated the session 4.5/5.
 
-[![](/plintch/images/2026/6/codemotion-madrid-workshop.jpg)](https://conferences.codemotion.com/madrid/)
+[![](/plinth/images/2026/6/codemotion-madrid-workshop.jpg)](https://conferences.codemotion.com/madrid/)
 
 **Slides:** [jabrena/plinth](https://github.com/jabrena/plinth)
 
@@ -134,13 +134,13 @@ Last month, the project was presented and used at the tech conference `Codemotio
 
 Every year, `MadridJUG` organizes `JMad`, a Java tech event based on `OpenSpace`.
 
-[![](/plintch/images/2026/6/IMG_8268.jpg)](https://jmad.madridjug.es/)
+[![](/plinth/images/2026/6/IMG_8268.jpg)](https://jmad.madridjug.es/)
 
 `JMad` is a nice opportunity to exchange ideas and have good debates about the topics Java developers want to discuss.
 
 This year's agenda was:
 
-![](/plintch/images/2026/6/IMG_2584.webp)
+![](/plinth/images/2026/6/IMG_2584.webp)
 
 This year, several AI topics were discussed, including `AI Governance` and how to manage `Skills` in your team, unit, or company.
 

--- a/site-generator/content/blog/2026/06/release-0.16.0.md
+++ b/site-generator/content/blog/2026/06/release-0.16.0.md
@@ -40,7 +40,7 @@ We will go into more detail later, but first, let's review the most interesting 
 
 Thanks to our community members in `Singapore`, `Hong Kong`, `Hanoi`, `London`, and `New York`. 👋👋👋
 
-If you have questions about the project, how to customize it for your team, how to use the skills in daily work, or how to solve tooling issues, use [`GitHub Discussions`](https://github.com/jabrena/cursor-rules-java/discussions).
+If you have questions about the project, how to customize it for your team, how to use the skills in daily work, or how to solve tooling issues, use [`GitHub Discussions`](https://github.com/jabrena/plinth/discussions).
 
 **Help this project grow:** [If this project helps your team, become a sponsor.](https://github.com/sponsors/jabrena)
 
@@ -48,7 +48,7 @@ If you have questions about the project, how to customize it for your team, how 
 
 <a id="enriching-the-workflow-with-commands-and-agents-not-only-skills"></a>
 
-The project started more than a year ago with a set of reusable `rules / system prompts`. That approach worked well after removing the restriction that associated rules with particular files, as described in [`ADR-002`](https://github.com/jabrena/cursor-rules-java/blob/main/documentation/adr/ADR-002-configure-cursor-rules-manual-scope.md). With the rise of `Skills`, it was a good decision to convert that material into skills and use the new capabilities provided by `Skill registries` like [https://www.skills.sh/](https://www.skills.sh/) and other registries.
+The project started more than a year ago with a set of reusable `rules / system prompts`. That approach worked well after removing the restriction that associated rules with particular files, as described in [`ADR-002`](https://github.com/jabrena/plinth/blob/main/documentation/adr/ADR-002-configure-cursor-rules-manual-scope.md). With the rise of `Skills`, it was a good decision to convert that material into skills and use the new capabilities provided by `Skill registries` like [https://www.skills.sh/](https://www.skills.sh/) and other registries.
 
 In this release, we go further by adding new semantics for expressing the actions a software engineer performs while solving a problem.
 
@@ -124,20 +124,20 @@ In other projects, you can find useful `Skills`, `Agents`, or `Commands`, but no
 
 <a id="what-are-the-top-10-skills-from-this-project-in-skillssh"></a>
 
-The project has `106 skills` and uses [Skills.sh](https://www.skills.sh/jabrena/cursor-rules-java) as its main skill registry. It has served `11.0K` installs in total. These are the current top 10 skills used by users there:
+The project has `106 skills` and uses [Skills.sh](https://www.skills.sh/jabrena/plinth) as its main skill registry. It has served `11.0K` installs in total. These are the current top 10 skills used by users there:
 
-1. [`110-java-maven-best-practices`](https://www.skills.sh/jabrena/cursor-rules-java/110-java-maven-best-practices) - search query: [maven](https://www.skills.sh/search?q=maven)
-2. [`121-java-object-oriented-design`](https://www.skills.sh/jabrena/cursor-rules-java/121-java-object-oriented-design) - search query: [java object oriented](https://www.skills.sh/search?q=java%20object%20oriented)
-3. [`124-java-secure-coding`](https://www.skills.sh/jabrena/cursor-rules-java/124-java-secure-coding) - search query: [java security](https://www.skills.sh/search?q=java%20security)
-4. [`131-java-testing-unit-testing`](https://www.skills.sh/jabrena/cursor-rules-java/131-java-testing-unit-testing) - search query: [java unit testing](https://www.skills.sh/search?q=java%20unit%20testing)
-5. [`142-java-functional-programming`](https://www.skills.sh/jabrena/cursor-rules-java/142-java-functional-programming) - search query: [java functional programming](https://www.skills.sh/search?q=java%20functional%20programming)
-6. [`128-java-generics`](https://www.skills.sh/jabrena/cursor-rules-java/128-java-generics) - search query: [java generics](https://www.skills.sh/search?q=java%20generics)
-7. [`111-java-maven-dependencies`](https://www.skills.sh/jabrena/cursor-rules-java/111-java-maven-dependencies) - search query: [maven](https://www.skills.sh/search?q=maven)
-8. [`141-java-refactoring-with-modern-features`](https://www.skills.sh/jabrena/cursor-rules-java/141-java-refactoring-with-modern-features)
-9. [`125-java-concurrency`](https://www.skills.sh/jabrena/cursor-rules-java/125-java-concurrency) - search query: [java concurrency](https://www.skills.sh/search?q=java%20concurrency)
-10. [`143-java-functional-exception-handling`](https://www.skills.sh/jabrena/cursor-rules-java/143-java-functional-exception-handling) - search query: [java functional programming](https://www.skills.sh/search?q=java%20functional%20programming)
+1. [`110-java-maven-best-practices`](https://www.skills.sh/jabrena/plinth/110-java-maven-best-practices) - search query: [maven](https://www.skills.sh/search?q=maven)
+2. [`121-java-object-oriented-design`](https://www.skills.sh/jabrena/plinth/121-java-object-oriented-design) - search query: [java object oriented](https://www.skills.sh/search?q=java%20object%20oriented)
+3. [`124-java-secure-coding`](https://www.skills.sh/jabrena/plinth/124-java-secure-coding) - search query: [java security](https://www.skills.sh/search?q=java%20security)
+4. [`131-java-testing-unit-testing`](https://www.skills.sh/jabrena/plinth/131-java-testing-unit-testing) - search query: [java unit testing](https://www.skills.sh/search?q=java%20unit%20testing)
+5. [`142-java-functional-programming`](https://www.skills.sh/jabrena/plinth/142-java-functional-programming) - search query: [java functional programming](https://www.skills.sh/search?q=java%20functional%20programming)
+6. [`128-java-generics`](https://www.skills.sh/jabrena/plinth/128-java-generics) - search query: [java generics](https://www.skills.sh/search?q=java%20generics)
+7. [`111-java-maven-dependencies`](https://www.skills.sh/jabrena/plinth/111-java-maven-dependencies) - search query: [maven](https://www.skills.sh/search?q=maven)
+8. [`141-java-refactoring-with-modern-features`](https://www.skills.sh/jabrena/plinth/141-java-refactoring-with-modern-features)
+9. [`125-java-concurrency`](https://www.skills.sh/jabrena/plinth/125-java-concurrency) - search query: [java concurrency](https://www.skills.sh/search?q=java%20concurrency)
+10. [`143-java-functional-exception-handling`](https://www.skills.sh/jabrena/plinth/143-java-functional-exception-handling) - search query: [java functional programming](https://www.skills.sh/search?q=java%20functional%20programming)
 
-**What is your favorite `Skill` from this project?** You can share it here: https://github.com/jabrena/cursor-rules-java/discussions/804
+**What is your favorite `Skill` from this project?** You can share it here: https://github.com/jabrena/plinth/discussions/804
 
 ## Applying Zero Trust with your Agent skills
 
@@ -169,7 +169,7 @@ Common skill risks include:
 - Untrusted content and indirect prompt injection
 - Tool poisoning and tool shadowing
 
-**Note:** The project runs an analysis for all skills on every commit using the tools described above. https://github.com/jabrena/cursor-rules-java/blob/main/.github/workflows/maven.yaml
+**Note:** The project runs an analysis for all skills on every commit using the tools described above. https://github.com/jabrena/plinth/blob/main/.github/workflows/maven.yaml
 
 If you are interested in this kind of validation, I recommend reading the following article: [How to validate skills?](/cursor-rules-java/blog/2026/06/skill-validators-pipeline.html)
 
@@ -257,7 +257,7 @@ To demonstrate the new capabilities, let's try to solve the first problem from t
   - Nordic API: https://my-json-server.typicode.com/jabrena/latency-problems/nordic
 ```
 
-Given this `User story` and the `OpenSpec` change defined here: https://github.com/jabrena/cursor-rules-java/tree/main/examples/openspec, you can implement it using the new `/implement-issue` command. Let's see how to do it and how to validate it.
+Given this `User story` and the `OpenSpec` change defined here: https://github.com/jabrena/plinth/tree/main/examples/openspec, you can implement it using the new `/implement-issue` command. Let's see how to do it and how to validate it.
 
 **/implement-issue:**
 
@@ -370,11 +370,11 @@ With the rise of `Skills`, there is a need for public registries for them. But w
 
 To take advantage of the public registry and the process for generating skills from `XML` sources, it is relatively easy to embed commands and agents in a `Meta Skill`. Once you have installed the skills, you can use the following inventory and installation workflows:
 
-- [`@001-commands-inventory`](https://www.skills.sh/jabrena/cursor-rules-java/001-commands-inventory)
-- [`@002-agents-inventory`](https://www.skills.sh/jabrena/cursor-rules-java/002-agents-inventory)
-- [`@003-skills-inventory`](https://www.skills.sh/jabrena/cursor-rules-java/003-skills-inventory)
-- [`@004-commands-installation`](https://www.skills.sh/jabrena/cursor-rules-java/004-commands-installation)
-- [`@005-agents-installation`](https://www.skills.sh/jabrena/cursor-rules-java/005-agents-installation)
+- [`@001-commands-inventory`](https://www.skills.sh/jabrena/plinth/001-commands-inventory)
+- [`@002-agents-inventory`](https://www.skills.sh/jabrena/plinth/002-agents-inventory)
+- [`@003-skills-inventory`](https://www.skills.sh/jabrena/plinth/003-skills-inventory)
+- [`@004-commands-installation`](https://www.skills.sh/jabrena/plinth/004-commands-installation)
+- [`@005-agents-installation`](https://www.skills.sh/jabrena/plinth/005-agents-installation)
 
 Then you can use them to install assets or generate the inventory files.
 
@@ -403,55 +403,55 @@ The value is that teams can pick the framework lane first, then apply the matchi
 
 **Spring Boot skills:**
 
-- [`@300-frameworks-spring-boot-create-project`](https://www.skills.sh/jabrena/cursor-rules-java/300-frameworks-spring-boot-create-project)
-- [`@301-frameworks-spring-boot-core`](https://www.skills.sh/jabrena/cursor-rules-java/301-frameworks-spring-boot-core)
-- [`@302-frameworks-spring-boot-rest`](https://www.skills.sh/jabrena/cursor-rules-java/302-frameworks-spring-boot-rest)
-- [`@303-frameworks-spring-boot-validation`](https://www.skills.sh/jabrena/cursor-rules-java/303-frameworks-spring-boot-validation)
-- [`@304-frameworks-spring-boot-security`](https://www.skills.sh/jabrena/cursor-rules-java/304-frameworks-spring-boot-security)
-- [`@305-frameworks-spring-boot-modulith`](https://www.skills.sh/jabrena/cursor-rules-java/305-frameworks-spring-boot-modulith)
-- [`@311-frameworks-spring-jdbc`](https://www.skills.sh/jabrena/cursor-rules-java/311-frameworks-spring-jdbc)
-- [`@312-frameworks-spring-data-jdbc`](https://www.skills.sh/jabrena/cursor-rules-java/312-frameworks-spring-data-jdbc)
-- [`@313-frameworks-spring-db-migrations-flyway`](https://www.skills.sh/jabrena/cursor-rules-java/313-frameworks-spring-db-migrations-flyway)
-- [`@314-frameworks-spring-kafka`](https://www.skills.sh/jabrena/cursor-rules-java/314-frameworks-spring-kafka)
-- [`@315-frameworks-spring-mongodb`](https://www.skills.sh/jabrena/cursor-rules-java/315-frameworks-spring-mongodb)
-- [`@316-frameworks-spring-mongodb-migrations-mongock`](https://www.skills.sh/jabrena/cursor-rules-java/316-frameworks-spring-mongodb-migrations-mongock)
-- [`@321-frameworks-spring-boot-testing-unit-tests`](https://www.skills.sh/jabrena/cursor-rules-java/321-frameworks-spring-boot-testing-unit-tests)
-- [`@322-frameworks-spring-boot-testing-integration-tests`](https://www.skills.sh/jabrena/cursor-rules-java/322-frameworks-spring-boot-testing-integration-tests)
-- [`@323-frameworks-spring-boot-testing-acceptance-tests`](https://www.skills.sh/jabrena/cursor-rules-java/323-frameworks-spring-boot-testing-acceptance-tests)
+- [`@300-frameworks-spring-boot-create-project`](https://www.skills.sh/jabrena/plinth/300-frameworks-spring-boot-create-project)
+- [`@301-frameworks-spring-boot-core`](https://www.skills.sh/jabrena/plinth/301-frameworks-spring-boot-core)
+- [`@302-frameworks-spring-boot-rest`](https://www.skills.sh/jabrena/plinth/302-frameworks-spring-boot-rest)
+- [`@303-frameworks-spring-boot-validation`](https://www.skills.sh/jabrena/plinth/303-frameworks-spring-boot-validation)
+- [`@304-frameworks-spring-boot-security`](https://www.skills.sh/jabrena/plinth/304-frameworks-spring-boot-security)
+- [`@305-frameworks-spring-boot-modulith`](https://www.skills.sh/jabrena/plinth/305-frameworks-spring-boot-modulith)
+- [`@311-frameworks-spring-jdbc`](https://www.skills.sh/jabrena/plinth/311-frameworks-spring-jdbc)
+- [`@312-frameworks-spring-data-jdbc`](https://www.skills.sh/jabrena/plinth/312-frameworks-spring-data-jdbc)
+- [`@313-frameworks-spring-db-migrations-flyway`](https://www.skills.sh/jabrena/plinth/313-frameworks-spring-db-migrations-flyway)
+- [`@314-frameworks-spring-kafka`](https://www.skills.sh/jabrena/plinth/314-frameworks-spring-kafka)
+- [`@315-frameworks-spring-mongodb`](https://www.skills.sh/jabrena/plinth/315-frameworks-spring-mongodb)
+- [`@316-frameworks-spring-mongodb-migrations-mongock`](https://www.skills.sh/jabrena/plinth/316-frameworks-spring-mongodb-migrations-mongock)
+- [`@321-frameworks-spring-boot-testing-unit-tests`](https://www.skills.sh/jabrena/plinth/321-frameworks-spring-boot-testing-unit-tests)
+- [`@322-frameworks-spring-boot-testing-integration-tests`](https://www.skills.sh/jabrena/plinth/322-frameworks-spring-boot-testing-integration-tests)
+- [`@323-frameworks-spring-boot-testing-acceptance-tests`](https://www.skills.sh/jabrena/plinth/323-frameworks-spring-boot-testing-acceptance-tests)
 
 **Quarkus skills:**
 
-- [`@400-frameworks-quarkus-create-project`](https://www.skills.sh/jabrena/cursor-rules-java/400-frameworks-quarkus-create-project)
-- [`@401-frameworks-quarkus-core`](https://www.skills.sh/jabrena/cursor-rules-java/401-frameworks-quarkus-core)
-- [`@402-frameworks-quarkus-rest`](https://www.skills.sh/jabrena/cursor-rules-java/402-frameworks-quarkus-rest)
-- [`@403-frameworks-quarkus-validation`](https://www.skills.sh/jabrena/cursor-rules-java/403-frameworks-quarkus-validation)
-- [`@404-frameworks-quarkus-security`](https://www.skills.sh/jabrena/cursor-rules-java/404-frameworks-quarkus-security)
-- [`@411-frameworks-quarkus-jdbc`](https://www.skills.sh/jabrena/cursor-rules-java/411-frameworks-quarkus-jdbc)
-- [`@412-frameworks-quarkus-panache`](https://www.skills.sh/jabrena/cursor-rules-java/412-frameworks-quarkus-panache)
-- [`@413-frameworks-quarkus-db-migrations-flyway`](https://www.skills.sh/jabrena/cursor-rules-java/413-frameworks-quarkus-db-migrations-flyway)
-- [`@414-frameworks-quarkus-kafka`](https://www.skills.sh/jabrena/cursor-rules-java/414-frameworks-quarkus-kafka)
-- [`@415-frameworks-quarkus-mongodb`](https://www.skills.sh/jabrena/cursor-rules-java/415-frameworks-quarkus-mongodb)
-- [`@416-frameworks-quarkus-mongodb-migrations-mongock`](https://www.skills.sh/jabrena/cursor-rules-java/416-frameworks-quarkus-mongodb-migrations-mongock)
-- [`@421-frameworks-quarkus-testing-unit-tests`](https://www.skills.sh/jabrena/cursor-rules-java/421-frameworks-quarkus-testing-unit-tests)
-- [`@422-frameworks-quarkus-testing-integration-tests`](https://www.skills.sh/jabrena/cursor-rules-java/422-frameworks-quarkus-testing-integration-tests)
-- [`@423-frameworks-quarkus-testing-acceptance-tests`](https://www.skills.sh/jabrena/cursor-rules-java/423-frameworks-quarkus-testing-acceptance-tests)
+- [`@400-frameworks-quarkus-create-project`](https://www.skills.sh/jabrena/plinth/400-frameworks-quarkus-create-project)
+- [`@401-frameworks-quarkus-core`](https://www.skills.sh/jabrena/plinth/401-frameworks-quarkus-core)
+- [`@402-frameworks-quarkus-rest`](https://www.skills.sh/jabrena/plinth/402-frameworks-quarkus-rest)
+- [`@403-frameworks-quarkus-validation`](https://www.skills.sh/jabrena/plinth/403-frameworks-quarkus-validation)
+- [`@404-frameworks-quarkus-security`](https://www.skills.sh/jabrena/plinth/404-frameworks-quarkus-security)
+- [`@411-frameworks-quarkus-jdbc`](https://www.skills.sh/jabrena/plinth/411-frameworks-quarkus-jdbc)
+- [`@412-frameworks-quarkus-panache`](https://www.skills.sh/jabrena/plinth/412-frameworks-quarkus-panache)
+- [`@413-frameworks-quarkus-db-migrations-flyway`](https://www.skills.sh/jabrena/plinth/413-frameworks-quarkus-db-migrations-flyway)
+- [`@414-frameworks-quarkus-kafka`](https://www.skills.sh/jabrena/plinth/414-frameworks-quarkus-kafka)
+- [`@415-frameworks-quarkus-mongodb`](https://www.skills.sh/jabrena/plinth/415-frameworks-quarkus-mongodb)
+- [`@416-frameworks-quarkus-mongodb-migrations-mongock`](https://www.skills.sh/jabrena/plinth/416-frameworks-quarkus-mongodb-migrations-mongock)
+- [`@421-frameworks-quarkus-testing-unit-tests`](https://www.skills.sh/jabrena/plinth/421-frameworks-quarkus-testing-unit-tests)
+- [`@422-frameworks-quarkus-testing-integration-tests`](https://www.skills.sh/jabrena/plinth/422-frameworks-quarkus-testing-integration-tests)
+- [`@423-frameworks-quarkus-testing-acceptance-tests`](https://www.skills.sh/jabrena/plinth/423-frameworks-quarkus-testing-acceptance-tests)
 
 **Micronaut skills:**
 
-- [`@500-frameworks-micronaut-create-project`](https://www.skills.sh/jabrena/cursor-rules-java/500-frameworks-micronaut-create-project)
-- [`@501-frameworks-micronaut-core`](https://www.skills.sh/jabrena/cursor-rules-java/501-frameworks-micronaut-core)
-- [`@502-frameworks-micronaut-rest`](https://www.skills.sh/jabrena/cursor-rules-java/502-frameworks-micronaut-rest)
-- [`@503-frameworks-micronaut-validation`](https://www.skills.sh/jabrena/cursor-rules-java/503-frameworks-micronaut-validation)
-- [`@504-frameworks-micronaut-security`](https://www.skills.sh/jabrena/cursor-rules-java/504-frameworks-micronaut-security)
-- [`@511-frameworks-micronaut-jdbc`](https://www.skills.sh/jabrena/cursor-rules-java/511-frameworks-micronaut-jdbc)
-- [`@512-frameworks-micronaut-data`](https://www.skills.sh/jabrena/cursor-rules-java/512-frameworks-micronaut-data)
-- [`@513-frameworks-micronaut-db-migrations-flyway`](https://www.skills.sh/jabrena/cursor-rules-java/513-frameworks-micronaut-db-migrations-flyway)
-- [`@514-frameworks-micronaut-kafka`](https://www.skills.sh/jabrena/cursor-rules-java/514-frameworks-micronaut-kafka)
-- [`@515-frameworks-micronaut-mongodb`](https://www.skills.sh/jabrena/cursor-rules-java/515-frameworks-micronaut-mongodb)
-- [`@516-frameworks-micronaut-mongodb-migrations-mongock`](https://www.skills.sh/jabrena/cursor-rules-java/516-frameworks-micronaut-mongodb-migrations-mongock)
-- [`@521-frameworks-micronaut-testing-unit-tests`](https://www.skills.sh/jabrena/cursor-rules-java/521-frameworks-micronaut-testing-unit-tests)
-- [`@522-frameworks-micronaut-testing-integration-tests`](https://www.skills.sh/jabrena/cursor-rules-java/522-frameworks-micronaut-testing-integration-tests)
-- [`@523-frameworks-micronaut-testing-acceptance-tests`](https://www.skills.sh/jabrena/cursor-rules-java/523-frameworks-micronaut-testing-acceptance-tests)
+- [`@500-frameworks-micronaut-create-project`](https://www.skills.sh/jabrena/plinth/500-frameworks-micronaut-create-project)
+- [`@501-frameworks-micronaut-core`](https://www.skills.sh/jabrena/plinth/501-frameworks-micronaut-core)
+- [`@502-frameworks-micronaut-rest`](https://www.skills.sh/jabrena/plinth/502-frameworks-micronaut-rest)
+- [`@503-frameworks-micronaut-validation`](https://www.skills.sh/jabrena/plinth/503-frameworks-micronaut-validation)
+- [`@504-frameworks-micronaut-security`](https://www.skills.sh/jabrena/plinth/504-frameworks-micronaut-security)
+- [`@511-frameworks-micronaut-jdbc`](https://www.skills.sh/jabrena/plinth/511-frameworks-micronaut-jdbc)
+- [`@512-frameworks-micronaut-data`](https://www.skills.sh/jabrena/plinth/512-frameworks-micronaut-data)
+- [`@513-frameworks-micronaut-db-migrations-flyway`](https://www.skills.sh/jabrena/plinth/513-frameworks-micronaut-db-migrations-flyway)
+- [`@514-frameworks-micronaut-kafka`](https://www.skills.sh/jabrena/plinth/514-frameworks-micronaut-kafka)
+- [`@515-frameworks-micronaut-mongodb`](https://www.skills.sh/jabrena/plinth/515-frameworks-micronaut-mongodb)
+- [`@516-frameworks-micronaut-mongodb-migrations-mongock`](https://www.skills.sh/jabrena/plinth/516-frameworks-micronaut-mongodb-migrations-mongock)
+- [`@521-frameworks-micronaut-testing-unit-tests`](https://www.skills.sh/jabrena/plinth/521-frameworks-micronaut-testing-unit-tests)
+- [`@522-frameworks-micronaut-testing-integration-tests`](https://www.skills.sh/jabrena/plinth/522-frameworks-micronaut-testing-integration-tests)
+- [`@523-frameworks-micronaut-testing-acceptance-tests`](https://www.skills.sh/jabrena/plinth/523-frameworks-micronaut-testing-acceptance-tests)
 
 ## Increasing engineering awareness with EU regulations
 
@@ -465,14 +465,14 @@ This becomes even more important with GenAI tooling. When prompts, embeddings, g
 
 `0.16.0` introduces a new alpha family of regulation engineering review skills:
 
-- [`@801-regulations-eu-ai-act`](https://www.skills.sh/jabrena/cursor-rules-java/801-regulations-eu-ai-act)
-- [`@802-regulations-dora`](https://www.skills.sh/jabrena/cursor-rules-java/802-regulations-dora)
-- [`@803-regulations-gdpr`](https://www.skills.sh/jabrena/cursor-rules-java/803-regulations-gdpr)
-- [`@804-regulations-eu-nis2`](https://www.skills.sh/jabrena/cursor-rules-java/804-regulations-eu-nis2)
-- [`@805-regulations-eu-cyber-resilience-act`](https://www.skills.sh/jabrena/cursor-rules-java/805-regulations-eu-cyber-resilience-act)
-- [`@806-regulations-eu-data-act`](https://www.skills.sh/jabrena/cursor-rules-java/806-regulations-eu-data-act)
-- [`@807-regulations-eu-digital-services-act`](https://www.skills.sh/jabrena/cursor-rules-java/807-regulations-eu-digital-services-act)
-- [`@808-regulations-eu-digital-markets-act`](https://www.skills.sh/jabrena/cursor-rules-java/808-regulations-eu-digital-markets-act)
+- [`@801-regulations-eu-ai-act`](https://www.skills.sh/jabrena/plinth/801-regulations-eu-ai-act)
+- [`@802-regulations-dora`](https://www.skills.sh/jabrena/plinth/802-regulations-dora)
+- [`@803-regulations-gdpr`](https://www.skills.sh/jabrena/plinth/803-regulations-gdpr)
+- [`@804-regulations-eu-nis2`](https://www.skills.sh/jabrena/plinth/804-regulations-eu-nis2)
+- [`@805-regulations-eu-cyber-resilience-act`](https://www.skills.sh/jabrena/plinth/805-regulations-eu-cyber-resilience-act)
+- [`@806-regulations-eu-data-act`](https://www.skills.sh/jabrena/plinth/806-regulations-eu-data-act)
+- [`@807-regulations-eu-digital-services-act`](https://www.skills.sh/jabrena/plinth/807-regulations-eu-digital-services-act)
+- [`@808-regulations-eu-digital-markets-act`](https://www.skills.sh/jabrena/plinth/808-regulations-eu-digital-markets-act)
 
 These skills are engineering review aids. **_They do not provide legal advice and they do not replace qualified legal, compliance, privacy, security, risk, product, or governance owners._**
 
@@ -497,21 +497,21 @@ The [Thoughtworks Technology Radar Vol. 34](https://www.thoughtworks.com/radar) 
 
 **Adopt**
 
-- **Curated shared instructions for software teams** — The Radar explicitly calls out `AGENTS.md` as a distribution mechanism for AI guidance, anchored into service templates so every new repository inherits the latest agent workflows. This project has been doing exactly that from the start. See [`@200-agents-md`](https://www.skills.sh/jabrena/cursor-rules-java/200-agents-md).
+- **Curated shared instructions for software teams** — The Radar explicitly calls out `AGENTS.md` as a distribution mechanism for AI guidance, anchored into service templates so every new repository inherits the latest agent workflows. This project has been doing exactly that from the start. See [`@200-agents-md`](https://www.skills.sh/jabrena/plinth/200-agents-md).
 - **Context engineering** — Treating the context window as a design surface rather than a static text box is now a foundational concern. The skill system in this project is a practical application of that principle: skills are loaded on demand, not front-loaded into a monolithic prompt.
 - **Zero trust architecture** — The Radar recommends ZTA as a non-negotiable default for agent deployments: never trust, always verify, least-privilege access. The [Applying Zero Trust with Agent Skills](#applying-zero-trust-with-your-agent-skills) section in this release directly addresses this applied to skill-based agent workflows.
 
 **Trial**
 
-- **Agent Skills** — The Radar places Agent Skills in Trial, noting they are an open standard for modularizing context, reducing token consumption and providing a controlled alternative to MCP. This project is one of the early skill registries on [skills.sh](https://www.skills.sh/jabrena/cursor-rules-java), shipping skills for Java Enterprise workflows.
+- **Agent Skills** — The Radar places Agent Skills in Trial, noting they are an open standard for modularizing context, reducing token consumption and providing a controlled alternative to MCP. This project is one of the early skill registries on [skills.sh](https://www.skills.sh/jabrena/plinth), shipping skills for Java Enterprise workflows.
 - **Feedback sensors for coding agents** — Deterministic quality gates wired into agent workflows so failures trigger self-correction. This project uses `skill-check` and `skill-scanner` as post-generation feedback sensors, and is now expanding coverage with `Gherkin` acceptance tests for Skills, Agents and Commands.
 - **Progressive context disclosure** — Agents should load only what is needed for the current task. The `001-commands-inventory`, `002-agents-inventory`, and `003-skills-inventory` skills serve as lightweight discovery indexes before detailed skill content is loaded.
-- **Mutation testing** — The Radar highlights `Pitest` for Java as a way to verify that a passing test suite genuinely validates behavior. The Java testing skills in this project include guidance on mutation testing as a quality signal. Use [`@112-java-maven-plugins`](https://www.skills.sh/jabrena/cursor-rules-java/112-java-maven-plugins) to add and configure the Pitest Maven plugin.
-- **Mapping code smells to refactoring techniques** — The Radar recommends Agent Skills and slash commands for mapping legacy patterns to specific refactoring approaches. This project covers this for Java across multiple dimensions: [`@141-java-refactoring-with-modern-features`](https://www.skills.sh/jabrena/cursor-rules-java/141-java-refactoring-with-modern-features) for modernising existing code, [`@121-java-object-oriented-design`](https://www.skills.sh/jabrena/cursor-rules-java/121-java-object-oriented-design) for OOP principles and code smells, [`@122-java-type-design`](https://www.skills.sh/jabrena/cursor-rules-java/122-java-type-design) for type-level design decisions, [`@142-java-functional-programming`](https://www.skills.sh/jabrena/cursor-rules-java/142-java-functional-programming) for functional style, and [`@143-java-functional-exception-handling`](https://www.skills.sh/jabrena/cursor-rules-java/143-java-functional-exception-handling) for functional error handling patterns.
+- **Mutation testing** — The Radar highlights `Pitest` for Java as a way to verify that a passing test suite genuinely validates behavior. The Java testing skills in this project include guidance on mutation testing as a quality signal. Use [`@112-java-maven-plugins`](https://www.skills.sh/jabrena/plinth/112-java-maven-plugins) to add and configure the Pitest Maven plugin.
+- **Mapping code smells to refactoring techniques** — The Radar recommends Agent Skills and slash commands for mapping legacy patterns to specific refactoring approaches. This project covers this for Java across multiple dimensions: [`@141-java-refactoring-with-modern-features`](https://www.skills.sh/jabrena/plinth/141-java-refactoring-with-modern-features) for modernising existing code, [`@121-java-object-oriented-design`](https://www.skills.sh/jabrena/plinth/121-java-object-oriented-design) for OOP principles and code smells, [`@122-java-type-design`](https://www.skills.sh/jabrena/plinth/122-java-type-design) for type-level design decisions, [`@142-java-functional-programming`](https://www.skills.sh/jabrena/plinth/142-java-functional-programming) for functional style, and [`@143-java-functional-exception-handling`](https://www.skills.sh/jabrena/plinth/143-java-functional-exception-handling) for functional error handling patterns.
 
 **Assess**
 
-- **Architecture drift reduction with LLMs** — The Radar mentions `ArchUnit` as a deterministic structural tool to combine with LLM-powered evaluation. Use [`@111-java-maven-dependencies`](https://www.skills.sh/jabrena/cursor-rules-java/111-java-maven-dependencies) to add ArchUnit to a Java project.
+- **Architecture drift reduction with LLMs** — The Radar mentions `ArchUnit` as a deterministic structural tool to combine with LLM-powered evaluation. Use [`@111-java-maven-dependencies`](https://www.skills.sh/jabrena/plinth/111-java-maven-dependencies) to add ArchUnit to a Java project.
 - **Code intelligence as agentic tooling** — The Radar calls out the Serena MCP server for semantic code retrieval. This project already enables `serena` as one of its configured MCP servers, giving agents structured access to the codebase rather than relying on text search.
 
 **Cross-cutting theme: Putting coding agents on a leash**
@@ -522,7 +522,7 @@ The Radar's editorial theme explicitly names `OpenSpec` alongside `GitHub Spec-K
 
 <a id="next-steps"></a>
 
-The next phase is already visible in the [`v0.17.0` milestone](https://github.com/jabrena/cursor-rules-java/milestone/11). The backlog continues the same direction as `0.16.0`: make agent workflows more useful, more deterministic, and easier to adopt in real teams.
+The next phase is already visible in the [`v0.17.0` milestone](https://github.com/jabrena/plinth/milestone/11). The backlog continues the same direction as `0.16.0`: make agent workflows more useful, more deterministic, and easier to adopt in real teams.
 
 Functionally, the next workstreams are:
 

--- a/site-generator/content/blog/2026/06/release-0.16.0.md
+++ b/site-generator/content/blog/2026/06/release-0.16.0.md
@@ -326,7 +326,7 @@ In this case, the command internally uses the agent `@robot-tech-lead`, which re
 
 *Running the test with Codex CLI for the Spring Boot variant*
 
-![](/plintch/images/2026/6/vscode-codex.png)
+![](/plinth/images/2026/6/vscode-codex.png)
 
 *Running the test with VS Code + Codex plugin*
 

--- a/site-generator/content/blog/2026/06/skill-validators-pipeline.md
+++ b/site-generator/content/blog/2026/06/skill-validators-pipeline.md
@@ -237,4 +237,4 @@ Skill validation is not a single gate. It is a layered review process that check
 
 The more capable AI agent workflows become, the more important it is to make those checks explicit, repeatable, and visible in the pipeline.
 
-**Example pipeline:** [maven.yaml](https://github.com/jabrena/cursor-rules-java/blob/main/.github/workflows/maven.yaml)
+**Example pipeline:** [maven.yaml](https://github.com/jabrena/plinth/blob/main/.github/workflows/maven.yaml)

--- a/site-generator/content/blog/2026/07/introduction-to-eu-regulations-part-ii.md
+++ b/site-generator/content/blog/2026/07/introduction-to-eu-regulations-part-ii.md
@@ -237,6 +237,6 @@ The common theme is evidence. Each skill helps Java teams turn regulatory or sta
 
 If you are using these workflows, experimenting with OpenSpec, or trying to introduce regulation skills into AI-assisted delivery, share your experience with the project.
 
-Use [GitHub Discussions](https://github.com/jabrena/cursor-rules-java/discussions) to post what is working, where the workflow feels unclear, which doubts you have, and what worries you about applying agents to real Java systems.
+Use [GitHub Discussions](https://github.com/jabrena/plinth/discussions) to post what is working, where the workflow feels unclear, which doubts you have, and what worries you about applying agents to real Java systems.
 
 Those conversations help improve the skills, the documentation, and the project workflow itself.

--- a/site-generator/content/blog/2026/07/release-0.17.0.md
+++ b/site-generator/content/blog/2026/07/release-0.17.0.md
@@ -32,7 +32,7 @@ Once it was explained the repository name change, lets continue with the article
 - [Improving CI and documentation validation](#improving-ci-and-documentation-validation)
 - [Next steps](#next-steps)
 
-If you have questions about the project, how to customize it for your team, how to use the skills in daily work, or how to solve tooling issues, use [`GitHub Discussions`](https://github.com/jabrena/cursor-rules-java/discussions).
+If you have questions about the project, how to customize it for your team, how to use the skills in daily work, or how to solve tooling issues, use [`GitHub Discussions`](https://github.com/jabrena/plinth/discussions).
 
 **Help this project grow:** [If this project helps your team, become a sponsor.](https://github.com/sponsors/jabrena)
 
@@ -44,12 +44,12 @@ AI coding tools are very good at producing code quickly. That is useful, but spe
 
 This release adds a new family of design skills:
 
-- [`@051-design-two-steps-methods`](https://www.skills.sh/jabrena/cursor-rules-java/051-design-two-steps-methods)
-- [`@052-design-hamburger-method`](https://www.skills.sh/jabrena/cursor-rules-java/052-design-hamburger-method)
-- [`@053-design-simple-rules`](https://www.skills.sh/jabrena/cursor-rules-java/053-design-simple-rules)
-- [`@054-design-tdd`](https://www.skills.sh/jabrena/cursor-rules-java/054-design-tdd)
-- [`@055-design-parallel-change`](https://www.skills.sh/jabrena/cursor-rules-java/055-design-parallel-change)
-- [`@056-design-avoid-breaking-changes`](https://www.skills.sh/jabrena/cursor-rules-java/056-design-avoid-breaking-changes)
+- [`@051-design-two-steps-methods`](https://www.skills.sh/jabrena/plinth/051-design-two-steps-methods)
+- [`@052-design-hamburger-method`](https://www.skills.sh/jabrena/plinth/052-design-hamburger-method)
+- [`@053-design-simple-rules`](https://www.skills.sh/jabrena/plinth/053-design-simple-rules)
+- [`@054-design-tdd`](https://www.skills.sh/jabrena/plinth/054-design-tdd)
+- [`@055-design-parallel-change`](https://www.skills.sh/jabrena/plinth/055-design-parallel-change)
+- [`@056-design-avoid-breaking-changes`](https://www.skills.sh/jabrena/plinth/056-design-avoid-breaking-changes)
 
 The goal is to move an agent from "generate the final patch" to "understand the change path". If you are interested in this direction, I recommend reading the following article: [From code generation to software engineering](/cursor-rules-java/blog/2026/06/from-code-generation-to-software-engineering.html)
 
@@ -70,12 +70,12 @@ Database migrations are one of the easiest places for an AI agent to produce a c
 
 This release improves the migration guidance for:
 
-- [`@313-frameworks-spring-db-migrations-flyway`](https://www.skills.sh/jabrena/cursor-rules-java/313-frameworks-spring-db-migrations-flyway)
-- [`@413-frameworks-quarkus-db-migrations-flyway`](https://www.skills.sh/jabrena/cursor-rules-java/413-frameworks-quarkus-db-migrations-flyway)
-- [`@513-frameworks-micronaut-db-migrations-flyway`](https://www.skills.sh/jabrena/cursor-rules-java/513-frameworks-micronaut-db-migrations-flyway)
-- [`@316-frameworks-spring-mongodb-migrations-mongock`](https://www.skills.sh/jabrena/cursor-rules-java/316-frameworks-spring-mongodb-migrations-mongock)
-- [`@416-frameworks-quarkus-mongodb-migrations-mongock`](https://www.skills.sh/jabrena/cursor-rules-java/416-frameworks-quarkus-mongodb-migrations-mongock)
-- [`@516-frameworks-micronaut-mongodb-migrations-mongock`](https://www.skills.sh/jabrena/cursor-rules-java/516-frameworks-micronaut-mongodb-migrations-mongock)
+- [`@313-frameworks-spring-db-migrations-flyway`](https://www.skills.sh/jabrena/plinth/313-frameworks-spring-db-migrations-flyway)
+- [`@413-frameworks-quarkus-db-migrations-flyway`](https://www.skills.sh/jabrena/plinth/413-frameworks-quarkus-db-migrations-flyway)
+- [`@513-frameworks-micronaut-db-migrations-flyway`](https://www.skills.sh/jabrena/plinth/513-frameworks-micronaut-db-migrations-flyway)
+- [`@316-frameworks-spring-mongodb-migrations-mongock`](https://www.skills.sh/jabrena/plinth/316-frameworks-spring-mongodb-migrations-mongock)
+- [`@416-frameworks-quarkus-mongodb-migrations-mongock`](https://www.skills.sh/jabrena/plinth/416-frameworks-quarkus-mongodb-migrations-mongock)
+- [`@516-frameworks-micronaut-mongodb-migrations-mongock`](https://www.skills.sh/jabrena/plinth/516-frameworks-micronaut-mongodb-migrations-mongock)
 
 The new guidance emphasizes migration safety, antipatterns, and `Parallel Change`.
 
@@ -103,7 +103,7 @@ If you want to go deeper into this topic, I recommend reading: [Why Do I Need to
 
 ## Making architecture boundaries visible with Onion Architecture
 
-This release adds [`@707-technologies-onion-architecture`](https://www.skills.sh/jabrena/cursor-rules-java/707-technologies-onion-architecture), a framework-agnostic skill for reviewing Java application boundaries.
+This release adds [`@707-technologies-onion-architecture`](https://www.skills.sh/jabrena/plinth/707-technologies-onion-architecture), a framework-agnostic skill for reviewing Java application boundaries.
 
 The skill helps engineers and agents inspect whether dependency direction and responsibility placement are consistent with Onion Architecture:
 
@@ -135,7 +135,7 @@ For framework agents, the skill is useful before making changes in `Spring Boot`
 
 Maven support continues to be one of the most used parts of the project, and `0.17.0` improves it in two directions.
 
-First, [`@111-java-maven-dependencies`](https://www.skills.sh/jabrena/cursor-rules-java/111-java-maven-dependencies) now includes `JavaMoney` guidance. This helps agents recognize when a Java project needs Money and Currency API support, including `JSR 354` and `Moneta` context.
+First, [`@111-java-maven-dependencies`](https://www.skills.sh/jabrena/plinth/111-java-maven-dependencies) now includes `JavaMoney` guidance. This helps agents recognize when a Java project needs Money and Currency API support, including `JSR 354` and `Moneta` context.
 
 Use this path when a project needs to model money, currencies, amounts, exchange-rate concerns, pricing, billing, financial calculations, or domain values where `BigDecimal` alone is not enough to describe the business meaning.
 
@@ -145,10 +145,10 @@ Use this path when a project needs to model money, currencies, amounts, exchange
 
 `0.16.0` introduced the first family of EU regulation engineering review skills. `0.17.0` extends that family with financial-market, market-integrity, product-liability, and AI management-system review support:
 
-- [`@810-regulations-eu-mifid-ii`](https://www.skills.sh/jabrena/cursor-rules-java/810-regulations-eu-mifid-ii)
-- [`@811-regulations-eu-market-abuse-regulation`](https://www.skills.sh/jabrena/cursor-rules-java/811-regulations-eu-market-abuse-regulation)
-- [`@812-regulations-eu-product-liability-directive`](https://www.skills.sh/jabrena/cursor-rules-java/812-regulations-eu-product-liability-directive)
-- [`@813-regulations-iso-42001`](https://www.skills.sh/jabrena/cursor-rules-java/813-regulations-iso-42001)
+- [`@810-regulations-eu-mifid-ii`](https://www.skills.sh/jabrena/plinth/810-regulations-eu-mifid-ii)
+- [`@811-regulations-eu-market-abuse-regulation`](https://www.skills.sh/jabrena/plinth/811-regulations-eu-market-abuse-regulation)
+- [`@812-regulations-eu-product-liability-directive`](https://www.skills.sh/jabrena/plinth/812-regulations-eu-product-liability-directive)
+- [`@813-regulations-iso-42001`](https://www.skills.sh/jabrena/plinth/813-regulations-iso-42001)
 
 These skills include questionnaires, report templates, examples, and acceptance prompts.
 

--- a/site-generator/content/blog/2026/07/release-0.17.0.md
+++ b/site-generator/content/blog/2026/07/release-0.17.0.md
@@ -16,7 +16,7 @@ The project is no longer only a collection of `Cursor rules for Java`, today the
 
 The metaphor comes from classical Roman architecture. In the old Roman empire, durable engineering depended on foundations, proportions, materials, load paths, maintenance, and repeatable methods. [Marcus Vitruvius Pollio](https://en.wikipedia.org/wiki/Vitruvius), described architecture around the enduring qualities often summarized as `firmitas`, `utilitas`, and `venustas`: [strength, usefulness, and beauty](https://en.wikipedia.org/wiki/Firmness,_commodity,_and_delight).
 
-![](/plintch/images/2026/7/firmitas-utilitas-venustas.png)
+![](/plinth/images/2026/7/firmitas-utilitas-venustas.png)
 
 That is a useful analogy for modern software engineering with AI.
 

--- a/site-generator/content/blog/2026/07/why-do-i-need-to-use-the-parallel-change-pattern.md
+++ b/site-generator/content/blog/2026/07/why-do-i-need-to-use-the-parallel-change-pattern.md
@@ -172,4 +172,4 @@ That tiny pause can prevent a clean-looking patch from becoming a production inc
 
 If you are using AI agents for migrations, refactoring, API evolution, or compatibility-sensitive Java work, share what you are learning with the project.
 
-Use [GitHub Discussions](https://github.com/jabrena/cursor-rules-java/discussions) to post where parallel change helps, where the workflow feels heavy, and which compatibility risks agents still miss.
+Use [GitHub Discussions](https://github.com/jabrena/plinth/discussions) to post where parallel change helps, where the workflow feels heavy, and which compatibility risks agents still miss.

--- a/site-generator/content/courses/profile-memory-leak/index.md
+++ b/site-generator/content/courses/profile-memory-leak/index.md
@@ -163,15 +163,15 @@ tags=java, profiling
 
 This course demonstrates practical usage of three key system prompts:
 
-### **[@161-java-profiling-detect](https://github.com/jabrena/cursor-rules-java/tree/main/.cursor/rules/161-java-profiling-detect.md)**
+### **[@161-java-profiling-detect](https://github.com/jabrena/plinth/tree/main/.cursor/rules/161-java-profiling-detect.md)**
 **Purpose:** Data collection and problem identification
 **Usage:** My Java application has performance issues - help me set up comprehensive profiling process using @161-java-profiling-detect and use the location examples/spring-boot-memory-leak-demo/profiler
 
-### **[@162-java-profiling-analyze](https://github.com/jabrena/cursor-rules-java/tree/main/.cursor/rules/162-java-profiling-analyze.md)**
+### **[@162-java-profiling-analyze](https://github.com/jabrena/plinth/tree/main/.cursor/rules/162-java-profiling-analyze.md)**
 **Purpose:** Systematic analysis and solution development
 **Usage:** Analyze the results located in examples/spring-boot-memory-leak-demo/profiler and use the cursor rule @162-java-profiling-analyze
 
-### **[@164-java-profiling-compare](https://github.com/jabrena/cursor-rules-java/tree/main/.cursor/rules/164-java-profiling-compare.md)**
+### **[@164-java-profiling-compare](https://github.com/jabrena/plinth/tree/main/.cursor/rules/164-java-profiling-compare.md)**
 **Purpose:** Before/after validation and improvement measurement
 **Usage:** Review if the problems was solved with last refactoring using the reports located in @/results with the cursor rule @164-java-profiling-compare
 

--- a/site-generator/content/courses/system-prompts-java/index.md
+++ b/site-generator/content/courses/system-prompts-java/index.md
@@ -41,8 +41,8 @@ This course is organized into **7 progressive modules** with **25+ hands-on exer
 
 1. **Clone the Repository**:
    ```bash
-   git clone https://github.com/jabrena/cursor-rules-java.git
-   cd cursor-rules-java
+   git clone https://github.com/jabrena/plinth.git
+   cd plinth
    ```
 
 2. **Setup Development Environment**:
@@ -73,4 +73,4 @@ Each module includes:
 
 ---
 
-*This course is part of the [Cursor Rules Java](https://github.com/jabrena/cursor-rules-java) project - a comprehensive collection of AI-powered system prompts for Java enterprise development.*
+*This course is part of the [Cursor Rules Java](https://github.com/jabrena/plinth) project - a comprehensive collection of AI-powered system prompts for Java enterprise development.*

--- a/site-generator/content/courses/system-prompts-java/module-7-advanced-patterns.md
+++ b/site-generator/content/courses/system-prompts-java/module-7-advanced-patterns.md
@@ -646,10 +646,10 @@ Team: Uses @behaviour-progressive-learning for knowledge sharing
 
 ### 📚 Continued Learning Resources
 
-- **[Cursor Rules Java Repository](https://github.com/jabrena/cursor-rules-java)**
-- **[Community Discussions](https://github.com/jabrena/cursor-rules-java/discussions)**
+- **[Cursor Rules Java Repository](https://github.com/jabrena/plinth)**
+- **[Community Discussions](https://github.com/jabrena/plinth/discussions)**
 - **[Latest Java Features](https://openjdk.java.net/)**
-- **[AI-Powered Development Blog](https://jabrena.github.io/cursor-rules-java/)**
+- **[jabrena/plinth](https://github.com/jabrena/plinth)**
 
 ---
 

--- a/site-generator/pom.xml
+++ b/site-generator/pom.xml
@@ -47,7 +47,7 @@
                                     <goal>copy-resources</goal>
                                 </goals>
                                 <configuration>
-                                    <outputDirectory>${project.build.directory}/docs-local/plintch/images</outputDirectory>
+                                    <outputDirectory>${project.build.directory}/docs-local/plinth/images</outputDirectory>
                                     <resources>
                                         <resource>
                                             <directory>${project.basedir}/assets/images</directory>

--- a/site-generator/templates/footer.ftl
+++ b/site-generator/templates/footer.ftl
@@ -15,7 +15,7 @@
   </#if>
   <#if (config.author_github)?has_content>
   <li>
-    <a href="https://github.com/${config.author_github}/cursor-rules-java" title="GitHub">
+    <a href="https://github.com/${config.author_github}/plinth" title="GitHub">
       <span class="fa-stack fa-lg">
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-github fa-stack-1x fa-inverse"></i>


### PR DESCRIPTION
## Summary
- Replace repository references from jabrena/cursor-rules-java to jabrena/plinth across docs, guides, site content, and project metadata
- Update the site footer repository link and regenerate docs from site-generator sources
- Keep README translations in sync with the English README updates

## Validation
- rg -n "jabrena/cursor-rules-java" . -g '!.git/**' -g '!target/**' -g '!**/target/**'
- ./mvnw clean generate-resources -pl site-generator -P site-update
- jbang markdown-validator/src/main/java/info/jab/markdownvalidator/MarkdownValidator.java .
- ./mvnw clean verify
- git diff --check