### PR TITLE
refactor(commands): rename implement command to implement-spec

### DIFF
--- a/.cursor/commands/implement-spec.md
+++ b/.cursor/commands/implement-spec.md
@@ -1,13 +1,13 @@
-# implement-issue
+# implement-spec
 
 ## Purpose
 
-Deliver a GitHub issue through an approved implementation plan or a validated OpenSpec task list.
+Deliver an approved implementation plan or validated OpenSpec task list through controlled implementation.
 
 ## Usage
 
 ```text
-/implement-issue <approved-plan|openspec-change> [task-or-group] [constraints]
+/implement-spec <approved-plan|openspec-change> [task-or-group] [constraints]
 ```
 
 ## Accepted inputs
@@ -28,14 +28,14 @@ A bare issue is context, not an execution contract. When repository policy requi
 
 - If the command runner is not `@robot-tech-lead`, immediately delegate the whole command execution to `@robot-tech-lead` and wait for its result.
 - `@robot-tech-lead` MUST invoke the selected implementation agent for implementation, test, and verification work; naming an agent in the response is not delegation.
-- If agent invocation is unavailable in the current environment, stop and report that `/implement-issue` cannot proceed instead of implementing directly.
+- If agent invocation is unavailable in the current environment, stop and report that `/implement-spec` cannot proceed instead of implementing directly.
 - Before any implementation agent starts, pass the branch/worktree gate below and report the selected isolation strategy.
 
 ## Branch/worktree gate
 
 - Before choosing a branch or worktree strategy, inspect the workspace with `git status --short`.
 - If the workspace is dirty, stop immediately and report the changed/untracked paths. Do not create a feature branch, create a worktree, delegate implementation, or ask for approval to continue in the dirty checkout.
