### PR TITLE
docs(release): update 0.17.0 article

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Current `System prompts/rules` are deprecated and will be removed in `v0.17.0`. 
 
 Commands compose the workflow by routing work to the right agent and skill set:
 
-### Plan
+### Analysis & Design
 
 Turn an idea into an actionable change with user stories, GitHub Issues or Jira, ADRs, diagrams, AI plan mode, and OpenSpec.
 
@@ -88,6 +88,7 @@ Turn an idea into an actionable change with user stories, GitHub Issues or Jira,
 /create-diagram
 @robot-architect
     @033-architecture-diagrams
+
 /create-spec
 @robot-tech-lead
     @042-planning-openspec
@@ -101,11 +102,11 @@ Turn an idea into an actionable change with user stories, GitHub Issues or Jira,
     @122-java-type-design
     @123-java-design-patterns
     @130-java-testing-strategies
+/review-alignment
+@robot-business-analyst
 /explore-design
 @robot-architect
     @034-architecture-design-exploration
-/review-alignment
-@robot-business-analyst
 
 MCP Servers
     Jbang-Quarkus-JDBC
@@ -129,6 +130,7 @@ Implement and improve Java applications with Maven, design, coding, testing, sec
     @robot-java-quarkus-coder
     @robot-java-micronaut-coder
     @robot-no-java
+
 MCP Servers
     Jbang-Quarkus-JDBC
     MongoDB

--- a/README_ES.md
+++ b/README_ES.md
@@ -70,7 +70,7 @@ Los `System prompts/rules` actuales están deprecados y se eliminarán en `v0.17
 Los commands componen el flujo de trabajo dirigiendo cada tarea al agente y al conjunto de skills adecuados:
 
 ```text
-Plan
+Analysis & Design
   /update-issue
     @robot-business-analyst
       @043-planning-github-issues
@@ -85,6 +85,7 @@ Plan
   /create-diagram
     @robot-architect
       @033-architecture-diagrams
+
   /create-spec
     @robot-tech-lead
       @042-planning-openspec
@@ -98,11 +99,11 @@ Plan
       @122-java-type-design
       @123-java-design-patterns
       @130-java-testing-strategies
+  /review-alignment
+    @robot-business-analyst
   /explore-design
     @robot-architect
       @034-architecture-design-exploration
-  /review-alignment
-    @robot-business-analyst
 
 Build
   /implement-spec
@@ -114,6 +115,7 @@ Build
       @robot-java-quarkus-coder
       @robot-java-micronaut-coder
       @robot-no-java
+
   MCP Servers
     Jbang-Quarkus-JDBC
     MongoDB
@@ -140,13 +142,13 @@ MCP Servers
   Grafana
 ```
 
-### Planificar
+### Análisis y diseño
 
 Convierte una idea en un cambio accionable mediante user stories, GitHub Issues o Jira, ADRs, diagramas, AI plan mode y OpenSpec.
 
 | Recurso | Opciones disponibles |
 | --- | --- |
-| **Commands** | [`/update-issue`](./.cursor/commands/update-issue.md) · `/explore-design` · `/create-adr` · `/create-diagram` · `/create-spec` · `/review-alignment` |
+| **Commands** | [`/update-issue`](./.cursor/commands/update-issue.md) · `/create-adr` · `/create-diagram` · `/create-spec` · `/review-alignment` · `/explore-design` |
 | **Agents** | `@robot-business-analyst` · `@robot-architect` · `@robot-tech-lead` |
 | **Skills** | [014-agile-user-story](https://www.skills.sh/jabrena/plinth/014-agile-user-story) · [030-architecture-adr-general](https://www.skills.sh/jabrena/plinth/030-architecture-adr-general) · [031-architecture-adr-functional-requirements](https://www.skills.sh/jabrena/plinth/031-architecture-adr-functional-requirements) · [032-architecture-adr-non-functional-requirements](https://www.skills.sh/jabrena/plinth/032-architecture-adr-non-functional-requirements) · [033-architecture-diagrams](https://www.skills.sh/jabrena/plinth/033-architecture-diagrams) · [034-architecture-design-exploration](https://www.skills.sh/jabrena/plinth/034-architecture-design-exploration) · [041-planning-plan-mode](https://www.skills.sh/jabrena/plinth/041-planning-plan-mode) · [042-planning-openspec](https://www.skills.sh/jabrena/plinth/042-planning-openspec) · [043-planning-github-issues](https://www.skills.sh/jabrena/plinth/043-planning-github-issues) · [044-planning-jira](https://www.skills.sh/jabrena/plinth/044-planning-jira) · [051-design-two-steps-methods](https://www.skills.sh/jabrena/plinth/051-design-two-steps-methods) · [052-design-hamburger-method](https://www.skills.sh/jabrena/plinth/052-design-hamburger-method) · [053-design-simple-rules](https://www.skills.sh/jabrena/plinth/053-design-simple-rules) · [056-design-avoid-breaking-changes](https://www.skills.sh/jabrena/plinth/056-design-avoid-breaking-changes) · [200-agents-md](https://www.skills.sh/jabrena/plinth/200-agents-md) |
 | **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -70,7 +70,7 @@ npx skills add jabrena/plinth --skill '*' --agent github-copilot -y
 Commands 通过把工作路由到合适的 agent 与 skill 集合来组合完整工作流：
 
 ```text
