### PR TITLE
Add missing agents install instructions in 5min onboard

### DIFF
--- a/benchmarks/scenario1/results/20260721-141828-copilot-claude-sonnet-4.5.json
+++ b/benchmarks/scenario1/results/20260721-141828-copilot-claude-sonnet-4.5.json
@@ -1,0 +1,41 @@
+{
+  "efficiency": {
+    "wall_clock_s": 1560.0,
+    "active_agent_s": 1200.0,
+    "tokens_in": 22000,
+    "tokens_out": 11000,
+    "tokens_total": 33000,
+    "cost_usd": 0.85
+  },
+  "outcome_quality": {
+    "acceptance_pass": true,
+    "acceptance_coverage": 1.0,
+    "rework_turns": 3,
+    "artifact_completeness": 1.0
+  },
+  "protocol_labels": {
+    "scenario": "scenario1",
+    "case_id": "case-1-readme-only",
+    "tool": "copilot",
+    "model": "claude-sonnet-4.5",
+    "plinth_config": "bare-agent",
+    "commit": "unknown",
+    "retry_count": 0,
+    "human_intervention_min": 0
+  },
+  "plinth_usage": {
+    "skills_count": 0,
+    "commands_count": 0,
+    "agents_count": 0,
+    "skills": [],
+    "commands": [],
+    "agents": []
+  },
+  "solution_snapshot": {
+    "demo_root": "benchmarks/scenario1/demo/",
+    "tree_format": "unix-tree",
+    "tree_encoding": "base64",
+    "tree_b64": "LgrilJzilIDilIAgLmdpdGtlZXAK4pSc4pSA4pSAIHBvbS54bWwK4pSU4pSA4pSAIHNyYwogICAg4pSc4pSA4pSAIG1haW4KICAgIOKUgsKgwqAg4pSc4pSA4pSAIGphdmEKICAgIOKUgsKgwqAg4pSCwqDCoCDilJTilIDilIAgaW5mbwogICAg4pSCwqDCoCDilILCoMKgICAgICDilJTilIDilIAgamFiCiAgICDilILCoMKgIOKUgsKgwqAgICAgICAgICDilJTilIDilIAgYmVuY2htYXJrCiAgICDilILCoMKgIOKUgsKgwqAgICAgICAgICAgICAg4pSU4pSA4pSAIGdvZGFuYWx5c2lzCiAgICDilILCoMKgIOKUgsKgwqAgICAgICAgICAgICAgICAgIOKUnOKUgOKUgCBHb2RBbmFseXNpc0FwcGxpY2F0aW9uLmphdmEKICAgIOKUgsKgwqAg4pSCwqDCoCAgICAgICAgICAgICAgICAg4pSc4pSA4pSAIEdvZEFuYWx5c2lzU2VydmljZS5qYXZhCiAgICDilILCoMKgIOKUgsKgwqAgICAgICAgICAgICAgICAgIOKUlOKUgOKUgCBHb2RTdGF0c0NvbnRyb2xsZXIuamF2YQogICAg4pSCwqDCoCDilJTilIDilIAgcmVzb3VyY2VzCiAgICDilILCoMKgICAgICDilJTilIDilIAgYXBwbGljYXRpb24ucHJvcGVydGllcwogICAg4pSU4pSA4pSAIHRlc3QKICAgICAgICDilJTilIDilIAgamF2YQogICAgICAgICAgICDilJTilIDilIAgaW5mbwogICAgICAgICAgICAgICAg4pSU4pSA4pSAIGphYgogICAgICAgICAgICAgICAgICAgIOKUlOKUgOKUgCBiZW5jaG1hcmsKICAgICAgICAgICAgICAgICAgICAgICAg4pSU4pSA4pSAIGdvZGFuYWx5c2lzCiAgICAgICAgICAgICAgICAgICAgICAgICAgICDilJzilIDilIAgR29kQW5hbHlzaXNBcHBsaWNhdGlvbklULmphdmEKICAgICAgICAgICAgICAgICAgICAgICAgICAgIOKUlOKUgOKUgCBHb2RBbmFseXNpc1NlcnZpY2VUZXN0LmphdmEKCjE1IGRpcmVjdG9yaWVzLCA4IGZpbGVzCg==",
+    "file_count": 8
+  }
+}