-- Continue only after the user cleans, commits, or stashes the workspace and reruns `/implement-issue`.
+- Continue only after the user cleans, commits, or stashes the workspace and reruns `/implement-spec`.
 - Determine whether the selected artifact should run in the current checkout, a new feature branch, or one or more linked worktrees.
 - If the work is serial and the current checkout is not already a safe, suitable feature branch, execute `/create-feature-branch` before delegating implementation.
 - If independent groups can run in parallel or need isolation, execute `/create-worktree` for each independent branch/worktree before delegating implementation.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ MCP Servers
 Implement and improve Java applications with Maven, design, coding, testing, security, documentation, Spring Boot, Quarkus, Micronaut, OpenAPI, and WireMock guidance.
 
 ```text
-/implement-issue
+/implement-spec
 @robot-tech-lead
     /create-feature-branch
     /create-worktree

--- a/README_ES.md
+++ b/README_ES.md
@@ -105,7 +105,7 @@ Plan
     @robot-business-analyst
 
 Build
-  /implement-issue
+  /implement-spec
       @robot-tech-lead
       /create-feature-branch
       /create-worktree
@@ -157,7 +157,7 @@ Implementa y mejora aplicaciones Java con orientación sobre Maven, diseño, pro
 
 | Recurso | Opciones disponibles |
 | --- | --- |
-| **Commands** | [`/create-feature-branch`](./.cursor/commands/create-feature-branch.md) · [`/create-worktree`](./.cursor/commands/create-worktree.md) · [`/implement-issue`](./.cursor/commands/implement-issue.md) |
+| **Commands** | [`/create-feature-branch`](./.cursor/commands/create-feature-branch.md) · [`/create-worktree`](./.cursor/commands/create-worktree.md) · [`/implement-spec`](./.cursor/commands/implement-spec.md) |
 | **Agents** | `@robot-tech-lead` · `@robot-no-java` · `@robot-java-coder` · `@robot-java-spring-boot-coder` · `@robot-java-quarkus-coder` · `@robot-java-micronaut-coder` |
 | **Skills** | [110-java-maven-best-practices](https://www.skills.sh/jabrena/plinth/110-java-maven-best-practices) · [111-java-maven-dependencies](https://www.skills.sh/jabrena/plinth/111-java-maven-dependencies) · [121-java-object-oriented-design](https://www.skills.sh/jabrena/plinth/121-java-object-oriented-design) · [124-java-secure-coding](https://www.skills.sh/jabrena/plinth/124-java-secure-coding) · [143-java-functional-exception-handling](https://www.skills.sh/jabrena/plinth/143-java-functional-exception-handling) |
 | **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [JavaDocs](https://www.javadocs.dev/mcp) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -105,7 +105,7 @@ Plan
     @robot-business-analyst
 
 Build
-  /implement-issue
+  /implement-spec
       @robot-tech-lead
       /create-feature-branch
       /create-worktree
@@ -157,7 +157,7 @@ MCP Servers
 
 | 资源 | 可用选项 |
 | --- | --- |
-| **Commands** | [`/create-feature-branch`](./.cursor/commands/create-feature-branch.md) · [`/create-worktree`](./.cursor/commands/create-worktree.md) · [`/implement-issue`](./.cursor/commands/implement-issue.md) |
+| **Commands** | [`/create-feature-branch`](./.cursor/commands/create-feature-branch.md) · [`/create-worktree`](./.cursor/commands/create-worktree.md) · [`/implement-spec`](./.cursor/commands/implement-spec.md) |
 | **Agents** | `@robot-tech-lead` · `@robot-no-java` · `@robot-java-coder` · `@robot-java-spring-boot-coder` · `@robot-java-quarkus-coder` · `@robot-java-micronaut-coder` |
 | **Skills** | [110-java-maven-best-practices](https://www.skills.sh/jabrena/plinth/110-java-maven-best-practices) · [111-java-maven-dependencies](https://www.skills.sh/jabrena/plinth/111-java-maven-dependencies) · [121-java-object-oriented-design](https://www.skills.sh/jabrena/plinth/121-java-object-oriented-design) · [124-java-secure-coding](https://www.skills.sh/jabrena/plinth/124-java-secure-coding) · [143-java-functional-exception-handling](https://www.skills.sh/jabrena/plinth/143-java-functional-exception-handling) |
 | **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [JavaDocs](https://www.javadocs.dev/mcp) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) |

--- a/documentation/openspec/specs/implement-spec-command/spec.md
+++ b/documentation/openspec/specs/implement-spec-command/spec.md
@@ -1,35 +1,35 @@
-# implement-issue-command Specification
+# implement-spec-command Specification
 
 ## Purpose
-TBD - created by archiving change align-implement-issue-command. Update Purpose after archive.
+Define the controlled implementation command for approved plans and validated OpenSpec task lists.
 ## Requirements
-### Requirement: Issue implementation command
+### Requirement: Spec implementation command
 
-The command bundle SHALL provide `/implement-issue` in place of `/implement`, and the command MUST use `@robot-tech-lead` to coordinate delivery through the existing Java, Spring Boot, Quarkus, or Micronaut coder agent.
+The command bundle SHALL provide `/implement-spec`, and the command MUST use `@robot-tech-lead` to coordinate delivery through the existing Java, Spring Boot, Quarkus, Micronaut, or non-Java coder agent.
 
 #### Scenario: Install the implementation command
 
 - **WHEN** a user installs the embedded command bundle
-- **THEN** the bundle contains `implement-issue.md`
+- **THEN** the bundle contains `implement-spec.md`
 - **AND** it does not contain `implement.md`
-- **AND** the inventory identifies `/implement-issue` as an implementation command
+- **AND** the inventory identifies `/implement-spec` as an implementation command
 
 ### Requirement: Executable artifact inputs
 
-`/implement-issue` MUST accept an approved implementation plan or an OpenSpec change containing a validated `tasks.md` as its execution contract.
+`/implement-spec` MUST accept an approved implementation plan or an OpenSpec change containing a validated `tasks.md` as its execution contract.
 
 #### Scenario: Implement from an approved plan
 
-- **WHEN** a user invokes `/implement-issue` with an approved implementation plan
+- **WHEN** a user invokes `/implement-spec` with an approved implementation plan
 - **THEN** `@robot-tech-lead` delegates implementation against the plan milestones and verification steps
 
 #### Scenario: Implement from an OpenSpec change
 
-- **WHEN** a user invokes `/implement-issue` with an OpenSpec change containing validated incomplete tasks
+- **WHEN** a user invokes `/implement-spec` with an OpenSpec change containing validated incomplete tasks
 - **THEN** `@robot-tech-lead` delegates implementation against those tasks
 - **AND** marks tasks complete only after acceptance criteria and focused checks pass
 
-#### Scenario: Issue has no executable artifact
+#### Scenario: Referenced issue has no executable artifact
 
 - **WHEN** a user supplies only an issue and repository policy requires structured planning
 - **THEN** the command stops implementation
@@ -37,7 +37,7 @@ The command bundle SHALL provide `/implement-issue` in place of `/implement`, an
 
 ### Requirement: Controlled delegation and verification
 
-`/implement-issue` MUST require framework-aware coder routing, dependency and file-ownership controls, evidence-based completion, and focused validation reporting within the selected execution artifact.
+`/implement-spec` MUST require framework-aware coder routing, dependency and file-ownership controls, evidence-based completion, and focused validation reporting within the selected execution artifact.
 
 #### Scenario: Delegate independent task groups
 
@@ -54,11 +54,11 @@ The command bundle SHALL provide `/implement-issue` in place of `/implement`, an
 #### Scenario: Complete implementation workflow
 
 - **WHEN** delegated tasks pass their acceptance criteria and focused checks
-- **THEN** `/implement-issue` reports changed files, test and build evidence, task status, blockers, and risks
+- **THEN** `/implement-spec` reports changed files, test and build evidence, task status, blockers, and risks
 
 #### Scenario: Select branch or worktree execution
 
-- **WHEN** `/implement-issue` reviews the approved plan or OpenSpec task list
+- **WHEN** `/implement-spec` reviews the approved plan or OpenSpec task list
 - **THEN** it decides whether the work should run on a feature branch or in one or more linked worktrees
 - **AND** it uses `/create-feature-branch` for serial current-checkout work
 - **AND** it uses `/create-worktree` when independent groups can run safely in parallel

--- a/skills-generator/src/main/resources/commands.xml
+++ b/skills-generator/src/main/resources/commands.xml
@@ -8,7 +8,7 @@
     <command file="create-diagram.md"/>
     <command file="create-spec.md"/>
     <command file="review-alignment.md"/>
-    <command file="implement-issue.md"/>
+    <command file="implement-spec.md"/>
     <command file="profile.md"/>
     <command file="benchmark.md"/>
 </command-inventory>

--- a/skills-generator/src/main/resources/skill-references/004-commands-installation.xml
+++ b/skills-generator/src/main/resources/skill-references/004-commands-installation.xml
@@ -72,7 +72,7 @@
                 <xi:include href="assets/commands/review-alignment.md" parse="text"/>
                 ```
                 ```markdown
-                <xi:include href="assets/commands/implement-issue.md" parse="text"/>
+                <xi:include href="assets/commands/implement-spec.md" parse="text"/>
                 ```
                 ```markdown
                 <xi:include href="assets/commands/profile.md" parse="text"/>

--- a/skills-generator/src/main/resources/skill-references/assets/commands/implement-spec.md
+++ b/skills-generator/src/main/resources/skill-references/assets/commands/implement-spec.md
@@ -1,13 +1,13 @@
-# implement-issue
+# implement-spec
 
 ## Purpose
 
-Deliver a GitHub issue through an approved implementation plan or a validated OpenSpec task list.
+Deliver an approved implementation plan or validated OpenSpec task list through controlled implementation.
 
 ## Usage
 
 ```text
