### PR TITLE
feat(skills-generator): add feature toggles skill

### DIFF
--- a/skills-generator/src/main/resources/skill-indexes/057-skill.xml
+++ b/skills-generator/src/main/resources/skill-indexes/057-skill.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="https://jabrena.github.io/pml/schemas/0.7.0/pml.xsd"
+      id="057-design-feature-toggles"
+      interactive="true">
+  <metadata>
+    <author>Sangwon Park</author>
+    <version>0.17.0</version>
+    <license>Apache-2.0</license>
+    <description>Use when designing, implementing, reviewing, testing, or cleaning up feature toggles, feature flags, kill switches, runtime configuration gates, canary controls, staged rollouts, experiments, or temporary compatibility switches in Java enterprise systems. This should trigger for requests such as Design a feature toggle strategy; Review this feature flag; Add a kill switch safely; Test toggle on and off paths; Clean up an expired feature toggle; Plan controlled rollout and rollback behavior.</description>
+  </metadata>
+
+  <title>Feature Toggles Design</title>
+  <goal><![CDATA[
+Guide Java Enterprise developers through safe feature toggle design and lifecycle management. **This is an interactive SKILL**.
+
+**What is covered in this Skill?**
+
+- Deciding when a feature toggle is appropriate versus a branch, configuration change, deployment change, or parallel change
+- Classifying release toggles, operational kill switches, experiment toggles, permission toggles, and migration toggles
+- Designing typed toggle ownership, defaults, evaluation scope, fallback behavior, observability, and rollback controls
+- Implementing toggles in Java services without scattering flag checks or creating hidden long-term complexity
+- Reviewing toggles for release, rollback, security, privacy, concurrency, and maintenance risk
+- Testing both enabled and disabled paths, configuration failure behavior, rollout rules, and cleanup readiness
+]]></goal>
+
+  <constraints>
+    <constraints-description>Use feature toggles as explicit, owned runtime control points rather than hidden conditional complexity.</constraints-description>
+    <constraint-list>
+      <constraint>**MUST** read `references/057-design-feature-toggles.md` before applying feature toggle guidance</constraint>
+      <constraint>**MUST** classify the toggle type, owner, expected lifetime, default state, rollout audience, and removal trigger before recommending implementation</constraint>
+      <constraint>**MUST** design safe defaults, fallback behavior, observability, and rollback behavior for runtime evaluation failures</constraint>
+      <constraint>**MUST** keep toggle evaluation centralized, typed, and testable instead of scattering raw configuration lookups through business logic</constraint>
+      <constraint>**MUST** include cleanup expectations for temporary toggles before implementation is considered complete</constraint>
+      <constraint>**MUST NOT** use feature toggles to hide incomplete design decisions, bypass security controls, or leave permanent branches without explicit ownership</constraint>
+    </constraint-list>
+  </constraints>
+
+  <triggers>
+    <trigger-list>
+      <trigger>Design a feature toggle strategy</trigger>
+      <trigger>Review this feature flag implementation</trigger>
+      <trigger>Add a kill switch safely</trigger>
+      <trigger>Plan a canary or staged rollout in a Java service</trigger>
+      <trigger>Test toggle on and off paths</trigger>
+      <trigger>Clean up an expired feature toggle</trigger>
+      <trigger>Decide whether this runtime behavior change needs a toggle</trigger>
+    </trigger-list>
+  </triggers>
+
+  <steps>
+    <step number="1">
+      <step-title>Classify the Toggle Need</step-title>
+      <step-content>Read `references/057-design-feature-toggles.md`, then identify the runtime behavior change, rollout risk, rollback expectation, affected users, operational owner, and whether a feature toggle is the smallest safe control mechanism.</step-content>
+    </step>
+    <step number="2">
+      <step-title>Design the Toggle Contract</step-title>
+      <step-content>Define the toggle type, stable name, typed decision API, default state, evaluation context, fallback behavior, audit needs, metrics, logs, and cleanup trigger. Prefer one decision point per behavior over repeated raw flag checks.</step-content>
+    </step>
+    <step number="3">
+      <step-title>Plan Implementation Boundaries</step-title>
+      <step-content>Place toggle evaluation near an application service, adapter, strategy selector, or request boundary. Keep domain code explicit, avoid secret or personal data in rules, and preserve consistent decisions across a request, transaction, message, or batch item.</step-content>
+    </step>
+    <step number="4">
+      <step-title>Review Release and Rollback Safety</step-title>
+      <step-content>Check whether disabled behavior preserves the current production contract, enabled behavior has rollout guardrails, operational teams can disable the behavior quickly, and cleanup will not break old deployments, data, or integrations.</step-content>
+    </step>
+    <step number="5">
+      <step-title>Test and Observe Both Paths</step-title>
+      <step-content>Test disabled, enabled, fallback, configuration failure, rollout targeting, and cleanup scenarios. Add metrics, logs, alerts, or dashboards that show toggle state, decision volume, error rate, latency impact, and kill-switch activation.</step-content>
+    </step>
+    <step number="6">
+      <step-title>Report the Toggle Plan</step-title>
+      <step-content>Report the decision, toggle contract, implementation boundary, test matrix, observability plan, rollout and rollback steps, cleanup owner, removal trigger, skipped checks, and remaining risks.</step-content>
+    </step>
+  </steps>
+</prompt>