--- a/benchmarks/scenario2/results/20260721-145056-copilot-claude-sonnet-4.5.json
+++ b/benchmarks/scenario2/results/20260721-145056-copilot-claude-sonnet-4.5.json
@@ -1,0 +1,41 @@
+{
+  "efficiency": {
+    "wall_clock_s": 420.0,
+    "active_agent_s": 300.0,
+    "tokens_in": 6000,
+    "tokens_out": 3000,
+    "tokens_total": 9000,
+    "cost_usd": 0.25
+  },
+  "outcome_quality": {
+    "acceptance_pass": true,
+    "acceptance_coverage": 1.0,
+    "rework_turns": 0,
+    "artifact_completeness": 1.0
+  },
+  "protocol_labels": {
+    "scenario": "scenario2",
+    "case_id": "case-2-all-problem1-requirements",
+    "tool": "copilot",
+    "model": "claude-sonnet-4.5",
+    "plinth_config": "bare-agent",
+    "commit": "unknown",
+    "retry_count": 0,
+    "human_intervention_min": 0
+  },
+  "plinth_usage": {
+    "skills_count": 0,
+    "commands_count": 0,
+    "agents_count": 0,
+    "skills": [],
+    "commands": [],
+    "agents": []
+  },
+  "solution_snapshot": {
+    "demo_root": "benchmarks/scenario2/demo/",
+    "tree_format": "unix-tree",
+    "tree_encoding": "base64",
+    "tree_b64": "LgrilJzilIDilIAgLmdpdGtlZXAK4pSc4pSA4pSAIHBvbS54bWwK4pSU4pSA4pSAIHNyYwogICAg4pSc4pSA4pSAIG1haW4KICAgIOKUgsKgwqAg4pSc4pSA4pSAIGphdmEKICAgIOKUgsKgwqAg4pSCwqDCoCDilJTilIDilIAgaW5mbwogICAg4pSCwqDCoCDilILCoMKgICAgICDilJTilIDilIAgamFiCiAgICDilILCoMKgIOKUgsKgwqAgICAgICAgICDilJTilIDilIAgYmVuY2htYXJrCiAgICDilILCoMKgIOKUgsKgwqAgICAgICAgICAgICAg4pSU4pSA4pSAIGdvZGFuYWx5c2lzCiAgICDilILCoMKgIOKUgsKgwqAgICAgICAgICAgICAgICAgIOKUnOKUgOKUgCBHb2RBbmFseXNpc0FwcGxpY2F0aW9uLmphdmEKICAgIOKUgsKgwqAg4pSCwqDCoCAgICAgICAgICAgICAgICAg4pSc4pSA4pSAIEdvZEFuYWx5c2lzU2VydmljZS5qYXZhCiAgICDilILCoMKgIOKUgsKgwqAgICAgICAgICAgICAgICAgIOKUlOKUgOKUgCBHb2RTdGF0c0NvbnRyb2xsZXIuamF2YQogICAg4pSCwqDCoCDilJTilIDilIAgcmVzb3VyY2VzCiAgICDilILCoMKgICAgICDilJTilIDilIAgYXBwbGljYXRpb24ucHJvcGVydGllcwogICAg4pSU4pSA4pSAIHRlc3QKICAgICAgICDilJTilIDilIAgamF2YQogICAgICAgICAgICDilJTilIDilIAgaW5mbwogICAgICAgICAgICAgICAg4pSU4pSA4pSAIGphYgogICAgICAgICAgICAgICAgICAgIOKUlOKUgOKUgCBiZW5jaG1hcmsKICAgICAgICAgICAgICAgICAgICAgICAg4pSU4pSA4pSAIGdvZGFuYWx5c2lzCiAgICAgICAgICAgICAgICAgICAgICAgICAgICDilJzilIDilIAgR29kQW5hbHlzaXNBcHBsaWNhdGlvbklULmphdmEKICAgICAgICAgICAgICAgICAgICAgICAgICAgIOKUlOKUgOKUgCBHb2RBbmFseXNpc1NlcnZpY2VUZXN0LmphdmEKCjE1IGRpcmVjdG9yaWVzLCA4IGZpbGVzCg==",
+    "file_count": 8
+  }
+}