-/implement-issue <approved-plan|openspec-change> [task-or-group] [constraints]
+/implement-spec <approved-plan|openspec-change> [task-or-group] [constraints]
 ```
 
 ## Accepted inputs
@@ -28,14 +28,14 @@ A bare issue is context, not an execution contract. When repository policy requi
 
 - If the command runner is not `@robot-tech-lead`, immediately delegate the whole command execution to `@robot-tech-lead` and wait for its result.
 - `@robot-tech-lead` MUST invoke the selected implementation agent for implementation, test, and verification work; naming an agent in the response is not delegation.
-- If agent invocation is unavailable in the current environment, stop and report that `/implement-issue` cannot proceed instead of implementing directly.
+- If agent invocation is unavailable in the current environment, stop and report that `/implement-spec` cannot proceed instead of implementing directly.
 - Before any implementation agent starts, pass the branch/worktree gate below and report the selected isolation strategy.
 
 ## Branch/worktree gate
 
 - Before choosing a branch or worktree strategy, inspect the workspace with `git status --short`.
 - If the workspace is dirty, stop immediately and report the changed/untracked paths. Do not create a feature branch, create a worktree, delegate implementation, or ask for approval to continue in the dirty checkout.
-- Continue only after the user cleans, commits, or stashes the workspace and reruns `/implement-issue`.
+- Continue only after the user cleans, commits, or stashes the workspace and reruns `/implement-spec`.
 - Determine whether the selected artifact should run in the current checkout, a new feature branch, or one or more linked worktrees.
 - If the work is serial and the current checkout is not already a safe, suitable feature branch, execute `/create-feature-branch` before delegating implementation.
 - If independent groups can run in parallel or need isolation, execute `/create-worktree` for each independent branch/worktree before delegating implementation.

--- a/skills-generator/src/main/resources/skill-references/assets/java-commands-inventory-template.md
+++ b/skills-generator/src/main/resources/skill-references/assets/java-commands-inventory-template.md
@@ -16,7 +16,7 @@ Provide a quick checklist of the embedded commands available for installation in
 | `/create-diagram` | Design | Create a focused architecture or design diagram from approved artifacts. |
 | `/create-spec` | Analysis / Design | Create or update one or more validated OpenSpec changes. |
 | `/review-alignment` | Analysis / Design | Review available artifacts for traceability, consistency, completeness, and readiness. |
-| `/implement-issue` | Implementation | Deliver an issue from an approved plan or validated OpenSpec task list through framework-aware delegation. |
+| `/implement-spec` | Implementation | Deliver an approved plan or validated OpenSpec task list through framework-aware delegation. |
 | `/profile` | Operation | Coordinate Java profiling from baseline detection through verified optimization. |
 | `/benchmark` | Operation | Select and coordinate JMeter, Gatling, or JMH performance workflows. |
 

--- a/skills-generator/src/test/java/info/jab/pml/CommandIndexesTest.java
+++ b/skills-generator/src/test/java/info/jab/pml/CommandIndexesTest.java
@@ -113,12 +113,12 @@ class CommandIndexesTest {
     }
 
     @Test
-    @DisplayName("Implement issue command must route executable artifacts through the tech lead")
-    void should_routeExecutableArtifact_when_implementIssueCommandIsInstalled() {
-        String command = loadClasspathResource("skill-references/assets/commands/implement-issue.md");
+    @DisplayName("Implement spec command must route executable artifacts through the tech lead")
+    void should_routeExecutableArtifact_when_implementSpecCommandIsInstalled() {
+        String command = loadClasspathResource("skill-references/assets/commands/implement-spec.md");
 
         assertThat(command)
-            .contains("/implement-issue <approved-plan|openspec-change>")
+            .contains("/implement-spec <approved-plan|openspec-change>")
             .contains("approved implementation plan")
             .contains("validated `tasks.md`")
             .contains("Owner: `@robot-tech-lead`")

--- a/skills-generator/src/test/resources/gherkin/commands/acceptance-tests-prompts-commands.md
+++ b/skills-generator/src/test/resources/gherkin/commands/acceptance-tests-prompts-commands.md
@@ -49,25 +49,25 @@ execute @skills-generator/src/test/resources/gherkin/commands/explore-design.fea
 and verify that acceptance-tests passes.
 ```
 
