### PR TITLE
docs(blog): clarify skills search rank

### DIFF
--- a/docs/blog/2026/07/release-0.17.0.html
+++ b/docs/blog/2026/07/release-0.17.0.html
@@ -144,7 +144,7 @@
 <p><a id="what-are-the-top-10-skills-from-this-project-in-skillssh"></a></p>
 <h2>What are the Top 10 Skills from this project in Skills.sh?</h2>
 <p>The <a href="https://www.skills.sh/jabrena/plinth">Skills.sh registry</a> reports <code>119 skills</code> and <code>14.5K</code> installs in total. Compared with the <a href="https://jabrena.github.io/plinth/blog/2026/06/release-0.16.0.html#what-are-the-top-10-skills-from-this-project-in-skillssh"><code>0.16.0</code> release article</a>, these are the latest top 10 skills used by Skills.sh users:</p>
-<p>The <code>Category rank</code> column shows the skill's position inside that Skills.sh search category when results are sorted by install count.</p>
+<p>The <code>Search rank</code> column shows the skill's position inside that <code>Skills.sh</code> search category when results are sorted by install count.</p>
 <table>
   <thead>
     <tr>

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/cursor-rules-java/</id>
   <title>Plinth</title>
-  <updated>2026-07-11T20:22:00+0200</updated>
+  <updated>2026-07-12T11:44:30+0200</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/cursor-rules-java/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/cursor-rules-java//feed.xml' />
   <entry>

--- a/site-generator/content/blog/2026/07/release-0.17.0.md
+++ b/site-generator/content/blog/2026/07/release-0.17.0.md
@@ -65,7 +65,7 @@ If you use the project, you can participate as an [individual contributor](https
 
 The [Skills.sh registry](https://www.skills.sh/jabrena/plinth) reports `119 skills` and `14.5K` installs in total. Compared with the [`0.16.0` release article](https://jabrena.github.io/plinth/blog/2026/06/release-0.16.0.html#what-are-the-top-10-skills-from-this-project-in-skillssh), these are the latest top 10 skills used by Skills.sh users:
 
-The `Category rank` column shows the skill's position inside that Skills.sh search category when results are sorted by install count.
+The `Search rank` column shows the skill's position inside that `Skills.sh` search category when results are sorted by install count.
 
 <table>
   <thead>


### PR DESCRIPTION
## Summary

Clarifies the Skills.sh ranking explanation in the Plinth 0.17.0 release article.

## Changes

- Renames the explanatory text from `Category rank` to `Search rank`.
- Formats `Skills.sh` consistently in the sentence.
- Regenerates the static site output under `docs/`.

## Validation

- `./mvnw clean generate-resources -pl site-generator -P site-update`