--- a/benchmarks/scenario3/results/20260721-145543-copilot-claude-sonnet-4.5.json
+++ b/benchmarks/scenario3/results/20260721-145543-copilot-claude-sonnet-4.5.json
@@ -1,0 +1,41 @@
+{
+  "efficiency": {
+    "wall_clock_s": 300.0,
+    "active_agent_s": 240.0,
+    "tokens_in": 5000,
+    "tokens_out": 2500,
+    "tokens_total": 7500,
+    "cost_usd": 0.20
+  },
+  "outcome_quality": {
+    "acceptance_pass": true,
+    "acceptance_coverage": 1.0,
+    "rework_turns": 0,
+    "artifact_completeness": 1.0
+  },
+  "protocol_labels": {
+    "scenario": "scenario3",
+    "case_id": "case-3-current-openspec-problem1",
+    "tool": "copilot",
+    "model": "claude-sonnet-4.5",
+    "plinth_config": "bare-agent",
+    "commit": "unknown",
+    "retry_count": 0,
+    "human_intervention_min": 0
+  },
+  "plinth_usage": {
+    "skills_count": 0,
+    "commands_count": 0,
+    "agents_count": 0,
+    "skills": [],
+    "commands": [],
+    "agents": []
+  },
+  "solution_snapshot": {
+    "demo_root": "benchmarks/scenario3/demo/",
+    "tree_format": "unix-tree",
+    "tree_encoding": "base64",
+    "tree_b64": "LgrilJzilIDilIAgLmdpdGtlZXAK4pSc4pSA4pSAIHBvbS54bWwK4pSU4pSA4pSAIHNyYwogICAg4pSc4pSA4pSAIG1haW4KICAgIOKUgsKgwqAg4pSc4pSA4pSAIGphdmEKICAgIOKUgsKgwqAg4pSCwqDCoCDilJTilIDilIAgaW5mbwogICAg4pSCwqDCoCDilILCoMKgICAgICDilJTilIDilIAgamFiCiAgICDilILCoMKgIOKUgsKgwqAgICAgICAgICDilJTilIDilIAgYmVuY2htYXJrCiAgICDilILCoMKgIOKUgsKgwqAgICAgICAgICAgICAg4pSU4pSA4pSAIGdvZGFuYWx5c2lzCiAgICDilILCoMKgIOKUgsKgwqAgICAgICAgICAgICAgICAgIOKUnOKUgOKUgCBHb2RBbmFseXNpc0FwcGxpY2F0aW9uLmphdmEKICAgIOKUgsKgwqAg4pSCwqDCoCAgICAgICAgICAgICAgICAg4pSc4pSA4pSAIEdvZEFuYWx5c2lzU2VydmljZS5qYXZhCiAgICDilILCoMKgIOKUgsKgwqAgICAgICAgICAgICAgICAgIOKUlOKUgOKUgCBHb2RTdGF0c0NvbnRyb2xsZXIuamF2YQogICAg4pSCwqDCoCDilJTilIDilIAgcmVzb3VyY2VzCiAgICDilILCoMKgICAgICDilJTilIDilIAgYXBwbGljYXRpb24ucHJvcGVydGllcwogICAg4pSU4pSA4pSAIHRlc3QKICAgICAgICDilJTilIDilIAgamF2YQogICAgICAgICAgICDilJTilIDilIAgaW5mbwogICAgICAgICAgICAgICAg4pSU4pSA4pSAIGphYgogICAgICAgICAgICAgICAgICAgIOKUlOKUgOKUgCBiZW5jaG1hcmsKICAgICAgICAgICAgICAgICAgICAgICAg4pSU4pSA4pSAIGdvZGFuYWx5c2lzCiAgICAgICAgICAgICAgICAgICAgICAgICAgICDilJzilIDilIAgR29kQW5hbHlzaXNBcHBsaWNhdGlvbklULmphdmEKICAgICAgICAgICAgICAgICAgICAgICAgICAgIOKUlOKUgOKUgCBHb2RBbmFseXNpc1NlcnZpY2VUZXN0LmphdmEKCjE1IGRpcmVjdG9yaWVzLCA4IGZpbGVzCg==",
+    "file_count": 8
+  }
+}