-## /implement-issue (Spring-boot)
+## /implement-spec (Spring-boot)
 
 ```bash
-execute @skills-generator/src/test/resources/gherkin/commands/implement-issue.feature
+execute @skills-generator/src/test/resources/gherkin/commands/implement-spec.feature
 and verify that acceptance-tests passes.
 ```
 
-## /implement-issue (Quarkus)
+## /implement-spec (Quarkus)
 
 ```bash
-execute @skills-generator/src/test/resources/gherkin/commands/implement-issue.feature
+execute @skills-generator/src/test/resources/gherkin/commands/implement-spec.feature
 and verify that acceptance-tests passes. 
 Implement it but using Quarkus, not Spring boot as the default requirement.
 ```
 
-## /implement-issue (Micronaut)
+## /implement-spec (Micronaut)
 
 ```bash
-execute @skills-generator/src/test/resources/gherkin/commands/implement-issue.feature
+execute @skills-generator/src/test/resources/gherkin/commands/implement-spec.feature
 and verify that acceptance-tests passes. 
 Implement it but using Micronaut, not Spring boot as the default requirement.
 ```

--- a/skills-generator/src/test/resources/gherkin/commands/implement-spec.feature
+++ b/skills-generator/src/test/resources/gherkin/commands/implement-spec.feature
@@ -1,7 +1,7 @@
-Feature: Validate implement-issue command with the God Analysis API OpenSpec example
+Feature: Validate implement-spec command with the God Analysis API OpenSpec example
 
 Background:
