### PR TITLE
docs(conferences): add JCConf 2026 talk proposal

### DIFF
--- a/documentation/conferences/cfp/jcconf-2026/ABSTRACT_TALK.md
+++ b/documentation/conferences/cfp/jcconf-2026/ABSTRACT_TALK.md
@@ -1,0 +1,22 @@
+# Abstract
+
+**AI Tooling for Java Development**
+
+AI coding assistants can generate Java code in seconds, but code generation is the easy part. The harder questions remain: What should we build? Why should we build it? Which functional and technical requirements must the implementation satisfy? How do we review the result, and what evidence tells us it is ready?
+
+This talk examines how AI tools are changing the software development life cycle for Java enterprise teams.
+
+The talk emphasizes the importance of expressing both functional requirements—the behavior and outcomes the software must deliver—and technical requirements such as architecture, security, performance, compatibility, observability, and regulatory constraints. Without this context, faster code generation can simply produce the wrong system more quickly.
+
+Attendees will also learn the main concepts behind modern AI development tools:
+
+- **Commands** express repeatable engineering actions.
+- **Skills** provide reusable domain and technical knowledge.
+- **Agents** perform bounded tasks with a defined role and context.
+- **MCP Servers** connect AI tools to trusted systems and project information.
+
+Examples using tools such as Cursor AI, Claude Code, Codex, and GitHub Copilot will make these concepts concrete without prescribing a single workflow or product. The central theme is engineering discipline: treat generated code and agent instructions with a Zero Trust mindset, keep software engineers in the loop, and require traceable evidence before accepting a change.
+
+Attendees will leave with a clearer understanding of how the Java SDLC is evolving, why well-defined requirements become even more important when working with AI, and how these tools can support engineers without replacing architectural judgment, review, or accountability.
+
+The talk will be delivered in English.

--- a/documentation/conferences/cfp/jcconf-2026/ELEVATOR-PITCH.md
+++ b/documentation/conferences/cfp/jcconf-2026/ELEVATOR-PITCH.md
@@ -1,0 +1,9 @@
+# Elevator Pitch
+
+## English
+
+AI assistants can generate Java code in seconds, but faster code generation does not guarantee the right software. Teams must still decide what to build, why it matters, which constraints apply, and what evidence proves that a change is ready. This talk explores how AI tools are changing the Java software development life cycle and the new challenges they create across requirements, design, implementation, testing, review, and operations.
+
+Attendees will discover why clear functional and technical requirements become even more important when AI participates in development. Through examples with Cursor AI, Claude Code, Codex, and GitHub Copilot, the talk introduces Commands, Skills, Agents, and MCP Servers as ways to give AI tools reusable knowledge, bounded responsibilities, and trusted project context.
+
+The focus is engineering discipline, not autonomous code generation. Attendees will leave with a practical understanding of how AI can support Java engineers while Zero Trust review, human oversight, and traceable evidence preserve architectural judgment and accountability.


### PR DESCRIPTION
## Summary

- add the JCConf 2026 abstract for **AI Tooling for Java Development**
- add a concise elevator pitch aligned with the abstract
- frame the talk around AI-driven SDLC changes, functional and technical requirements, and responsible use of Commands, Skills, Agents, and MCP Servers

## Why

Prepare a focused 45-minute conference proposal that explains the general challenges and opportunities of AI tooling in Java development without prescribing a single workflow.

## Impact

Documentation only. The proposal emphasizes engineering discipline, Zero Trust review, human oversight, and traceable evidence.

## Validation

- Markdown validator: 400 documents validated, zero errors