### PR TITLE
refactor(agents): remove Cursor-specific readonly from agents.xsd

### DIFF
--- a/plinth-agents-generator/src/main/java/info/jab/pml/AgentMarkdownRenderer.java
+++ b/plinth-agents-generator/src/main/java/info/jab/pml/AgentMarkdownRenderer.java
@@ -16,8 +16,7 @@ import org.w3c.dom.Document;
  * as skill Markdown generation in {@code plinth-skills-generator}.
  *
  * <p>Frontmatter fields are emitted only from XML source values ({@code @id},
- * {@code metadata/description}, optional {@code metadata/model}, optional
- * {@code metadata/readonly}).
+ * {@code metadata/description}, optional {@code metadata/model}).
  */
 public final class AgentMarkdownRenderer {
 

--- a/plinth-agents-generator/src/main/resources/agent-to-markdown.xsl
+++ b/plinth-agents-generator/src/main/resources/agent-to-markdown.xsl
@@ -42,10 +42,6 @@ metadata:</xsl:text>
 model: </xsl:text>
       <xsl:value-of select="normalize-space(metadata/model)"/>
     </xsl:if>
-    <xsl:if test="translate(normalize-space(metadata/readonly), 'TRUE', 'true') = 'true'">
-      <xsl:text>
-readonly: true</xsl:text>
-    </xsl:if>
     <xsl:text>
 ---
 

--- a/plinth-agents-generator/src/main/resources/agents.xsd
+++ b/plinth-agents-generator/src/main/resources/agents.xsd
@@ -28,7 +28,6 @@
                 <xs:element ref="title"/>
                 <xs:element ref="description"/>
                 <xs:element ref="model" minOccurs="0"/>
-                <xs:element ref="readonly" minOccurs="0"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>
@@ -46,7 +45,6 @@
     <xs:element name="title" type="xs:string"/>
     <xs:element name="description" type="xs:string"/>
     <xs:element name="model" type="xs:string"/>
-    <xs:element name="readonly" type="xs:boolean"/>
 
     <!-- System role -->
     <xs:element name="role" type="xs:string"/>

--- a/plinth-agents-generator/src/main/resources/agents/robot-architect.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-architect.xml
@@ -12,7 +12,6 @@
         <title>robot-architect</title>
         <description>Java architecture specialist. Explores design alternatives, records significant decisions as ADRs, creates architecture diagrams, and prepares implementation plans or OpenSpec changes without implementing application code.</description>
         <model>inherit</model>
-        <readonly>false</readonly>
     </metadata>
 
     <role>You are an experienced Java Software Architect. You help project users move from an understood problem to an approved design direction, explicit architecture decisions, useful architecture views, and implementation-ready planning or specification artifacts.</role>

--- a/plinth-agents-generator/src/main/resources/agents/robot-business-analyst.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-business-analyst.xml
@@ -12,7 +12,6 @@
         <title>robot-business-analyst</title>
         <description>Business analyst. Creates structured GitHub or Jira issues and performs read-only alignment and readiness reviews across requirements, plans, OpenSpec changes, ADRs, and diagrams.</description>
         <model>inherit</model>
-        <readonly>false</readonly>
     </metadata>
 
     <role>You are an experienced business analyst focused on issue quality, requirements consistency, traceability, and delivery readiness, not technical implementation.</role>

--- a/plinth-agents-generator/src/main/resources/agents/robot-java-coder.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-java-coder.xml
@@ -12,7 +12,6 @@
         <title>robot-java-coder</title>
         <description>Implementation specialist for Java projects. Use when writing code, refactoring, configuring Maven, or applying Java best practices.</description>
         <model>inherit</model>
-        <readonly>false</readonly>
     </metadata>
 
     <role>You are an Implementation Specialist for Java projects. You focus on writing and improving code.</role>

--- a/plinth-agents-generator/src/main/resources/agents/robot-java-micronaut-coder.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-java-micronaut-coder.xml
@@ -12,7 +12,6 @@
         <title>robot-java-micronaut-coder</title>
         <description>Implementation specialist for Micronaut projects. Use when writing controllers, REST APIs, validation, security, Micronaut Data repositories, Kafka, MongoDB, CDI-style beans, or any Micronaut-specific code.</description>
         <model>inherit</model>
-        <readonly>false</readonly>
     </metadata>
 
     <role>You are an Implementation Specialist for Micronaut projects. You focus on writing and improving Micronaut application code.</role>

--- a/plinth-agents-generator/src/main/resources/agents/robot-java-performance.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-java-performance.xml
@@ -12,7 +12,6 @@
         <title>robot-java-performance</title>
         <description>Java performance coordinator. Profiles applications, designs benchmarks, preserves evidence, and delegates approved optimizations to Java/framework coder agents without implementing code directly.</description>
         <model>inherit</model>
-        <readonly>false</readonly>
     </metadata>
 
     <role>You are a Java Performance Engineer focused on profiling, benchmarking, reproducibility, and evidence-backed performance decisions.</role>

--- a/plinth-agents-generator/src/main/resources/agents/robot-java-quarkus-coder.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-java-quarkus-coder.xml
@@ -12,7 +12,6 @@
         <title>robot-java-quarkus-coder</title>
         <description>Implementation specialist for Quarkus projects. Use when writing resources, REST APIs, validation, security, Panache/JDBC data access, Kafka, MongoDB, CDI beans, or any Quarkus-specific code.</description>
         <model>inherit</model>
-        <readonly>false</readonly>
     </metadata>
 
     <role>You are an Implementation Specialist for Quarkus projects. You focus on writing and improving Quarkus application code.</role>

--- a/plinth-agents-generator/src/main/resources/agents/robot-java-spring-boot-coder.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-java-spring-boot-coder.xml
@@ -12,7 +12,6 @@
         <title>robot-java-spring-boot-coder</title>
         <description>Implementation specialist for Spring Boot projects. Use when writing controllers, REST APIs, validation, security, Kafka, MongoDB, Spring Data, Spring Test slices, or any Spring Boot-specific code.</description>
         <model>inherit</model>
-        <readonly>false</readonly>
     </metadata>
 
     <role>You are an Implementation Specialist for Spring Boot projects. You focus on writing and improving Spring Boot application code.</role>

--- a/plinth-agents-generator/src/main/resources/agents/robot-no-java.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-no-java.xml
@@ -12,7 +12,6 @@
         <title>robot-no-java</title>
         <description>Default implementation specialist for non-Java projects. Use when an issue, plan, or OpenSpec task list does not use Java, Maven, or a JVM-based framework.</description>
         <model>inherit</model>
-        <readonly>false</readonly>
     </metadata>
 
     <role>You are an Implementation Specialist for non-Java project work. You handle tasks that do not use Java, Maven, Spring Boot, Quarkus, or Micronaut.</role>

--- a/plinth-agents-generator/src/main/resources/agents/robot-tech-lead.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-tech-lead.xml
@@ -12,7 +12,6 @@
         <title>robot-tech-lead</title>
         <description>Tech lead for Java Enterprise Development. Coordinates implementation delivery from an approved plan or OpenSpec task list through the appropriate Java, Spring Boot, Quarkus, Micronaut, or non-Java implementation agent without implementing code itself.</description>
         <model>inherit</model>
-        <readonly>false</readonly>
     </metadata>
 
     <role>You are a Tech Lead for Java Enterprise Development. Your primary responsibility is implementation-phase delivery: coordinate approved implementation plans or OpenSpec task lists by delegating implementation to specialized agents and synthesizing their outputs.</role>


### PR DESCRIPTION
## Summary
- Remove non-generic `metadata/readonly` from `agents.xsd` so agent definitions stay vendor-neutral
- Drop `<readonly>` from all agent XML sources and stop emitting `readonly` from `agent-to-markdown.xsl`
- Related cleanup from the multi-vendor gap analysis on #1046

## Test plan
- [x] `xmllint --schema agents.xsd` validates all agent XML files
- [x] `./mvnw clean verify -pl plinth-agents-generator`
- [x] Confirm generated agent Markdown frontmatter no longer includes `readonly`


Made with [Cursor](https://cursor.com)