-  Given the command prompt file ".cursor/commands/implement-issue.md"
+  Given the command prompt file ".cursor/commands/implement-spec.md"
   And the OpenSpec project path "examples/openspec/god-analysis-api"
   And the OpenSpec change path "examples/openspec/god-analysis-api/openspec/changes/add-god-analysis-api"
   And the implementation target directory "examples/openspec/god-analysis-api/demo"
@@ -9,11 +9,11 @@ Background:
 
 @acceptance-test
 Scenario: Implement God Analysis API from a validated OpenSpec change
-  Remark: Acceptance execution must use the implement-issue command contract and must not implement outside the requested demo directory.
+  Remark: Acceptance execution must use the implement-spec command contract and must not implement outside the requested demo directory.
   Given the OpenSpec change "add-god-analysis-api" contains "proposal.md", "design.md", "tasks.md", and "specs/god-analysis-api/spec.md"
   And the OpenSpec change is validated with "openspec validate --all" from "examples/openspec/god-analysis-api"
-  And the command prompt source ".cursor/commands/implement-issue.md" is read before execution
-  When the user executes the prompt "/implement-issue examples/openspec/god-analysis-api/openspec/changes/add-god-analysis-api implement in examples/openspec/god-analysis-api/demo"
+  And the command prompt source ".cursor/commands/implement-spec.md" is read before execution
+  When the user executes the prompt "/implement-spec examples/openspec/god-analysis-api/openspec/changes/add-god-analysis-api implement in examples/openspec/god-analysis-api/demo"
   Then the command loads the selected OpenSpec "tasks.md" as the execution contract
   And the command confirms the selected OpenSpec change is current, validated, and internally consistent
   And the command identifies the implementation as a Spring Boot MVC Java service from the OpenSpec design and technology constraints

--- a/skills-generator/src/test/resources/gherkin/skills/001-commands-inventory.feature
+++ b/skills-generator/src/test/resources/gherkin/skills/001-commands-inventory.feature
@@ -27,7 +27,7 @@ Scenario: Generate embedded commands inventory with every command asset
     | create-diagram.md        | /create-diagram          |
     | create-spec.md           | /create-spec             |
     | review-alignment.md      | /review-alignment        |
-    | implement-issue.md       | /implement-issue         |
+    | implement-spec.md       | /implement-spec         |
     | profile.md               | /profile                 |
     | benchmark.md             | /benchmark               |
   And every command row in the generated file corresponds to a same-named source file in "skills-generator/src/main/resources/skill-references/assets/commands"