--- a/skills-generator/src/main/resources/skill-references/057-design-feature-toggles.xml
+++ b/skills-generator/src/main/resources/skill-references/057-design-feature-toggles.xml
@@ -1,0 +1,313 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt>
+    <metadata>
+        <author>Sangwon Park</author>
+        <version>0.17.0</version>
+        <license>Apache-2.0</license>
+        <title>Feature Toggles Design</title>
+        <description>Examples for designing, implementing, testing, operating, and cleaning up feature toggles in Java enterprise systems without creating avoidable release, rollback, security, or maintenance risk.</description>
+    </metadata>
+
+    <role>You are a senior Java Enterprise engineer who provides concrete examples for safe runtime behavior controls.</role>
+
+    <tone>Be practical and example-driven. Prefer small Java, configuration, test, and cleanup examples that make toggle ownership, defaults, rollback, and removal visible.</tone>
+
+    <goal>
+        Provide concrete examples that support the Feature Toggles skill workflow. Use these examples to show how Java teams can keep feature toggles typed, owned, observable, reversible, and removable.
+    </goal>
+
+    <constraints>
+        <constraints-description>Use these examples as implementation references, not as a second workflow.</constraints-description>
+        <constraint-list>
+            <constraint>**EXAMPLES FIRST**: Prefer concrete Java, configuration, testing, operations, and cleanup examples over another sequence of process steps</constraint>
+            <constraint>**TYPED BOUNDARY**: Keep provider-specific flag keys behind a typed decision API</constraint>
+            <constraint>**SAFE DEFAULTS**: Show the default and failure behavior explicitly in code or configuration</constraint>
+            <constraint>**ROLLBACK PATH**: Keep the disabled path testable until cleanup removes the temporary toggle</constraint>
+            <constraint>**NO SENSITIVE RULES**: Do not put secrets, personal data, internal cohort logic, or authorization bypasses in toggle names, rules, logs, or metrics</constraint>
+        </constraint-list>
+    </constraints>
+
+    <examples>
+        <toc auto-generate="true" />
+
+        <example number="1" id="toggle-contract-record">
+            <example-header>
+                <example-title>Toggle contract record</example-title>
+                <example-subtitle>Document the owner, default, rollback, and cleanup trigger before coding</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                A release toggle should have enough metadata for reviewers and operators to understand the runtime contract. The contract can live in an issue, OpenSpec task, ADR, release checklist, or code-adjacent documentation.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="markdown"><![CDATA[Toggle: checkoutRiskScoringEnabled
+Type: release toggle
+Owner: Checkout Platform
+Default: false
+Disabled behavior: legacy manual review remains the production path
+Enabled behavior: risk scoring service evaluates eligible checkout orders
+Rollback: set false in the feature service; propagation expected under 60 seconds
+Observability: checkout.risk_scoring.decision and checkout.risk_scoring.errors
+Cleanup trigger: 100 percent rollout stable for 14 days with no rollback incidents
+Cleanup task: remove legacyReviewService branch, old config key, and disabled-path tests]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="markdown"><![CDATA[Toggle: newCheckout
+Owner: TBD
+Default: probably off
+Rollback: turn it off
+Cleanup: later]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="2" id="spring-boot-configuration-backed-decision">
+            <example-header>
+                <example-title>Spring Boot configuration-backed decision</example-title>
+                <example-subtitle>Bind configuration once and expose a typed decision method</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Configuration binding keeps the default visible and provider-independent. Business code depends on a domain decision instead of reading raw property names.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="java"><![CDATA[@ConfigurationProperties(prefix = "checkout.features")
+public record CheckoutFeatureProperties(boolean riskScoringEnabled) {
+
+    public CheckoutFeatureProperties {
+        // Default remains false when configuration is absent.
+    }
+}
+
+@Component
+public final class CheckoutFeatureDecisions {
+
+    private final CheckoutFeatureProperties properties;
+
+    public CheckoutFeatureDecisions(CheckoutFeatureProperties properties) {
+        this.properties = properties;
+    }
+
+    public boolean useRiskScoring(CheckoutContext context) {
+        return properties.riskScoringEnabled() && context.isEligibleForRiskScoring();
+    }
+}]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="java"><![CDATA[if (environment.getProperty("new.impl", Boolean.class, false)) {
+    riskScoringService.score(order);
+}]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="3" id="strategy-selector-boundary">
+            <example-header>
+                <example-title>Strategy selector boundary</example-title>
+                <example-subtitle>Choose one implementation path near the application boundary</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                When the behavior is substantial, selecting a strategy keeps branch logic out of domain objects and makes both paths easier to test.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="java"><![CDATA[public final class CheckoutService {
+
+    private final CheckoutFeatureDecisions featureDecisions;
+    private final CheckoutRiskScoring riskScoring;
+    private final LegacyCheckoutReview legacyReview;
+
+    public Receipt submit(CheckoutCommand command) {
+        CheckoutContext context = CheckoutContext.from(command);
+        if (featureDecisions.useRiskScoring(context)) {
+            return riskScoring.submit(command);
+        }
+        return legacyReview.submit(command);
+    }
+}]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="java"><![CDATA[public final class Order {
+
+    public void submit(Environment environment) {
+        if (environment.getProperty("checkout.features.risk-scoring-enabled", Boolean.class)) {
+            // new path
+        }
+        // repeated checks in domain code
+    }
+}]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="4" id="request-consistency">
+            <example-header>
+                <example-title>Request consistency</example-title>
+                <example-subtitle>Evaluate once when mid-flow changes would be unsafe</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                For transactions, messages, batch items, billing, authorization-adjacent behavior, or external calls, carry the decision value through the flow so one request cannot mix old and new behavior.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="java"><![CDATA[public Receipt submit(CheckoutCommand command) {
+    CheckoutContext context = CheckoutContext.from(command);
+    boolean useRiskScoring = featureDecisions.useRiskScoring(context);
+
+    CheckoutDecision decision = new CheckoutDecision(command, useRiskScoring);
+    return checkoutProcessor.process(decision);
+}]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="java"><![CDATA[public Receipt submit(CheckoutCommand command) {
+    fraudGateway.reserve(command);
+    if (featureClient.isEnabled("checkoutRiskScoringEnabled")) {
+        riskScoringService.score(command);
+    }
+    if (featureClient.isEnabled("checkoutRiskScoringEnabled")) {
+        receiptPublisher.publishNewReceipt(command);
+    }
+}]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="5" id="unit-tests-for-both-paths">
+            <example-header>
+                <example-title>Unit tests for both paths</example-title>
+                <example-subtitle>Keep disabled, enabled, and fallback behavior covered</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                The disabled path is the rollback path. Keep it tested until the cleanup change removes the old behavior.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="java"><![CDATA[@Test
+void usesLegacyReviewWhenRiskScoringIsDisabled() {
+    CheckoutFeatureDecisions decisions = decisions(false);
+
+    checkoutService.submit(command, decisions);
+
+    verify(legacyReview).submit(command);
+    verifyNoInteractions(riskScoring);
+}
+
+@Test
+void usesRiskScoringWhenRiskScoringIsEnabledAndContextIsEligible() {
+    CheckoutFeatureDecisions decisions = decisions(true);
+
+    checkoutService.submit(command, decisions);
+
+    verify(riskScoring).submit(command);
+    verifyNoInteractions(legacyReview);
+}
+
+@Test
+void fallsBackToDisabledBehaviorWhenProviderValueIsMissing() {
+    CheckoutFeatureDecisions decisions = decisionsWithMissingValue();
+
+    assertThat(decisions.useRiskScoring(context)).isFalse();
+}]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="java"><![CDATA[@Test
+void newCheckoutWorks() {
+    enable("new.impl");
+    checkoutService.submit(command);
+    verify(riskScoring).submit(command);
+}]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="6" id="operational-kill-switch">
+            <example-header>
+                <example-title>Operational kill switch</example-title>
+                <example-subtitle>Make emergency disablement observable and reversible</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                A kill switch can be long-lived, but it still needs an owner, safe default, metric, and runbook entry. It should disable risky optional work without breaking the core contract.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="java"><![CDATA[public void publishRecommendationEvents(List<RecommendationEvent> events) {
+    if (featureDecisions.disableRecommendationPublishing()) {
+        meterRegistry.counter("recommendations.publisher.skipped", "reason", "kill_switch").increment(events.size());
+        logger.warn("Recommendation publishing skipped by operational kill switch");
+        return;
+    }
+
+    recommendationPublisher.publish(events);
+}]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="java"><![CDATA[if (featureClient.isEnabled("disableEverything")) {
+    return;
+}]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+
+        <example number="7" id="cleanup-after-rollout">
+            <example-header>
+                <example-title>Cleanup after rollout</example-title>
+                <example-subtitle>Remove temporary toggle artifacts after stability evidence is complete</example-subtitle>
+            </example-header>
+            <example-description>
+                <![CDATA[
+                Cleanup is not only deleting one if statement. Remove the old branch, decision method, provider key, stale tests, dashboards, alerts, and documentation that existed only for the temporary rollout.
+                ]]>
+            </example-description>
+            <code-examples>
+                <good-example>
+                    <code-block language="markdown"><![CDATA[Cleanup checklist for checkoutRiskScoringEnabled:
+- Confirm 100 percent rollout was stable for 14 days
+- Remove legacyReviewService branch from CheckoutService
+- Delete CheckoutFeatureDecisions#useRiskScoring when no other rollout uses it
+- Remove checkout.features.risk-scoring-enabled from configuration templates
+- Delete disabled-path tests and keep released behavior tests
+- Remove rollout dashboard panels and provider entry
+- Close cleanup task with release note reference]]></code-block>
+                </good-example>
+                <bad-example last-item="true">
+                    <code-block language="markdown"><![CDATA[Cleanup:
+- Leave the flag in case we need it later
+- Keep both branches because they still compile
+- Remove only the dashboard]]></code-block>
+                </bad-example>
+            </code-examples>
+        </example>
+    </examples>
+
+    <output-format>
+        <output-format-list>
+            <output-format-item>Use examples that name the toggle, owner, default, disabled behavior, enabled behavior, rollback mechanism, observability, and cleanup trigger</output-format-item>
+            <output-format-item>Prefer Java snippets with typed decision APIs over raw provider string lookups</output-format-item>
+            <output-format-item>Include tests for disabled, enabled, fallback, rollback, and cleanup behavior when the example touches code</output-format-item>
+            <output-format-item>Show operational examples with metrics, logs, alerts, or runbook signals when the toggle controls production risk</output-format-item>
+            <output-format-item>Call out anti-examples that hide ownership, use vague names, scatter checks, skip rollback validation, or defer cleanup indefinitely</output-format-item>
+        </output-format-list>
+    </output-format>
+
+    <safeguards>
+        <safeguards-list>
+            <safeguards-item>Do not duplicate the Feature Toggles skill workflow inside this reference; keep this file focused on examples</safeguards-item>
+            <safeguards-item>Do not recommend raw feature-provider lookups throughout controllers, domain objects, repositories, jobs, or clients</safeguards-item>
+            <safeguards-item>Do not show toggle examples that bypass authentication, authorization, audit, compliance, rate limiting, or data retention controls</safeguards-item>
+            <safeguards-item>Do not present rollback as safe unless the disabled path and provider failure behavior are tested</safeguards-item>
+            <safeguards-item>Do not leave temporary release toggles without owner, expiry condition, cleanup task, and validation evidence</safeguards-item>
+        </safeguards-list>
+    </safeguards>
+</prompt>

--- a/skills-generator/src/main/resources/skills.xml
+++ b/skills-generator/src/main/resources/skills.xml
@@ -126,6 +126,11 @@
             <reference>056-design-avoid-breaking-changes</reference>
         </reference-list>
     </skill>
+    <skill id="057" skillId="057-design-feature-toggles">
+        <reference-list>
+            <reference>057-design-feature-toggles</reference>
+        </reference-list>
+    </skill>
     <skill id="110">
         <reference-list>
             <reference>110-java-maven-best-practices</reference>

--- a/skills-generator/src/test/java/info/jab/pml/SkillReferenceGeneratorTest.java
+++ b/skills-generator/src/test/java/info/jab/pml/SkillReferenceGeneratorTest.java
@@ -91,7 +91,10 @@ class SkillReferenceGeneratorTest {
             saveGeneratedContentToTarget(generatedContent, baseFileName + ".md");
 
             // Then - Validate the generated content structure
-            String[] lines = generatedContent.split("\\n");
+            String[] lines = generatedContent
+                .replace("\r\n", "\n")
+                .replace('\r', '\n')
+                .split("\\n");
 
             validateHasMainTitle(lines, baseFileName);
             validateRequiredSections(lines, baseFileName);

--- a/skills-generator/src/test/resources/gherkin/skills/057-design-feature-toggles.feature
+++ b/skills-generator/src/test/resources/gherkin/skills/057-design-feature-toggles.feature
@@ -1,0 +1,43 @@
+Feature: Validate changes from usage of Feature Toggles design skill
+
+Background:
+  Given the skill "057-design-feature-toggles"
+
+@acceptance-test
+Scenario: Generate a Feature Toggles skill for Java enterprise development
+  Given the local generated skill path ".agents/skills/057-design-feature-toggles"
+  When the skill ".agents/skills/057-design-feature-toggles" guides a Java enterprise feature toggle design
+  Then the skill reads "references/057-design-feature-toggles.md"
+  And the generated skill explains when to use feature toggles in Java enterprise systems
+  And the guidance distinguishes feature toggles from branches, ordinary configuration, deployment changes, and Parallel Change
+  And the guidance covers release toggles, operational kill switches, experiment toggles, permission toggles, and migration toggles
+  And the guidance defines owner, default state, rollout audience, expected lifetime, and removal trigger before implementation
+  And the guidance covers design, implementation, review, cleanup, and testing concerns
+  And the guidance recommends centralized typed toggle decisions instead of scattered raw configuration lookups
+  And the guidance includes safe defaults, fallback behavior, observability, rollback, security, and privacy considerations
+  And the guidance requires tests for disabled, enabled, rollback, failure, targeting, observability, and cleanup scenarios
+
+@acceptance-test
+Scenario: Review a Java feature flag implementation for lifecycle risk
+  Given the user request is "Review this feature flag for a staged checkout rollout in a Spring Boot service"
+  And the local generated skill path ".agents/skills/057-design-feature-toggles"
+  When the skill ".agents/skills/057-design-feature-toggles" reviews the feature flag implementation
+  Then the skill reads "references/057-design-feature-toggles.md"
+  And the review classifies the toggle type and lifecycle
+  And the review checks whether the disabled path preserves current production behavior
+  And the review checks whether the enabled path has rollout guardrails and validation signals
+  And the review checks whether disabling the toggle is a tested rollback path
+  And the review checks whether the toggle can bypass authentication, authorization, audit, compliance, rate limiting, or data retention controls
+  And the review identifies cleanup ownership, removal trigger, stale branch risk, and tests that should be removed or simplified after cleanup
+
+@integration-test
+Scenario: Validate Feature Toggles skill generation and prompt coverage
+  Given the Feature Toggles skill XML sources have been added
+  And the matching Gherkin feature file "skills-generator/src/test/resources/gherkin/skills/057-design-feature-toggles.feature" has been added
+  When the skills-generator module is validated and local skills are regenerated
+  Then the edited XML is well formed
+  And the module verification passes
+  And the generated skill output can be inspected under ".agents/skills/057-design-feature-toggles"
+  And the generated skill output contains "SKILL.md"
+  And the generated skill output contains "references/057-design-feature-toggles.md"
+  And the acceptance prompt inventory includes "execute @skills-generator/src/test/resources/gherkin/skills/057-design-feature-toggles.feature"

--- a/skills-generator/src/test/resources/gherkin/skills/acceptance-tests-prompts-skills.md
+++ b/skills-generator/src/test/resources/gherkin/skills/acceptance-tests-prompts-skills.md
@@ -176,6 +176,13 @@ execute @skills-generator/src/test/resources/gherkin/skills/056-design-avoid-bre
 and verify that acceptance-tests passes.
 ```
 
+## 057-design-feature-toggles
+
+```bash
+execute @skills-generator/src/test/resources/gherkin/skills/057-design-feature-toggles.feature
+and verify that acceptance-tests passes.
+```
+
 ## 110-java-maven-best-practices
 
 ```bash


### PR DESCRIPTION
This PR replaces #980

## Summary

Closes #965 

- Add `057-design-feature-toggles` skill XML sources for Java enterprise feature toggle guidance
- Register the new skill in `skills.xml`
- Add Gherkin coverage and acceptance prompt inventory entry
- Normalize generated-content line splitting in `SkillReferenceGeneratorTest` for CRLF-safe validation on Windows

## Validation

- Ran `.\mvnw.cmd clean verify -pl skills-generator`
- Verified generated local output:
  - `.agents/skills/057-design-feature-toggles/SKILL.md`
  - `.agents/skills/057-design-feature-toggles/references/057-design-feature-toggles.md`

## Notes

The public `skills/` release output was intentionally left unchanged. This PR updates the XML sources and verifies local generated output under `.agents/skills/`; release output should be refreshed only when preparing a release.