### PR TITLE
docs(blog): update release skills stats

### DIFF
--- a/docs/blog/2026/07/release-0.17.0.html
+++ b/docs/blog/2026/07/release-0.17.0.html
@@ -143,7 +143,7 @@
 <p>If you use the project, you can participate as an <a href="https://github.com/jabrena/plinth/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22">individual contributor</a> or by sharing your experience in <a href="https://github.com/jabrena/plinth/discussions"><code>GitHub Discussions</code></a>.</p>
 <p><a id="what-are-the-top-10-skills-from-this-project-in-skillssh"></a></p>
 <h2>What are the Top 10 Skills from this project in Skills.sh?</h2>
-<p>The <a href="https://www.skills.sh/jabrena/plinth">Skills.sh registry</a> reports <code>118 skills</code> and <code>14.5K</code> installs in total. Compared with the <a href="https://jabrena.github.io/plinth/blog/2026/06/release-0.16.0.html#what-are-the-top-10-skills-from-this-project-in-skillssh"><code>0.16.0</code> release article</a>, these are the latest top 10 skills used by Skills.sh users:</p>
+<p>The <a href="https://www.skills.sh/jabrena/plinth">Skills.sh registry</a> reports <code>119 skills</code> and <code>14.5K</code> installs in total. Compared with the <a href="https://jabrena.github.io/plinth/blog/2026/06/release-0.16.0.html#what-are-the-top-10-skills-from-this-project-in-skillssh"><code>0.16.0</code> release article</a>, these are the latest top 10 skills used by Skills.sh users:</p>
 <p>The <code>Category rank</code> column shows the skill's position inside that Skills.sh search category when results are sorted by install count.</p>
 <table>
   <thead>
@@ -348,8 +348,8 @@
   </tbody>
 </table>
 <p><strong>Note:</strong> The project is currently consolidating the <code>Skills.sh</code> data from <code>cursor-rules-java</code> to <code>plinth</code>: <a href="https://www.skills.sh/jabrena">https://www.skills.sh/jabrena</a>. There is an open ticket for this work: <a href="https://github.com/jabrena/plinth/issues/975">https://github.com/jabrena/plinth/issues/975</a></p>
-<p><a id="enhancing-openspec-operations"></a><br />
-<a id="design-skills-for-safer-delivery"></a></p>
+<p>If you use the project but you have doubts about any Skill, you could share your feedback in <a href="https://github.com/jabrena/plinth/discussions"><code>GitHub Discussions</code></a>.</p>
+<p><a id="design-skills-for-safer-delivery"></a></p>
 <h2>Design skills for safer delivery</h2>
 <p>AI coding tools are very good at producing code quickly. That is useful, but speed alone is not the same as engineering discipline. Real delivery work also needs design sequencing, compatibility analysis, test strategy, small slices, and reviewable evidence.</p>
 <p>This release adds a new family of design skills to be used in the workflow:</p>

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/cursor-rules-java/</id>
   <title>Plinth</title>
-  <updated>2026-07-11T19:46:32+0200</updated>
+  <updated>2026-07-11T20:22:00+0200</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/cursor-rules-java/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/cursor-rules-java//feed.xml' />
   <entry>

--- a/site-generator/content/blog/2026/07/release-0.17.0.md
+++ b/site-generator/content/blog/2026/07/release-0.17.0.md
@@ -63,7 +63,7 @@ If you use the project, you can participate as an [individual contributor](https
 
 ## What are the Top 10 Skills from this project in Skills.sh?
 
-The [Skills.sh registry](https://www.skills.sh/jabrena/plinth) reports `118 skills` and `14.5K` installs in total. Compared with the [`0.16.0` release article](https://jabrena.github.io/plinth/blog/2026/06/release-0.16.0.html#what-are-the-top-10-skills-from-this-project-in-skillssh), these are the latest top 10 skills used by Skills.sh users:
+The [Skills.sh registry](https://www.skills.sh/jabrena/plinth) reports `119 skills` and `14.5K` installs in total. Compared with the [`0.16.0` release article](https://jabrena.github.io/plinth/blog/2026/06/release-0.16.0.html#what-are-the-top-10-skills-from-this-project-in-skillssh), these are the latest top 10 skills used by Skills.sh users:
 
 The `Category rank` column shows the skill's position inside that Skills.sh search category when results are sorted by install count.
 
@@ -279,7 +279,8 @@ The same view for framework-specific skills shows the top 5 project skills for `
 
 **Note:** The project is currently consolidating the `Skills.sh` data from `cursor-rules-java` to `plinth`: https://www.skills.sh/jabrena. There is an open ticket for this work: https://github.com/jabrena/plinth/issues/975
 
-<a id="enhancing-openspec-operations"></a>
+If you use the project but you have doubts about any Skill, you could share your feedback in [`GitHub Discussions`](https://github.com/jabrena/plinth/discussions).
+
 <a id="design-skills-for-safer-delivery"></a>
 
 ## Design skills for safer delivery


### PR DESCRIPTION
## Summary

Updates the Plinth 0.17.0 release article with the latest Skills.sh count and adds a direct feedback prompt for readers who have doubts about any skill.

## Changes

- Updates the Skills.sh registry count from `118 skills` to `119 skills`.
- Adds a GitHub Discussions sentence after the Skills.sh consolidation note.
- Regenerates the static site output under `docs/`.

## Validation

- `./mvnw clean generate-resources -pl site-generator -P site-update`
