### PR TITLE
docs(site): remove JCConf 2026 workshop section from 0.17.0 post

### DIFF
--- a/docs/blog/2026/07/release-0.17.0.html
+++ b/docs/blog/2026/07/release-0.17.0.html
@@ -130,7 +130,6 @@
 <li><a href="#improving-security-gates-in-the-pipeline-with-virustotal">Improving security gates in the pipeline with VirusTotal</a></li>
 <li><a href="#recommended-books-talks-for-this-summer">Recommended Books and Talks for this summer</a></li>
 <li><a href="#next-steps">Next steps</a></li>
-<li><a href="#doubts">Do you still have questions about the project?</a></li>
 </ul>
 <p>If you have questions about the project, how to customize it for your team, how to use the skills in daily work, or how to solve tooling issues, use <a href="https://github.com/jabrena/plinth/discussions"><code>GitHub Discussions</code></a>.</p>
 <p><strong>Help this project grow:</strong> <a href="https://github.com/sponsors/jabrena">If this project helps your team, become a sponsor.</a></p>
@@ -694,10 +693,6 @@ static final ArchRule should_keep_driven_adapters_independent_from_driving_adapt
 <li>Add a skill about <code>JVM Flags</code>.</li>
 <li>Go deeper into the EU regulation ecosystem for <code>GenAI</code>.</li>
 </ul>
-<p><a id="doubts"></a></p>
-<h2>Do you still have questions about the project?</h2>
-<p>If you feel stuck using this project or have questions, you can attend the following workshop at <a href="https://jcconf.tw/2026/"><code>JCConf 2026</code></a>:</p>
-<p><a href="https://jcconf.tw/2026/"><img src="/plinth/images/2026/7/jcconf-2026.png" alt="" /></a></p>
 
 </article>
 </div>

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/cursor-rules-java/</id>
   <title>Plinth</title>
-  <updated>2026-07-12T13:25:58+0200</updated>
+  <updated>2026-07-13T09:09:04+0200</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/cursor-rules-java/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/cursor-rules-java//feed.xml' />
   <entry>

--- a/site-generator/content/blog/2026/07/release-0.17.0.md
+++ b/site-generator/content/blog/2026/07/release-0.17.0.md
@@ -39,7 +39,6 @@ Now that the repository name change has been explained, let's continue by review
 - [Improving security gates in the pipeline with VirusTotal](#improving-security-gates-in-the-pipeline-with-virustotal)
 - [Recommended Books and Talks for this summer](#recommended-books-talks-for-this-summer)
 - [Next steps](#next-steps)
-- [Do you still have questions about the project?](#doubts)
 
 If you have questions about the project, how to customize it for your team, how to use the skills in daily work, or how to solve tooling issues, use [`GitHub Discussions`](https://github.com/jabrena/plinth/discussions).
 
@@ -701,11 +700,3 @@ For the next release, we plan to work on a few topics:
 - Update the `Spring Boot` support for `4.1.0`.
 - Add a skill about `JVM Flags`.
 - Go deeper into the EU regulation ecosystem for `GenAI`.
-
-<a id="doubts"></a>
-
-## Do you still have questions about the project?
-
-If you feel stuck using this project or have questions, you can attend the following workshop at [`JCConf 2026`](https://jcconf.tw/2026/):
-
-[![](/plinth/images/2026/7/jcconf-2026.png)](https://jcconf.tw/2026/)


### PR DESCRIPTION
Drop the cancelled workshop call-to-action from the release article and regenerate the published site output.

# Rationale for this change

Explain the reasons to change the repository

# What changes are included in this PR?

Explain what changes do this PR

# Are these changes tested?

Explain if the PR was tested and explain details

# Are there any user-facing changes?

Explain if the PR will impact the final user