--- a/skills-generator/src/test/resources/gherkin/skills/004-commands-installation.feature
+++ b/skills-generator/src/test/resources/gherkin/skills/004-commands-installation.feature
@@ -29,7 +29,7 @@ Scenario: Install embedded commands into the GitHub commands destination
     | create-diagram.md        |
     | create-spec.md           |
     | review-alignment.md      |
-    | implement-issue.md       |
+    | implement-spec.md       |
     | profile.md               |
     | benchmark.md             |
   And each installed command file matches its same-named embedded asset content

--- a/skills/001-commands-inventory/references/001-commands-inventory.md
+++ b/skills/001-commands-inventory/references/001-commands-inventory.md
@@ -39,7 +39,7 @@ Provide a quick checklist of the embedded commands available for installation in
 | `/create-plan` | Analysis / Design | Create or refine an executable technical implementation plan. |
 | `/create-spec` | Analysis / Design | Create or update one or more validated OpenSpec changes. |
 | `/review-alignment` | Analysis / Design | Review available artifacts for traceability, consistency, completeness, and readiness. |
-| `/implement-issue` | Implementation | Deliver an issue from an approved plan or validated OpenSpec task list through framework-aware delegation. |
+| `/implement-spec` | Implementation | Deliver an approved plan or validated OpenSpec task list through framework-aware delegation. |
 | `/profile` | Operation | Coordinate Java profiling from baseline detection through verified optimization. |
 | `/benchmark` | Operation | Select and coordinate JMeter, Gatling, or JMH performance workflows. |
 | `/kill-port` | Operation | Free a localhost port by stopping the process listening on it. |

--- a/skills/004-commands-installation/references/004-commands-installation.md
+++ b/skills/004-commands-installation/references/004-commands-installation.md
@@ -522,16 +522,16 @@ Review available analysis and design artifacts for consistency, traceability, co
 
 ```
 ```markdown
-# implement-issue
+# implement-spec
 
 ## Purpose
 
-Deliver a GitHub issue through an approved implementation plan or a validated OpenSpec task list.
+Deliver an approved implementation plan or validated OpenSpec task list through controlled implementation.
 
 ## Usage
 
 ```text
-/implement-issue <approved-plan|openspec-change> [task-or-group] [constraints]
+/implement-spec <approved-plan|openspec-change> [task-or-group] [constraints]
 ```
 
 ## Accepted inputs
@@ -552,7 +552,7 @@ A bare issue is context, not an execution contract. When repository policy requi
 
 - If the command runner is not `@robot-tech-lead`, immediately delegate the whole command execution to `@robot-tech-lead` and wait for its result.
 - `@robot-tech-lead` MUST invoke the selected implementation agent for implementation, test, and verification work; naming an agent in the response is not delegation.
-- If agent invocation is unavailable in the current environment, stop and report that `/implement-issue` cannot proceed instead of implementing directly.
+- If agent invocation is unavailable in the current environment, stop and report that `/implement-spec` cannot proceed instead of implementing directly.
 - Before any implementation agent starts, pass the branch/worktree gate below and report the selected isolation strategy.
 
 ## Branch/worktree gate


### PR DESCRIPTION
## Summary
- Rename the implementation command from /implement-issue to /implement-spec across command assets, Cursor command files, installer and inventory references.
- Update OpenSpec command specification, command acceptance fixtures, README links, and generated command skill references.

## Validation
- xmllint --noout skills-generator/src/main/resources/commands.xml skills-generator/src/main/resources/skill-references/004-commands-installation.xml
- ./mvnw clean install -pl skills-generator -P release
- ./mvnw install -pl skills-generator
- npx skill-check@latest skills --no-security-scan --format github
- skill-scanner scan-all ./skills --recursive --use-behavioral --policy strict --fail-on-severity high
- cd documentation && openspec validate --all
- jbang markdown-validator/src/main/java/info/jab/mv/MarkdownValidator.java .