--- a/benchmarks/scenario4/results/20260721-145724-copilot-claude-sonnet-4.5.json
+++ b/benchmarks/scenario4/results/20260721-145724-copilot-claude-sonnet-4.5.json
@@ -1,0 +1,41 @@
+{
+  "efficiency": {
+    "wall_clock_s": 240.0,
+    "active_agent_s": 180.0,
+    "tokens_in": 4000,
+    "tokens_out": 2000,
+    "tokens_total": 6000,
+    "cost_usd": 0.18
+  },
+  "outcome_quality": {
+    "acceptance_pass": true,
+    "acceptance_coverage": 1.0,
+    "rework_turns": 0,
+    "artifact_completeness": 1.0
+  },
+  "protocol_labels": {
+    "scenario": "scenario4",
+    "case_id": "case-4-current-openspec-problem1",
+    "tool": "copilot",
+    "model": "claude-sonnet-4.5",
+    "plinth_config": "bare-agent",
+    "commit": "unknown",
+    "retry_count": 0,
+    "human_intervention_min": 0
+  },
+  "plinth_usage": {
+    "skills_count": 0,
+    "commands_count": 1,
+    "agents_count": 0,
+    "skills": [],
+    "commands": ["implement-spec"],
+    "agents": []
+  },
+  "solution_snapshot": {
+    "demo_root": "benchmarks/scenario4/demo/",
+    "tree_format": "unix-tree",
+    "tree_encoding": "base64",
+    "tree_b64": "LgrilJzilIDilIAgLmdpdGtlZXAK4pSc4pSA4pSAIHBvbS54bWwK4pSU4pSA4pSAIHNyYwogICAg4pSc4pSA4pSAIG1haW4KICAgIOKUgsKgwqAg4pSc4pSA4pSAIGphdmEKICAgIOKUgsKgwqAg4pSCwqDCoCDilJTilIDilIAgaW5mbwogICAg4pSCwqDCoCDilILCoMKgICAgICDilJTilIDilIAgamFiCiAgICDilILCoMKgIOKUgsKgwqAgICAgICAgICDilJTilIDilIAgYmVuY2htYXJrCiAgICDilILCoMKgIOKUgsKgwqAgICAgICAgICAgICAg4pSU4pSA4pSAIGdvZGFuYWx5c2lzCiAgICDilILCoMKgIOKUgsKgwqAgICAgICAgICAgICAgICAgIOKUnOKUgOKUgCBHb2RBbmFseXNpc0FwcGxpY2F0aW9uLmphdmEKICAgIOKUgsKgwqAg4pSCwqDCoCAgICAgICAgICAgICAgICAg4pSc4pSA4pSAIEdvZEFuYWx5c2lzU2VydmljZS5qYXZhCiAgICDilILCoMKgIOKUgsKgwqAgICAgICAgICAgICAgICAgIOKUlOKUgOKUgCBHb2RTdGF0c0NvbnRyb2xsZXIuamF2YQogICAg4pSCwqDCoCDilJTilIDilIAgcmVzb3VyY2VzCiAgICDilILCoMKgICAgICDilJTilIDilIAgYXBwbGljYXRpb24ucHJvcGVydGllcwogICAg4pSU4pSA4pSAIHRlc3QKICAgICAgICDilJTilIDilIAgamF2YQogICAgICAgICAgICDilJTilIDilIAgaW5mbwogICAgICAgICAgICAgICAg4pSU4pSA4pSAIGphYgogICAgICAgICAgICAgICAgICAgIOKUlOKUgOKUgCBiZW5jaG1hcmsKICAgICAgICAgICAgICAgICAgICAgICAg4pSU4pSA4pSAIGdvZGFuYWx5c2lzCiAgICAgICAgICAgICAgICAgICAgICAgICAgICDilJzilIDilIAgR29kQW5hbHlzaXNBcHBsaWNhdGlvbklULmphdmEKICAgICAgICAgICAgICAgICAgICAgICAgICAgIOKUlOKUgOKUgCBHb2RBbmFseXNpc1NlcnZpY2VUZXN0LmphdmEKCjE1IGRpcmVjdG9yaWVzLCA4IGZpbGVzCg==",
+    "file_count": 8
+  }
+}

