### PR TITLE
docs(cfp): update dvbe26 ai workshop pitch

### DIFF
--- a/documentation/conferences/cfp/dvbe26/technical-ai-workshop/ABSTRACT_TALK.md
+++ b/documentation/conferences/cfp/dvbe26/technical-ai-workshop/ABSTRACT_TALK.md
@@ -1,22 +1,27 @@
-Abstract
+# Abstract
 
 **Technical Workshop on AI-Native Tooling for Java Development**
 
-For nearly three decades, enterprise Java software has been built manually by software engineers. In 2023, a new generation of AI-powered tools emerged — and tools like Cursor AI, Claude Code, Codex and GitHub Copilot are now fundamentally changing how software is designed, implemented, and operated across the full SDLC.
+For nearly three decades, enterprise Java software has been built manually by software engineers. In 2023, a new generation of AI-powered tools emerged, and tools like Cursor AI, Claude Code, Codex, and GitHub Copilot are now changing how software is planned, designed, implemented, validated, and operated across the full SDLC.
 
-This workshop introduces an opinionated AI-native workflow for evolving modern Java Enterprise SDLC practices through reusable Skills, Agents, Commands, and MCP Servers — organized around three delivery phases: Plan, Build, and Operate — to answer the key engineering questions every team faces: what to build, why to build it, and how to build it well.
+This workshop introduces an opinionated AI-native workflow for evolving modern Java Enterprise SDLC practices through reusable Skills, Agents, Commands, and MCP Servers. The workflow is organized around three delivery phases: Plan, Build, and Operate. It shows how to use AI tools as practical engineering collaborators to answer the key questions every team faces: what to build, why to build it, how to build it safely, and how to prove that the work is ready.
 
 The workshop is designed for all levels and covers the following topics in a practical, hands-on way:
 
 - How the SDLC has evolved with AI-native engineering workflows organized around the Plan / Build / Operate model
-- How to use Commands to automate repeatable actions across the full lifecycle
-- How to compose reusable Skills across analysis, design, implementation, and operations phases
-- How to configure and delegate to Agents
-- How to apply a Zero Trust mindset to agent skills
+- How to use Commands to automate repeatable actions across planning, implementation, validation, and operations
+- How to compose reusable Skills across analysis, design, implementation, operations, and regulatory review
+- How to apply design methods such as two-step changes, the hamburger method, simple design rules, TDD, parallel change, and breaking-change avoidance
+- How to connect issue-driven planning with OpenSpec, GitHub Issues, and Azure DevOps work items
+- How to configure and delegate to specialized Agents
+- How to apply a Zero Trust mindset to agent skills, generated artifacts, and automated workflows
+- How to use OpenSpec/SpecKit
 - How to extend agent capabilities with MCP Servers
 - How to write a solid AGENTS.md
-- How to use OpenSpec
+- How to write a solid Skill
+- How to write a solid Agent
+- How to write a solid Command
 
-The demos will walk through real examples using Spring Boot, Quarkus, and Micronaut.
+The demos will walk through real examples using Spring Boot, Quarkus, and Micronaut, including migration-safety guidance, framework-specific implementation workflows, and engineering review patterns for regulated Java systems.
 
 The workshop will be delivered in English.

--- a/documentation/conferences/cfp/dvbe26/technical-ai-workshop/ELEVATOR-PITCH.md
+++ b/documentation/conferences/cfp/dvbe26/technical-ai-workshop/ELEVATOR-PITCH.md
@@ -1,7 +1,9 @@
-Elevator pitch
+# Elevator Pitch
 
-Elevator pitch in English
+## English
 
-The Java SDLC is being rewritten. Commands, Skills, Agents, and MCP Servers are turning what used to be manual, repetitive engineering work into structured, AI-native workflows organized around three phases — Plan, Build, and Operate — and teams that adopt them early are shipping faster with fewer mistakes.
+The Java SDLC is being rewritten. AI tools such as Cursor AI, Claude Code, Codex, and GitHub Copilot are becoming practical engineering collaborators, but teams need more than chat prompts to use them safely. Commands, Skills, Agents, and MCP Servers turn manual, repetitive engineering work into structured AI-native workflows organized around three phases: Plan, Build, and Operate.
 
-In just 180 minutes, attendees will get hands-on with an opinionated AI-native workflow built specifically for Java enterprise development — learning how to drive the full lifecycle with commands like /implement-issue, compose and validate reusable Skills with Gherkin acceptance tests, apply a Zero Trust mindset to agent-generated code, and delegate implementation to framework-specific Agents that can target Spring Boot, Quarkus, or Micronaut from the same workflow.
+In 180 minutes, attendees will get hands-on with an opinionated workflow built for Java enterprise development. They will learn how to connect issue-driven planning with OpenSpec/SpecKit, automate repeatable work with Commands, compose reusable Skills, apply design methods such as TDD, parallel change, and breaking-change avoidance, and delegate implementation to specialized Agents for Spring Boot, Quarkus, and Micronaut.
+
+The workshop focuses on using AI tools with engineering discipline: Zero Trust review of generated artifacts, validation with acceptance prompts and CI checks, migration-safety guidance, and traceable evidence that proves the work is ready. Attendees leave with a concrete model for deciding what to build, why to build it, how to build it safely, and how to validate it in real Java systems.


### PR DESCRIPTION
## Summary
- Refresh the DVBE26 technical AI workshop abstract with the 0.17.0 capabilities
- Emphasize AI tools as practical engineering collaborators across Plan, Build, and Operate
- Align the elevator pitch with OpenSpec/SpecKit, validation evidence, Zero Trust, and specialized Java agents

## Validation
- jbang markdown-validator/src/main/java/info/jab/markdownvalidator/MarkdownValidator.java .