### PR TITLE
docs(guides): move skill portal links to references

### DIFF
--- a/documentation/guides/PROJECT-REFERENCES.md
+++ b/documentation/guides/PROJECT-REFERENCES.md
@@ -54,6 +54,10 @@ This page collects talks, articles, reference links, skill portals, and related 
 ### Skill Portals
 
 - [skills.sh cursor-rules-java](https://skills.sh/jabrena/plinth)
+- [Agent Skills Hub plinth](https://agentskillshub.top/skill/jabrena/plinth/)
+- [MCP App Store Mongock skills search](https://mcpapp-store.com/skills?q=Mongock+)
+- [JVM Skills](https://jvmskills.com/)
+- [Tarai Java refactoring with modern features skill](https://tarai.dev/en/skill/141-java-refactoring-with-modern-features/)
 - [Vercel Labs skills issues](https://github.com/vercel-labs/skills/issues)
 - [Tessl skill registry](https://tessl.io/registry/skills/github/jabrena/plinth)
 - [ClaudSkills author page](https://claudskills.com/author/jabrena/)

--- a/documentation/guides/PROJECT-REFERENCES_ES.md
+++ b/documentation/guides/PROJECT-REFERENCES_ES.md
@@ -54,6 +54,10 @@ Esta página reúne charlas, artículos, enlaces de referencia, portales de skil
 ### Portales de Skills
 
 - [skills.sh cursor-rules-java](https://skills.sh/jabrena/plinth)
+- [Plinth en Agent Skills Hub](https://agentskillshub.top/skill/jabrena/plinth/)
+- [Búsqueda de skills de Mongock en MCP App Store](https://mcpapp-store.com/skills?q=Mongock+)
+- [JVM Skills](https://jvmskills.com/)
+- [Skill de Tarai sobre refactorización Java con características modernas](https://tarai.dev/en/skill/141-java-refactoring-with-modern-features/)
 - [Issues de Vercel Labs skills](https://github.com/vercel-labs/skills/issues)
 - [Registro de skills de Tessl](https://tessl.io/registry/skills/github/jabrena/plinth)
 - [Página de autor en ClaudSkills](https://claudskills.com/author/jabrena/)

--- a/documentation/guides/PROJECT-REFERENCES_ZH.md
+++ b/documentation/guides/PROJECT-REFERENCES_ZH.md
@@ -54,6 +54,10 @@
 ### Skill 门户
 
 - [skills.sh cursor-rules-java](https://skills.sh/jabrena/plinth)
+- [Agent Skills Hub plinth 页面](https://agentskillshub.top/skill/jabrena/plinth/)
+- [MCP App Store Mongock skills 搜索](https://mcpapp-store.com/skills?q=Mongock+)
+- [JVM Skills](https://jvmskills.com/)
+- [Tarai Java 现代特性重构 skill](https://tarai.dev/en/skill/141-java-refactoring-with-modern-features/)
 - [Vercel Labs skills issues](https://github.com/vercel-labs/skills/issues)
 - [Tessl skill registry](https://tessl.io/registry/skills/github/jabrena/plinth)
 - [ClaudSkills 作者页](https://claudskills.com/author/jabrena/)

--- a/documentation/guides/THIRD-PARTIES.md
+++ b/documentation/guides/THIRD-PARTIES.md
@@ -4,17 +4,12 @@ This repository develop System Prompts, Skills & Agents but in the ecosystem exi
 
 ## Skills
 
-- https://agentskillshub.top/skill/jabrena/plinth/
-- https://mcpapp-store.com/skills?q=Mongock+
-- https://jvmskills.com/
-- https://skills.sh/teachingai/agent-skills/maven-search
 - https://github.com/making/claude-skills
 - https://github.com/levnikolaevich/claude-code-skills/tree/master/skills-catalog
 - https://github.com/TheBushidoCollective/han/tree/main/plugins/patterns/bdd/skills/bdd-scenarios
 - https://skills.sh/thebushidocollective/han/playwright-bdd-gherkin-syntax
 - https://github.com/eferro/skill-factory/blob/main/output_skills/practices/code-simplifier/SKILL.md
 - https://github.com/eferro/skill-factory/blob/main/output_skills/practices/story-splitting/SKILL.md
-- https://github.com/eferro/skill-factory/blob/main/output_skills/practices/hamburger-method/SKILL.md
 - https://github.com/Envy-7z/mobile-agent-skillpack/blob/main/skills/thinkies/SKILL.md
 - https://skills.sh/giuseppe-trisciuoglio/developer-kit/spring-boot-resilience4j
 - https://skills.sh/giuseppe-trisciuoglio/developer-kit/spring-boot-actuator
@@ -27,7 +22,6 @@ This repository develop System Prompts, Skills & Agents but in the ecosystem exi
 - https://github.com/forrestchang/andrej-karpathy-skills/blob/main/skills/karpathy-guidelines/SKILL.md
 - https://github.com/KentBeck/TCRSkill/tree/main
 - https://github.com/mattpocock/skills/tree/main/skills/productivity/grill-me
-- https://tarai.dev/en/skill/141-java-refactoring-with-modern-features/
 
 ## Agents
 
@@ -37,6 +31,5 @@ This repository develop System Prompts, Skills & Agents but in the ecosystem exi
 ## MCP Servers
 
 - https://github.com/quarkiverse/quarkus-mcp-servers
-- arvindand/maven-tools-mcp:latest
 - https://www.javadocs.dev/mcp
 - https://github.com/rtk-ai/rtk


### PR DESCRIPTION
## Summary
- Move selected skill portal links from THIRD-PARTIES into PROJECT-REFERENCES
- Keep Spanish and Chinese reference guides in sync

## Validation
- jbang markdown-validator/src/main/java/info/jab/mv/MarkdownValidator.java .