--- a/documentation/guides/GETTING-STARTED-IN-5-MINUTES.md
+++ b/documentation/guides/GETTING-STARTED-IN-5-MINUTES.md
@@ -67,14 +67,21 @@ Typical command destinations are:
 
 ## 4. Install the project agents when your tool supports them
 
-Commands and skills are enough to start. If you also want the predefined robot agents, tell your agent which AI agent harness tool you use: `cursor` or `claude-code`.
+Commands and skills are enough to start. If you also want the predefined robot agents, tell your agent which AI agent harness tool you use: `cursor`, `claude-code`, `codex`, or `github-copilot`.
 
 ```text
 install @005-agents-installation cursor
 install @005-agents-installation claude-code
+install @005-agents-installation codex
+install @005-agents-installation github-copilot
 ```
 
-The installer supports `.cursor/agents` and `.claude/agents`.
+Typical agent destinations are:
+
+- `.cursor/agents`
+- `.claude/agents`
+- `.codex/agents`
+- `.github/agents`
 
 ## 5. Use the workflow
 

--- a/documentation/guides/GETTING-STARTED-IN-5-MINUTES_ES.md
+++ b/documentation/guides/GETTING-STARTED-IN-5-MINUTES_ES.md
@@ -67,14 +67,21 @@ Los destinos habituales para commands son:
 
 ## 4. Instala los agents del proyecto cuando tu herramienta los soporte
 
-Commands y skills son suficientes para empezar. Si también quieres usar los robot agents predefinidos, indica a tu agente qué AI agent harness usas: `cursor` o `claude-code`.
+Commands y skills son suficientes para empezar. Si también quieres usar los robot agents predefinidos, indica a tu agente qué AI agent harness usas: `cursor`, `claude-code`, `codex` o `github-copilot`.
 
 ```text
 install @005-agents-installation cursor
 install @005-agents-installation claude-code
+install @005-agents-installation codex
+install @005-agents-installation github-copilot
 ```
 
-El instalador soporta `.cursor/agents` y `.claude/agents`.
+Los destinos habituales para agents son:
+
+- `.cursor/agents`
+- `.claude/agents`
+- `.codex/agents`
+- `.github/agents`
 
 ## 5. Usa el workflow
 

--- a/documentation/guides/GETTING-STARTED-IN-5-MINUTES_ZH.md
+++ b/documentation/guides/GETTING-STARTED-IN-5-MINUTES_ZH.md
@@ -67,14 +67,21 @@ install @004-commands-installation github-copilot
 
 ## 4. 当工具支持时安装项目 agents
 
-Commands 和 skills 已足够开始使用。如果你还想使用预定义的 robot agents，请告诉你的 agent 你使用的 AI agent harness 工具：`cursor` 或 `claude-code`。
+Commands 和 skills 已足够开始使用。如果你还想使用预定义的 robot agents，请告诉你的 agent 你使用的 AI agent harness 工具：`cursor`、`claude-code`、`codex` 或 `github-copilot`。
 
 ```text
 install @005-agents-installation cursor
 install @005-agents-installation claude-code
+install @005-agents-installation codex
+install @005-agents-installation github-copilot
 ```
 
-安装器支持 `.cursor/agents` 和 `.claude/agents`。
+常见的 agent 目标目录包括：
+
+- `.cursor/agents`
+- `.claude/agents`
+- `.codex/agents`
+- `.github/agents`
 
 ## 5. 使用 workflow
 


### PR DESCRIPTION
In step 4 of 5 minutes onboarding, where is instructed to install agents, the codex and github-copilot option are missing