-Plan
+Analysis & Design
   /update-issue
     @robot-business-analyst
       @043-planning-github-issues
@@ -85,6 +85,7 @@ Plan
   /create-diagram
     @robot-architect
       @033-architecture-diagrams
+
   /create-spec
     @robot-tech-lead
       @042-planning-openspec
@@ -98,11 +99,11 @@ Plan
       @122-java-type-design
       @123-java-design-patterns
       @130-java-testing-strategies
+  /review-alignment
+    @robot-business-analyst
   /explore-design
     @robot-architect
       @034-architecture-design-exploration
-  /review-alignment
-    @robot-business-analyst
 
 Build
   /implement-spec
@@ -114,6 +115,7 @@ Build
       @robot-java-quarkus-coder
       @robot-java-micronaut-coder
       @robot-no-java
+
   MCP Servers
     Jbang-Quarkus-JDBC
     MongoDB
@@ -140,13 +142,13 @@ MCP Servers
   Grafana
 ```
 
-### 规划
+### 分析与设计
 
 通过 user stories、GitHub Issues 或 Jira、ADR、图表、AI plan mode 和 OpenSpec，将想法转化为可执行的变更。
 
 | 资源 | 可用选项 |
 | --- | --- |
-| **Commands** | [`/update-issue`](./.cursor/commands/update-issue.md) · `/explore-design` · `/create-adr` · `/create-diagram` · `/create-spec` · `/review-alignment` |
+| **Commands** | [`/update-issue`](./.cursor/commands/update-issue.md) · `/create-adr` · `/create-diagram` · `/create-spec` · `/review-alignment` · `/explore-design` |
 | **Agents** | `@robot-business-analyst` · `@robot-architect` · `@robot-tech-lead` |
 | **Skills** | [014-agile-user-story](https://www.skills.sh/jabrena/plinth/014-agile-user-story) · [030-architecture-adr-general](https://www.skills.sh/jabrena/plinth/030-architecture-adr-general) · [031-architecture-adr-functional-requirements](https://www.skills.sh/jabrena/plinth/031-architecture-adr-functional-requirements) · [032-architecture-adr-non-functional-requirements](https://www.skills.sh/jabrena/plinth/032-architecture-adr-non-functional-requirements) · [033-architecture-diagrams](https://www.skills.sh/jabrena/plinth/033-architecture-diagrams) · [034-architecture-design-exploration](https://www.skills.sh/jabrena/plinth/034-architecture-design-exploration) · [041-planning-plan-mode](https://www.skills.sh/jabrena/plinth/041-planning-plan-mode) · [042-planning-openspec](https://www.skills.sh/jabrena/plinth/042-planning-openspec) · [043-planning-github-issues](https://www.skills.sh/jabrena/plinth/043-planning-github-issues) · [044-planning-jira](https://www.skills.sh/jabrena/plinth/044-planning-jira) · [051-design-two-steps-methods](https://www.skills.sh/jabrena/plinth/051-design-two-steps-methods) · [052-design-hamburger-method](https://www.skills.sh/jabrena/plinth/052-design-hamburger-method) · [053-design-simple-rules](https://www.skills.sh/jabrena/plinth/053-design-simple-rules) · [056-design-avoid-breaking-changes](https://www.skills.sh/jabrena/plinth/056-design-avoid-breaking-changes) · [200-agents-md](https://www.skills.sh/jabrena/plinth/200-agents-md) |
 | **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) |

--- a/docs/blog/2026/07/release-0.17.0.html
+++ b/docs/blog/2026/07/release-0.17.0.html
@@ -121,7 +121,8 @@
 <ul>
 <li><a href="#community-first">Community first!</a></li>
 <li><a href="#what-are-the-top-10-skills-from-this-project-in-skillssh">What are the Top 10 Skills from this project in Skills.sh?</a></li>
-<li><a href="#enhancing-openspec-operations">Enhancing OpenSpec operations</a></li>
+<li><a href="#design-skills-for-safer-delivery">Design skills for safer delivery</a></li>
+<li><a href="#comparing-plinth-commands-with-openspec-and-spec-kit">Comparing Plinth commands with OpenSpec and Spec Kit</a></li>
 <li><a href="#improving-migration-safety-with-flyway-mongock-and-parallel-change">Improving migration safety with Flyway, Mongock, and Parallel Change</a></li>
 <li><a href="#making-architecture-boundaries-visible-with-hexagonal-architecture">Making architecture boundaries visible with Hexagonal Architecture</a></li>
 <li><a href="#adding-more-types-possibilities">Modeling the domain with stronger Java types</a></li>
@@ -216,9 +217,140 @@
     </tr>
   </tbody>
 </table>
+<p>The same view for framework-specific skills shows the top 5 project skills for <code>Spring Boot</code>, <code>Quarkus</code>, and <code>Micronaut</code> searches:</p>
+<p><strong>Spring Boot</strong></p>
+<table>
+  <thead>
+    <tr>
+      <th>Plinth rank</th>
+      <th>Skills.sh Search</th>
+      <th>Skills.sh Search rank</th>
+      <th>Skill</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>#1</code></td>
+      <td><a href="https://www.skills.sh/search?q=spring%20boot">Spring Boot</a></td>
+      <td><code>#42</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/301-frameworks-spring-boot-core"><code>301-frameworks-spring-boot-core</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#2</code></td>
+      <td><a href="https://www.skills.sh/search?q=spring%20boot">Spring Boot</a></td>
+      <td><code>#43</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/302-frameworks-spring-boot-rest"><code>302-frameworks-spring-boot-rest</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#3</code></td>
+      <td><a href="https://www.skills.sh/search?q=spring%20boot">Spring Boot</a></td>
+      <td><code>#44</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/321-frameworks-spring-boot-testing-unit-tests"><code>321-frameworks-spring-boot-testing-unit-tests</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#4</code></td>
+      <td><a href="https://www.skills.sh/search?q=spring%20boot">Spring Boot</a></td>
+      <td><code>#45</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/322-frameworks-spring-boot-testing-integration-tests"><code>322-frameworks-spring-boot-testing-integration-tests</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#5</code></td>
+      <td><a href="https://www.skills.sh/search?q=spring%20boot">Spring Boot</a></td>
+      <td><code>#46</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/323-frameworks-spring-boot-testing-acceptance-tests"><code>323-frameworks-spring-boot-testing-acceptance-tests</code></a></td>
+    </tr>
+  </tbody>
+</table>
+<p><strong>Quarkus</strong></p>
+<table>
+  <thead>
+    <tr>
+      <th>Plinth rank</th>
+      <th>Skills.sh Search</th>
+      <th>Skills.sh Search rank</th>
+      <th>Skill</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>#1</code></td>
+      <td><a href="https://www.skills.sh/search?q=quarkus">Quarkus</a></td>
+      <td><code>#12</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/412-frameworks-quarkus-panache"><code>412-frameworks-quarkus-panache</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#2</code></td>
+      <td><a href="https://www.skills.sh/search?q=quarkus">Quarkus</a></td>
+      <td><code>#13</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/402-frameworks-quarkus-rest"><code>402-frameworks-quarkus-rest</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#3</code></td>
+      <td><a href="https://www.skills.sh/search?q=quarkus">Quarkus</a></td>
+      <td><code>#14</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/401-frameworks-quarkus-core"><code>401-frameworks-quarkus-core</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#4</code></td>
+      <td><a href="https://www.skills.sh/search?q=quarkus">Quarkus</a></td>
+      <td><code>#15</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/411-frameworks-quarkus-jdbc"><code>411-frameworks-quarkus-jdbc</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#5</code></td>
+      <td><a href="https://www.skills.sh/search?q=quarkus">Quarkus</a></td>
+      <td><code>#16</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/421-frameworks-quarkus-testing-unit-tests"><code>421-frameworks-quarkus-testing-unit-tests</code></a></td>
+    </tr>
+  </tbody>
+</table>
+<p><strong>Micronaut</strong></p>
+<table>
+  <thead>
+    <tr>
+      <th>Plinth rank</th>
+      <th>Skills.sh Search</th>
+      <th>Skills.sh Search rank</th>
+      <th>Skill</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>#1</code></td>
+      <td><a href="https://www.skills.sh/search?q=micronaut">Micronaut</a></td>
+      <td><code>#2</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/521-frameworks-micronaut-testing-unit-tests"><code>521-frameworks-micronaut-testing-unit-tests</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#2</code></td>
+      <td><a href="https://www.skills.sh/search?q=micronaut">Micronaut</a></td>
+      <td><code>#3</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/512-frameworks-micronaut-data"><code>512-frameworks-micronaut-data</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#3</code></td>
+      <td><a href="https://www.skills.sh/search?q=micronaut">Micronaut</a></td>
+      <td><code>#4</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/522-frameworks-micronaut-testing-integration-tests"><code>522-frameworks-micronaut-testing-integration-tests</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#4</code></td>
+      <td><a href="https://www.skills.sh/search?q=micronaut">Micronaut</a></td>
+      <td><code>#5</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/502-frameworks-micronaut-rest"><code>502-frameworks-micronaut-rest</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#5</code></td>
+      <td><a href="https://www.skills.sh/search?q=micronaut">Micronaut</a></td>
+      <td><code>#6</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/523-frameworks-micronaut-testing-acceptance-tests"><code>523-frameworks-micronaut-testing-acceptance-tests</code></a></td>
+    </tr>
+  </tbody>
+</table>
 <p><strong>Note:</strong> The project is currently consolidating the <code>Skills.sh</code> data from <code>cursor-rules-java</code> to <code>plinth</code>: <a href="https://www.skills.sh/jabrena">https://www.skills.sh/jabrena</a>. There is an open ticket for this work: <a href="https://github.com/jabrena/plinth/issues/975">https://github.com/jabrena/plinth/issues/975</a></p>
-<p><a id="enhancing-openspec-operations"></a></p>
-<h2>Enhancing OpenSpec operations</h2>
+<p><a id="enhancing-openspec-operations"></a><br />
+<a id="design-skills-for-safer-delivery"></a></p>
+<h2>Design skills for safer delivery</h2>
 <p>AI coding tools are very good at producing code quickly. That is useful, but speed alone is not the same as engineering discipline. Real delivery work also needs design sequencing, compatibility analysis, test strategy, small slices, and reviewable evidence.</p>
 <p>This release adds a new family of design skills to be used in the workflow:</p>
 <ul>
@@ -234,7 +366,17 @@
 “SDD is not Aladdin’s lamp—it won’t grant every software wish”.</p>
 </blockquote>
 <p>Once the OpenSpec change is created, the next step is to refine it with design skills before implementation begins. The spec describes the intent, but the design skills help shape the change into a safer engineering path: smaller slices, clearer compatibility decisions, stronger test strategy, and explicit review points.</p>
-<p>That is why the <code>Plinth commands</code> are designed around the same delivery phases used by <code>OpenSpec</code> and <code>Spec Kit</code>. The commands are not isolated shortcuts; they map to a workflow that moves from intake to specification, design refinement, task planning, implementation, and closure:</p>
+<blockquote>
+<p>&quot;There is no favorable wind for the sailor who doesn’t know where to go”<br />
+― Seneca</p>
+</blockquote>
+<p><strong>Invest quality time in gathering and refining the requirements that belong in the spec.</strong> The design phase should move deliberately at <code>1x</code>; once the spec is clear, implementation can safely accelerate toward <code>10x</code> because the intent, constraints, and verification path are already understood.</p>
+<p><a href="https://www.amazon.es/dp/B0893242P4?ref=nb_sb_ss_w_as-reorder_k2_1_13&amp;amp=&amp;crid=3MILANAXX5K8P&amp;sprefix=kitchen%2Bclock&amp;th=1"><img src="/plinth/images/2026/7/kitchen-timer-new.png" alt="" /></a></p>
+<p>Continue running <a href="https://agilealliance.org/glossary/three-amigos/"><code>Three Amigos sessions</code></a> to combine business, technology, and quality perspectives before implementation starts.</p>
+<p>If you are interested in this new set of design skills, I recommend reading <a href="/cursor-rules-java/blog/2026/06/from-code-generation-to-software-engineering.html">From code generation to software engineering</a>.</p>
+<p><a id="comparing-plinth-commands-with-openspec-and-spec-kit"></a></p>
+<h2>Comparing Plinth commands with OpenSpec and Spec Kit</h2>
+<p><code>Plinth commands</code> make software engineers' lives easier by hiding the tool-specific details of the SDD workflow. The comparison below shows how those commands map to <code>OpenSpec</code> and <code>Spec Kit</code> phases, from intake to specification, design refinement, task planning, and implementation.</p>
 <table>
   <thead>
     <tr>
@@ -276,7 +418,7 @@
     </tr>
   </tbody>
 </table>
-<p>This comparison is useful because it shows how <code>Plinth</code> maps to initiatives like <code>OpenSpec</code> and <code>Spec Kit</code>. <code>Plinth</code> commands use agents to handle specs under the hood:</p>
+<p>Looking deeper into the command execution details, we can see the relationship between <code>Plinth commands</code> and <code>Plinth agents</code>:</p>
 <table>
   <thead>
     <tr>
@@ -292,21 +434,6 @@
       <td>Refines issue content across GitHub, Jira, or Azure DevOps inputs.</td>
     </tr>
     <tr>
-      <td><code>/review-alignment</code></td>
-      <td><code>@robot-business-analyst</code></td>
-      <td>Reviews traceability, consistency, gaps, and implementation readiness.</td>
-    </tr>
-    <tr>
-      <td><code>/create-spec</code></td>
-      <td><code>@robot-tech-lead</code></td>
-      <td>Applies planning, design, compatibility, and testing skills before tasking.</td>
-    </tr>
-    <tr>
-      <td><code>/explore-design</code></td>
-      <td><code>@robot-architect</code></td>
-      <td>Compares design options and recommends an approved technical direction.</td>
-    </tr>
-    <tr>
       <td><code>/create-adr</code></td>
       <td><code>@robot-architect</code></td>
       <td>Records architecture decisions, alternatives, and consequences.</td>
@@ -315,6 +442,21 @@
       <td><code>/create-diagram</code></td>
       <td><code>@robot-architect</code></td>
       <td>Creates architecture or design diagrams from trusted source artifacts.</td>
+    </tr>
+    <tr>
+      <td><code>/create-spec</code></td>
+      <td><code>@robot-tech-lead</code></td>
+      <td>Applies planning, design, compatibility, and testing skills before tasking.</td>
+    </tr>
+    <tr>
+      <td><code>/review-alignment</code></td>
+      <td><code>@robot-business-analyst</code></td>
+      <td>Reviews traceability, consistency, gaps, and implementation readiness.</td>
+    </tr>
+    <tr>
+      <td><code>/explore-design</code></td>
+      <td><code>@robot-architect</code></td>
+      <td>Compares design options and recommends an approved technical direction.</td>
     </tr>
     <tr>
       <td><code>/implement-spec</code></td>
@@ -333,14 +475,7 @@
     </tr>
   </tbody>
 </table>
-<blockquote>
-<p>&quot;There is no favorable wind for the sailor who doesn’t know where to go”<br />
-― Seneca</p>
-</blockquote>
-<p><strong>Invest quality time in gathering and refining the requirements that belong in the spec.</strong> The design phase should move deliberately at <code>1x</code>; once the spec is clear, implementation can safely accelerate toward <code>10x</code> because the intent, constraints, and verification path are already understood.</p>
-<p><a href="https://www.amazon.es/dp/B0893242P4?ref=nb_sb_ss_w_as-reorder_k2_1_13&amp;amp=&amp;crid=3MILANAXX5K8P&amp;sprefix=kitchen%2Bclock&amp;th=1"><img src="/plinth/images/2026/7/kitchen-timer-new.png" alt="" /></a></p>
-<p>Continuing to run <a href="https://agilealliance.org/glossary/three-amigos/"><code>Three Amigos sessions</code></a> is healthy.</p>
-<p>If you are interested in this new set of design skills, I recommend reading <a href="/cursor-rules-java/blog/2026/06/from-code-generation-to-software-engineering.html">From code generation to software engineering</a>.</p>
+<p>In future releases, the agents related to <code>Analysis &amp; Design</code> will become more independent to increase decoupling between phases. For example, <code>/create-spec</code> currently maps to <code>@robot-tech-lead</code>. Starting in release <code>0.18.0</code>, <code>@robot-tech-lead</code> will participate only in implementation phases. This change will make the project more modular and easier to customize for your organization.</p>
 <p><a id="improving-migration-safety-with-flyway-mongock-and-parallel-change"></a></p>
 <h2>Improving migration safety with Flyway, Mongock, and Parallel Change</h2>
 <p>Database migrations are one of the easiest places for an AI agent to produce a clean-looking but unsafe patch. Bad migrations can damage a database in ways that are hard to recover from:</p>
@@ -559,7 +694,7 @@ static final ArchRule should_keep_driven_adapters_independent_from_driving_adapt
 <li>Add <code>Katas</code> that help users learn <code>Plinth</code> incrementally.</li>
 <li>Improve behavior across the <code>Design phase</code>.</li>
 <li>Decouple agents for design and implementation.</li>
-<li>Make the project more modular so it is easier to integrate in organizations.</li>
+<li>Make the project more modular so it is easier to integrate into organizations.</li>
 <li>Update the <code>Spring Boot</code> support for <code>4.1.0</code>.</li>
 <li>Add a skill about <code>JVM Flags</code>.</li>
 <li>Go deeper into the EU regulation ecosystem for <code>GenAI</code>.</li>

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/cursor-rules-java/</id>
   <title>Plinth</title>
-  <updated>2026-07-10T18:53:38+0200</updated>
+  <updated>2026-07-11T12:30:27+0200</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/cursor-rules-java/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/cursor-rules-java//feed.xml' />
   <entry>

--- a/site-generator/content/blog/2026/07/release-0.17.0.md
+++ b/site-generator/content/blog/2026/07/release-0.17.0.md
@@ -30,7 +30,8 @@ Now that the repository name change has been explained, let's continue by review
 
 - [Community first!](#community-first)
 - [What are the Top 10 Skills from this project in Skills.sh?](#what-are-the-top-10-skills-from-this-project-in-skillssh)
-- [Enhancing OpenSpec operations](#enhancing-openspec-operations)
+- [Design skills for safer delivery](#design-skills-for-safer-delivery)
+- [Comparing Plinth commands with OpenSpec and Spec Kit](#comparing-plinth-commands-with-openspec-and-spec-kit)
 - [Improving migration safety with Flyway, Mongock, and Parallel Change](#improving-migration-safety-with-flyway-mongock-and-parallel-change)
 - [Making architecture boundaries visible with Hexagonal Architecture](#making-architecture-boundaries-visible-with-hexagonal-architecture)
 - [Modeling the domain with stronger Java types](#adding-more-types-possibilities)
@@ -138,11 +139,149 @@ The `Category rank` column shows the skill's position inside that Skills.sh sear
   </tbody>
 </table>
 
+The same view for framework-specific skills shows the top 5 project skills for `Spring Boot`, `Quarkus`, and `Micronaut` searches:
+
+**Spring Boot**
+
+<table>
+  <thead>
+    <tr>
+      <th>Plinth rank</th>
+      <th>Skills.sh Search</th>
+      <th>Skills.sh Search rank</th>
+      <th>Skill</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>#1</code></td>
+      <td><a href="https://www.skills.sh/search?q=spring%20boot">Spring Boot</a></td>
+      <td><code>#42</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/301-frameworks-spring-boot-core"><code>301-frameworks-spring-boot-core</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#2</code></td>
+      <td><a href="https://www.skills.sh/search?q=spring%20boot">Spring Boot</a></td>
+      <td><code>#43</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/302-frameworks-spring-boot-rest"><code>302-frameworks-spring-boot-rest</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#3</code></td>
+      <td><a href="https://www.skills.sh/search?q=spring%20boot">Spring Boot</a></td>
+      <td><code>#44</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/321-frameworks-spring-boot-testing-unit-tests"><code>321-frameworks-spring-boot-testing-unit-tests</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#4</code></td>
+      <td><a href="https://www.skills.sh/search?q=spring%20boot">Spring Boot</a></td>
+      <td><code>#45</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/322-frameworks-spring-boot-testing-integration-tests"><code>322-frameworks-spring-boot-testing-integration-tests</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#5</code></td>
+      <td><a href="https://www.skills.sh/search?q=spring%20boot">Spring Boot</a></td>
+      <td><code>#46</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/323-frameworks-spring-boot-testing-acceptance-tests"><code>323-frameworks-spring-boot-testing-acceptance-tests</code></a></td>
+    </tr>
+  </tbody>
+</table>
+
+**Quarkus**
+
+<table>
+  <thead>
+    <tr>
+      <th>Plinth rank</th>
+      <th>Skills.sh Search</th>
+      <th>Skills.sh Search rank</th>
+      <th>Skill</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>#1</code></td>
+      <td><a href="https://www.skills.sh/search?q=quarkus">Quarkus</a></td>
+      <td><code>#12</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/412-frameworks-quarkus-panache"><code>412-frameworks-quarkus-panache</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#2</code></td>
+      <td><a href="https://www.skills.sh/search?q=quarkus">Quarkus</a></td>
+      <td><code>#13</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/402-frameworks-quarkus-rest"><code>402-frameworks-quarkus-rest</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#3</code></td>
+      <td><a href="https://www.skills.sh/search?q=quarkus">Quarkus</a></td>
+      <td><code>#14</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/401-frameworks-quarkus-core"><code>401-frameworks-quarkus-core</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#4</code></td>
+      <td><a href="https://www.skills.sh/search?q=quarkus">Quarkus</a></td>
+      <td><code>#15</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/411-frameworks-quarkus-jdbc"><code>411-frameworks-quarkus-jdbc</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#5</code></td>
+      <td><a href="https://www.skills.sh/search?q=quarkus">Quarkus</a></td>
+      <td><code>#16</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/421-frameworks-quarkus-testing-unit-tests"><code>421-frameworks-quarkus-testing-unit-tests</code></a></td>
+    </tr>
+  </tbody>
+</table>
+
+**Micronaut**
+
+<table>
+  <thead>
+    <tr>
+      <th>Plinth rank</th>
+      <th>Skills.sh Search</th>
+      <th>Skills.sh Search rank</th>
+      <th>Skill</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>#1</code></td>
+      <td><a href="https://www.skills.sh/search?q=micronaut">Micronaut</a></td>
+      <td><code>#2</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/521-frameworks-micronaut-testing-unit-tests"><code>521-frameworks-micronaut-testing-unit-tests</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#2</code></td>
+      <td><a href="https://www.skills.sh/search?q=micronaut">Micronaut</a></td>
+      <td><code>#3</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/512-frameworks-micronaut-data"><code>512-frameworks-micronaut-data</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#3</code></td>
+      <td><a href="https://www.skills.sh/search?q=micronaut">Micronaut</a></td>
+      <td><code>#4</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/522-frameworks-micronaut-testing-integration-tests"><code>522-frameworks-micronaut-testing-integration-tests</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#4</code></td>
+      <td><a href="https://www.skills.sh/search?q=micronaut">Micronaut</a></td>
+      <td><code>#5</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/502-frameworks-micronaut-rest"><code>502-frameworks-micronaut-rest</code></a></td>
+    </tr>
+    <tr>
+      <td><code>#5</code></td>
+      <td><a href="https://www.skills.sh/search?q=micronaut">Micronaut</a></td>
+      <td><code>#6</code></td>
+      <td><a href="https://www.skills.sh/jabrena/plinth/523-frameworks-micronaut-testing-acceptance-tests"><code>523-frameworks-micronaut-testing-acceptance-tests</code></a></td>
+    </tr>
+  </tbody>
+</table>
+
 **Note:** The project is currently consolidating the `Skills.sh` data from `cursor-rules-java` to `plinth`: https://www.skills.sh/jabrena. There is an open ticket for this work: https://github.com/jabrena/plinth/issues/975
 
 <a id="enhancing-openspec-operations"></a>
+<a id="design-skills-for-safer-delivery"></a>
 
-## Enhancing OpenSpec operations
+## Design skills for safer delivery
 
 AI coding tools are very good at producing code quickly. That is useful, but speed alone is not the same as engineering discipline. Real delivery work also needs design sequencing, compatibility analysis, test strategy, small slices, and reviewable evidence.
 
@@ -160,7 +299,22 @@ This release adds a new family of design skills to be used in the workflow:
 
 Once the OpenSpec change is created, the next step is to refine it with design skills before implementation begins. The spec describes the intent, but the design skills help shape the change into a safer engineering path: smaller slices, clearer compatibility decisions, stronger test strategy, and explicit review points.
 
-That is why the `Plinth commands` are designed around the same delivery phases used by `OpenSpec` and `Spec Kit`. The commands are not isolated shortcuts; they map to a workflow that moves from intake to specification, design refinement, task planning, implementation, and closure:
+> "There is no favorable wind for the sailor who doesn’t know where to go”
+> ― Seneca
+
+**Invest quality time in gathering and refining the requirements that belong in the spec.** The design phase should move deliberately at `1x`; once the spec is clear, implementation can safely accelerate toward `10x` because the intent, constraints, and verification path are already understood.
+
+[![](/plinth/images/2026/7/kitchen-timer-new.png)](https://www.amazon.es/dp/B0893242P4?ref=nb_sb_ss_w_as-reorder_k2_1_13&amp=&crid=3MILANAXX5K8P&sprefix=kitchen%2Bclock&th=1)
+
+Continue running [`Three Amigos sessions`](https://agilealliance.org/glossary/three-amigos/) to combine business, technology, and quality perspectives before implementation starts.
+
+If you are interested in this new set of design skills, I recommend reading [From code generation to software engineering](/cursor-rules-java/blog/2026/06/from-code-generation-to-software-engineering.html).
+
+<a id="comparing-plinth-commands-with-openspec-and-spec-kit"></a>
+
+## Comparing Plinth commands with OpenSpec and Spec Kit
+
+`Plinth commands` make software engineers' lives easier by hiding the tool-specific details of the SDD workflow. The comparison below shows how those commands map to `OpenSpec` and `Spec Kit` phases, from intake to specification, design refinement, task planning, and implementation.
 
 <table>
   <thead>
@@ -204,7 +358,7 @@ That is why the `Plinth commands` are designed around the same delivery phases u
   </tbody>
 </table>
 
-This comparison is useful because it shows how `Plinth` maps to initiatives like `OpenSpec` and `Spec Kit`. `Plinth` commands use agents to handle specs under the hood:
+Looking deeper into the command execution details, we can see the relationship between `Plinth commands` and `Plinth agents`:
 
 <table>
   <thead>
@@ -221,21 +375,6 @@ This comparison is useful because it shows how `Plinth` maps to initiatives like
       <td>Refines issue content across GitHub, Jira, or Azure DevOps inputs.</td>
     </tr>
     <tr>
-      <td><code>/review-alignment</code></td>
-      <td><code>@robot-business-analyst</code></td>
-      <td>Reviews traceability, consistency, gaps, and implementation readiness.</td>
-    </tr>
-    <tr>
-      <td><code>/create-spec</code></td>
-      <td><code>@robot-tech-lead</code></td>
-      <td>Applies planning, design, compatibility, and testing skills before tasking.</td>
-    </tr>
-    <tr>
-      <td><code>/explore-design</code></td>
-      <td><code>@robot-architect</code></td>
-      <td>Compares design options and recommends an approved technical direction.</td>
-    </tr>
-    <tr>
       <td><code>/create-adr</code></td>
       <td><code>@robot-architect</code></td>
       <td>Records architecture decisions, alternatives, and consequences.</td>
@@ -244,6 +383,21 @@ This comparison is useful because it shows how `Plinth` maps to initiatives like
       <td><code>/create-diagram</code></td>
       <td><code>@robot-architect</code></td>
       <td>Creates architecture or design diagrams from trusted source artifacts.</td>
+    </tr>
+    <tr>
+      <td><code>/create-spec</code></td>
+      <td><code>@robot-tech-lead</code></td>
+      <td>Applies planning, design, compatibility, and testing skills before tasking.</td>
+    </tr>
+    <tr>
+      <td><code>/review-alignment</code></td>
+      <td><code>@robot-business-analyst</code></td>
+      <td>Reviews traceability, consistency, gaps, and implementation readiness.</td>
+    </tr>
+    <tr>
+      <td><code>/explore-design</code></td>
+      <td><code>@robot-architect</code></td>
+      <td>Compares design options and recommends an approved technical direction.</td>
     </tr>
     <tr>
       <td><code>/implement-spec</code></td>
@@ -263,16 +417,7 @@ This comparison is useful because it shows how `Plinth` maps to initiatives like
   </tbody>
 </table>
 
-> "There is no favorable wind for the sailor who doesn’t know where to go”
-> ― Seneca
-
-**Invest quality time in gathering and refining the requirements that belong in the spec.** The design phase should move deliberately at `1x`; once the spec is clear, implementation can safely accelerate toward `10x` because the intent, constraints, and verification path are already understood.
-
-[![](/plinth/images/2026/7/kitchen-timer-new.png)](https://www.amazon.es/dp/B0893242P4?ref=nb_sb_ss_w_as-reorder_k2_1_13&amp=&crid=3MILANAXX5K8P&sprefix=kitchen%2Bclock&th=1)
-
-Continuing to run [`Three Amigos sessions`](https://agilealliance.org/glossary/three-amigos/) is healthy.
-
-If you are interested in this new set of design skills, I recommend reading [From code generation to software engineering](/cursor-rules-java/blog/2026/06/from-code-generation-to-software-engineering.html).
+In future releases, the agents related to `Analysis & Design` will become more independent to increase decoupling between phases. For example, `/create-spec` currently maps to `@robot-tech-lead`. Starting in release `0.18.0`, `@robot-tech-lead` will participate only in implementation phases. This change will make the project more modular and easier to customize for your organization.
 
 <a id="improving-migration-safety-with-flyway-mongock-and-parallel-change"></a>
 
@@ -560,7 +705,7 @@ For the next release, we plan to work on a few topics:
 - Add `Katas` that help users learn `Plinth` incrementally.
 - Improve behavior across the `Design phase`.
 - Decouple agents for design and implementation.
-- Make the project more modular so it is easier to integrate in organizations.
+- Make the project more modular so it is easier to integrate into organizations.
 - Update the `Spring Boot` support for `4.1.0`.
 - Add a skill about `JVM Flags`.
 - Go deeper into the EU regulation ecosystem for `GenAI`.


### PR DESCRIPTION
## Summary
- split the release article OpenSpec section into design skills and command comparison sections
- add framework-specific Skills.sh ranking tables for Spring Boot, Quarkus, and Micronaut
- sync README command terminology and ordering across English, Spanish, and Chinese
- regenerate the published site output

## Validation
- ./mvnw clean generate-resources -pl site-generator -P site-update
- jbang markdown-validator/src/main/java/info/jab/mv/MarkdownValidator.java .
- git diff --check
- git diff --cached --check