### PR TITLE
Feat/1075 add command frontmatter metadata

### DIFF
--- a/.cursor/commands/benchmark.md
+++ b/.cursor/commands/benchmark.md
@@ -1,3 +1,15 @@
+---
+description: 'Design and coordinate a reproducible Java performance test.'
+argument-hint: '[target]'
+model: 'inherit'
+agent: 'robot-java-performance'
+tools:
+  - 'Read'
+  - 'Write'
+  - 'Edit'
+  - 'Bash'
+---
+
 # benchmark
 
 Select and coordinate an appropriate Java performance test with reproducible workload, environment, thresholds, and result artifacts.

--- a/.cursor/commands/close-spec.md
+++ b/.cursor/commands/close-spec.md
@@ -1,3 +1,13 @@
+---
+description: 'Archive a completed OpenSpec change by name.'
+argument-hint: '[openspec-change]'
+model: 'inherit'
+agent: 'robot-architect'
+tools:
+  - 'Read'
+  - 'Bash'
+---
+
 # close-spec
 
 Archive an OpenSpec change by name, using the OpenSpec CLI, so completed changes can be reconciled and removed from the active change list.

--- a/.cursor/commands/create-acceptance-criteria.md
+++ b/.cursor/commands/create-acceptance-criteria.md
@@ -1,3 +1,13 @@
+---
+description: 'Derive and post confirmed Gherkin acceptance criteria for an issue.'
+argument-hint: '[issue-url]'
+model: 'inherit'
+agent: 'robot-business-analyst'
+tools:
+  - 'Read'
+  - 'Bash'
+---
+
 # create-acceptance-criteria
 
 Derive observable Gherkin acceptance criteria from the Functional Specification comment produced by `/explore-problem` and post the confirmed result as a separate comment on the same issue.

--- a/.cursor/commands/create-adr.md
+++ b/.cursor/commands/create-adr.md
@@ -1,3 +1,14 @@
+---
+description: 'Create a repository ADR for an approved architectural decision.'
+argument-hint: '[decision-source] [adr-type]'
+model: 'inherit'
+agent: 'robot-architect'
+tools:
+  - 'Read'
+  - 'Write'
+  - 'Edit'
+---
+
 # create-adr
 
 Record an important architectural decision, its context, alternatives, and consequences.

--- a/.cursor/commands/create-diagram.md
+++ b/.cursor/commands/create-diagram.md
@@ -1,3 +1,14 @@
+---
+description: 'Create an architecture or design diagram from selected source artifacts.'
+argument-hint: '[source-artifact] [diagram-type]'
+model: 'inherit'
+agent: 'robot-architect'
+tools:
+  - 'Read'
+  - 'Write'
+  - 'Edit'
+---
+
 # create-diagram
 
 Create an architecture or design diagram that explains a selected system view.

--- a/.cursor/commands/create-feature-branch.md
+++ b/.cursor/commands/create-feature-branch.md
@@ -1,3 +1,13 @@
+---
+description: 'Create and switch to a conventionally named feature branch.'
+argument-hint: '[issue-or-change|type description] [base-reference]'
+model: 'inherit'
+agent: 'robot-tech-lead'
+tools:
+  - 'Read'
+  - 'Bash'
+---
+
 # create-feature-branch
 
 Create and switch the current checkout to a conventionally named local branch for GitHub issue, OpenSpec, analysis, design, documentation, or implementation work.

--- a/.cursor/commands/create-spec.md
+++ b/.cursor/commands/create-spec.md
@@ -1,3 +1,15 @@
+---
+description: 'Create or update OpenSpec artifacts from approved source material.'
+argument-hint: '[issue-url]'
+model: 'inherit'
+agent: 'robot-architect'
+tools:
+  - 'Read'
+  - 'Write'
+  - 'Edit'
+  - 'Bash'
+---
+
 # create-spec
 
 Create or update one or more OpenSpec changes from the available issue, design, ADR, plan, or existing OpenSpec artifacts.

--- a/.cursor/commands/create-worktree.md
+++ b/.cursor/commands/create-worktree.md
@@ -1,3 +1,13 @@
+---
+description: 'Create an isolated Git worktree on a new conventionally named branch.'
+argument-hint: '[issue-or-change|type description] [target-path] [base-reference]'
+model: 'inherit'
+agent: 'robot-tech-lead'
+tools:
+  - 'Read'
+  - 'Bash'
+---
+
 # create-worktree
 
 Always create a new branch and linked Git worktree for isolated or parallel work without changing the current checkout.

--- a/.cursor/commands/explore-design.md
+++ b/.cursor/commands/explore-design.md
@@ -1,3 +1,15 @@
+---
+description: 'Refine the technical design of an issue or OpenSpec change before implementation.'
+argument-hint: '[openspec-change]'
+model: 'inherit'
+agent: 'robot-architect'
+tools:
+  - 'Read'
+  - 'Write'
+  - 'Edit'
+  - 'Bash'
+---
+
 # explore-design
 
 Improve and refine the technical approach for an issue or OpenSpec change after initial specification—with alternatives, trade-offs, compatibility review, rollout controls, and verification strategy—before implementation.

--- a/.cursor/commands/explore-problem.md
+++ b/.cursor/commands/explore-problem.md
@@ -1,3 +1,13 @@
+---
+description: 'Analyze an issue through five lenses and post a Functional Specification.'
+argument-hint: '[issue-url]'
+model: 'inherit'
+agent: 'robot-business-analyst'
+tools:
+  - 'Read'
+  - 'Bash'
+---
+
 # explore-problem
 
 Evaluate an issue through five points of view — problem framing, root cause analysis, assumption analysis, context mapping, and quality attribute discovery — and post the resulting Functional Specification as a new comment on the issue.

--- a/.cursor/commands/implement-spec.md
+++ b/.cursor/commands/implement-spec.md
@@ -1,3 +1,15 @@
+---
+description: 'Deliver an approved plan or OpenSpec change through controlled implementation.'
+argument-hint: '[openspec-change]'
+model: 'inherit'
+agent: 'robot-tech-lead'
+tools:
+  - 'Read'
+  - 'Write'
+  - 'Edit'
+  - 'Bash'
+---
+
 # implement-spec
 
 Deliver an approved implementation plan or validated OpenSpec task list through controlled implementation.

--- a/.cursor/commands/profile.md
+++ b/.cursor/commands/profile.md
@@ -1,3 +1,15 @@
+---
+description: 'Coordinate a reproducible Java profiling and optimization lifecycle.'
+argument-hint: '[target]'
+model: 'inherit'
+agent: 'robot-java-performance'
+tools:
+  - 'Read'
+  - 'Write'
+  - 'Edit'
+  - 'Bash'
+---
+
 # profile
 
 Coordinate a Java profiling lifecycle from reproducible baseline through evidence-backed optimization verification.

--- a/.cursor/commands/review-alignment.md
+++ b/.cursor/commands/review-alignment.md
@@ -1,3 +1,12 @@
+---
+description: 'Review analysis and design artifacts for implementation readiness.'
+argument-hint: '[artifact] [artifact ...]'
+model: 'inherit'
+agent: 'robot-business-analyst'
+tools:
+  - 'Read'
+---
+
 # review-alignment
 
 Review available analysis and design artifacts for consistency, traceability, completeness, and implementation readiness.

--- a/.cursor/commands/update-issue.md
+++ b/.cursor/commands/update-issue.md
@@ -1,3 +1,13 @@
+---
+description: 'Update an issue description with structured, evidence-backed content.'
+argument-hint: '[issue-url]'
+model: 'inherit'
+agent: 'robot-business-analyst'
+tools:
+  - 'Read'
+  - 'Bash'
+---
+
 # update-issue
 
 Update an existing project issue description with structured, evidence-backed content.

--- a/documentation/openspec/changes/add-command-frontmatter-metadata/.openspec.yaml
+++ b/documentation/openspec/changes/add-command-frontmatter-metadata/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/documentation/openspec/changes/add-command-frontmatter-metadata/design.md
+++ b/documentation/openspec/changes/add-command-frontmatter-metadata/design.md
@@ -1,0 +1,119 @@
+## Context
+
+The command pipeline currently treats XML under `plinth-commands-generator/src/main/resources/commands/` as authoritative, validates it with the no-namespace `commands.xsd`, renders Markdown with `command-to-markdown.xsl`, and bridges the generated files into the `004-commands-installation` skill. Generated command files currently start with `# <command-id>` and contain no YAML frontmatter.
+
+Issue [#1075](https://github.com/jabrena/plinth/issues/1075), its complete Functional Specification, and its approved acceptance criteria require every inventoried command to carry Cursor-compatible frontmatter while preserving the existing Markdown body. The maintainer-confirmed build boundary is `.agents/skills/004-commands-installation/assets/commands` after `./mvnw clean verify -pl plinth-skills-generator -am`; installing those assets into a selected tool directory remains the responsibility of `004-commands-installation`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Represent `description`, `argument-hint`, `model`, `agent`, and a repeatable tool list in every authoritative command XML document.
+- Render valid YAML frontmatter before the existing Markdown heading.
+- Map XML `tools/list-tools/tool` entries to YAML `tools` sequence entries.
+- Preserve every command's existing Markdown content after the frontmatter.
+- Package one frontmatter-enabled asset for every inventoried command in the generated `004-commands-installation` skill.
+- Verify schema validity, rendering, inventory coverage, propagation, and body preservation through the existing Maven reactor build.
+
+**Non-Goals:**
+
+- Change command file names, inventory order, workflow behavior, ownership, routing, safeguards, or Markdown body semantics.
+- Change the interactive installation behavior of `004-commands-installation`.
+- Claim that Cursor frontmatter fields have identical semantics in every supported command framework.
+- Refresh public `skills/`; local generation continues to target `.agents/skills` unless the release profile is explicitly selected.
+- Select a new command architecture or replace the existing XML → XSLT → Markdown pipeline.
+
+## Change Boundary Assessment
+
+This is one atomic change. Schema representation, frontmatter rendering, XML-source migration, and installer-asset propagation share one user-visible outcome, build, ownership boundary, and rollback path. Splitting the work by XSD, XSLT, or Maven module would create technical-layer changes with no independently useful result.
+
+## Decisions
+
+### Add a required frontmatter subtree before the narrative contract
+
+`commands.xsd` will extend the root command sequence with a required `frontmatter` element before `goal`. The subtree will use this source shape:
+
+```xml
+<frontmatter>
+    <description>One sentence describing what this command does.</description>
+    <argument-hint>[optional arguments]</argument-hint>
+    <model>inherit</model>
+    <agent>inherit</agent>
+    <tools>
+        <list-tools>
+            <tool>Read</tool>
+            <tool>Edit</tool>
+        </list-tools>
+    </tools>
+</frontmatter>
+```
+
+All five metadata fields are required because the issue requires every generated command to follow the approved structure. `list-tools` contains one or more `tool` elements so the XML model represents the YAML sequence explicitly.
+
+Alternative considered: make the entire subtree optional for incremental migration. Rejected because it would permit a successful build with commands that still lack the accepted metadata and would weaken inventory-wide coverage.
+
+### Keep metadata values extensible and command-specific
+
+The XSD will enforce element structure and repetition but will not enumerate model, agent, or tool values. Each command source owns its description, argument hint, inherited model/agent selection, and applicable tools. Initial migration will use the approved `model: inherit` and `agent: inherit` values while command-specific descriptions, hints, and tools are reviewed against each command contract.
+
+Alternative considered: define one global tool list in the inventory or stylesheet. Rejected because `tools/list-tools/tool` is part of each command source and command capabilities can differ.
+
+### Prepend frontmatter without re-rendering the existing body differently
+
+The root XSLT template will render an opening delimiter, metadata keys and tool sequence, a closing delimiter, and then the existing heading/body templates. The established rendering of `goal`, `constraints`, `steps`, `output-format`, and `safeguards` remains unchanged.
+
+Generated scalar values must be emitted in a YAML-safe representation. Verification will parse or otherwise validate the complete frontmatter rather than relying only on delimiter checks.
+
+Alternative considered: embed raw YAML in `goal` CDATA. Rejected because metadata would not be schema-validated, would duplicate formatting across fourteen sources, and would make the tools list opaque to XML processing.
+
+### Reuse the existing command-to-skill bridge
+
+No new packaging path is introduced. `plinth-commands-generator` continues to generate Markdown during `process-classes`; `plinth-skills-generator` continues to bridge those outputs during `generate-resources`; and the generated skill continues to expose them under `004-commands-installation/assets/commands`.
+
+The bridge and installer parity tests will verify content propagation, not merely file presence. Direct output into `.cursor/commands` is outside this build stage.
+
+### Validate at schema, renderer, bundle, and propagation boundaries
+
+Verification will cover:
+
+- all command XML sources validate against the updated XSD;
+- every inventoried generated Markdown file starts with valid frontmatter;
+- each XML tool value appears in the corresponding YAML `tools` sequence;
+- the Markdown following the closing delimiter preserves the previous command content;
+- `004-commands-installation/assets/commands` contains exactly one corresponding asset for every inventory entry; and
+- `./mvnw clean verify -pl plinth-skills-generator -am` exercises the integrated path.
+
+## Source Authority and Derivation
+
+| Concern | Authority | Direction |
+|---|---|---|
+| Problem, value, and frontmatter example | Issue #1075 description | Issue to OpenSpec |
+| Root cause, schema constraint, quality attributes | Functional Specification comment | Comment to design and specs |
+| Build command and installer-asset outcomes | Approved acceptance-criteria comment | Comment to specs and tasks |
+| Current component and Maven boundaries | Repository XML, XSD, XSLT, POMs, and tests | Repository to design |
+
+Later approved acceptance criteria supersede the earlier direct `.cursor/commands` build-path description. No derivation flows back to the issue automatically.
+
+## Risks / Trade-offs
+
+- **Incorrect YAML escaping could create frontmatter that looks plausible but is invalid** → validate generated metadata as YAML and include representative punctuation in renderer tests.
+- **Command-specific metadata may drift from command behavior** → keep metadata in the same XML source and add per-command contract assertions where routing or tool access matters.
+- **A partial migration could leave installer output inconsistent** → require frontmatter in the XSD and verify every inventory entry.
+- **Prepending metadata could alter existing command bodies through whitespace changes** → compare the content after the closing delimiter with the previous generated body.
+- **Cursor-compatible metadata may be ignored or interpreted differently by other installer destinations** → preserve the body and document that this change guarantees the approved Cursor format only.
+
+## Migration Plan
+
+1. Extend `commands.xsd` with the required frontmatter subtree and repeatable tool representation.
+2. Add reviewed metadata to every XML source declared by `commands.xml`.
+3. Update the XSLT to prepend YAML frontmatter while preserving the existing body templates.
+4. Add focused schema, renderer, inventory, bridge, and installer-asset tests.
+5. Run XML validation and `./mvnw clean verify -pl plinth-skills-generator -am`.
+6. Inspect `.agents/skills/004-commands-installation/assets/commands` for complete, valid output.
+
+Rollback removes the frontmatter subtree, renderer prefix, migrated metadata, and associated tests together; the prior Markdown body generation and Maven bridge then remain intact.
+
+## Open Questions
+
+- Which exact description, argument hint, and tool list is approved for each of the fourteen commands? Implementation must review these values command by command rather than copy one example blindly.
+- Which test-scope YAML validation mechanism best proves syntactic validity without adding a production runtime dependency? This is an implementation choice; the requirement to validate generated YAML is fixed.

--- a/documentation/openspec/changes/add-command-frontmatter-metadata/design.md
+++ b/documentation/openspec/changes/add-command-frontmatter-metadata/design.md
@@ -8,9 +8,9 @@ Issue [#1075](https://github.com/jabrena/plinth/issues/1075), its complete Funct
 
 **Goals:**
 
-- Represent `description`, `argument-hint`, `model`, `agent`, and a repeatable tool list in every authoritative command XML document.
+- Represent `description`, `argument-hint`, `model`, `agent`, and a repeatable tool list inside an agents-style `metadata` element in every authoritative command XML document.
 - Render valid YAML frontmatter before the existing Markdown heading.
-- Map XML `tools/list-tools/tool` entries to YAML `tools` sequence entries.
+- Map XML `tools/tools-list/tool` entries to YAML `tools` sequence entries.
 - Preserve XML tool order in the generated YAML sequence.
 - Preserve every command's existing Markdown content byte-for-byte after the frontmatter.
 - Verify that every generated command contains the maintainer-approved metadata declared by its XML source.
@@ -27,30 +27,30 @@ Issue [#1075](https://github.com/jabrena/plinth/issues/1075), its complete Funct
 
 ## Change Boundary Assessment
 
-This is one atomic change. Schema representation, frontmatter rendering, XML-source migration, and installer-asset propagation share one user-visible outcome, build, ownership boundary, and rollback path. Splitting the work by XSD, XSLT, or Maven module would create technical-layer changes with no independently useful result.
+This is one atomic change. Schema representation, YAML-frontmatter rendering, XML-source migration, and installer-asset propagation share one user-visible outcome, build, ownership boundary, and rollback path. Splitting the work by XSD, XSLT, or Maven module would create technical-layer changes with no independently useful result.
 
 ## Decisions
 
-### Add a required frontmatter subtree before the narrative contract
+### Add a required XML metadata subtree before the narrative contract
 
-`commands.xsd` will extend the root command sequence with a required `frontmatter` element before `goal`. The subtree will use this source shape:
+`commands.xsd` will follow the `agents.xsd` convention by extending the root command sequence with a required global `metadata` element reference before `goal`. Its children are composed through global element references and use this source shape:
 
 ```xml
-<frontmatter>
+<metadata>
     <description>One sentence describing what this command does.</description>
     <argument-hint>[optional arguments]</argument-hint>
     <model>inherit</model>
     <agent>inherit</agent>
     <tools>
-        <list-tools>
+        <tools-list>
             <tool>Read</tool>
             <tool>Edit</tool>
-        </list-tools>
+        </tools-list>
     </tools>
-</frontmatter>
+</metadata>
 ```
 
-All five metadata fields are required because the issue requires every generated command to follow the approved structure. `list-tools` contains one or more `tool` elements so the XML model represents the YAML sequence explicitly.
+All five metadata fields are required because the issue requires every generated command to follow the approved structure. `tools-list` contains one or more `tool` elements so the XML model represents the YAML sequence explicitly.
 
 Alternative considered: make the entire subtree optional for incremental migration. Rejected because it would permit a successful build with commands that still lack the accepted metadata and would weaken inventory-wide coverage.
 
@@ -58,15 +58,15 @@ Alternative considered: make the entire subtree optional for incremental migrati
 
 The XSD will enforce element structure and repetition but will not enumerate model, agent, or tool values. Each command source owns its description, argument hint, inherited model/agent selection, and applicable tools. Initial migration will use the approved `model: inherit` and `agent: inherit` values while command-specific descriptions, hints, and tools are reviewed against each command contract.
 
-Alternative considered: define one global tool list in the inventory or stylesheet. Rejected because `tools/list-tools/tool` is part of each command source and command capabilities can differ.
+Alternative considered: define one global tool list in the inventory or stylesheet. Rejected because `tools/tools-list/tool` is part of each command source and command capabilities can differ.
 
 ### Prepend frontmatter without re-rendering the existing body differently
 
 The root XSLT template will render an opening delimiter, metadata keys and tool sequence, a closing delimiter, and then the existing heading/body templates. The established rendering of `goal`, `constraints`, `steps`, `output-format`, and `safeguards` remains unchanged.
 
-One named XSLT template will emit metadata scalars in a YAML-safe single-quoted representation and escape embedded apostrophes by doubling them. The stylesheet will iterate over `tools/list-tools/tool` in document order so the YAML sequence is deterministic and preserves the XML order. Tests will cover YAML-significant punctuation and whitespace boundaries instead of relying only on simple values.
+One named XSLT template will emit metadata scalars in a YAML-safe single-quoted representation and escape embedded apostrophes by doubling them. The stylesheet will iterate over `tools/tools-list/tool` in document order so the YAML sequence is deterministic and preserves the XML order. Tests will cover YAML-significant punctuation and whitespace boundaries instead of relying only on simple values.
 
-Generated frontmatter will be parsed as YAML 1.2 with SnakeYAML Engine in test scope. Tests will assert the parsed keys and values against the XML source, including the ordered tools sequence. The parser is verification infrastructure only and adds no production runtime responsibility.
+Generated YAML frontmatter will be parsed as YAML 1.2 with SnakeYAML Engine in test scope. Tests will assert the parsed keys and values against the XML `metadata` source, including the ordered tools sequence. The parser is verification infrastructure only and adds no production runtime responsibility.
 
 Alternative considered: embed raw YAML in `goal` CDATA. Rejected because metadata would not be schema-validated, would duplicate formatting across fourteen sources, and would make the tools list opaque to XML processing.
 
@@ -103,20 +103,20 @@ Later approved acceptance criteria supersede the earlier direct `.cursor/command
 
 - **Incorrect YAML escaping could create frontmatter that looks plausible but is invalid** → parse generated metadata with a test-scoped YAML 1.2 parser and include apostrophes, colons, hashes, brackets, backslashes, and whitespace boundaries in renderer tests.
 - **Command-specific metadata may drift from command behavior** → keep metadata in the same XML source and add per-command contract assertions where routing or tool access matters.
-- **A partial migration could leave installer output inconsistent** → require frontmatter in the XSD and verify every inventory entry.
+- **A partial migration could leave installer output inconsistent** → require XML `metadata` in the XSD and verify every inventory entry.
 - **Prepending metadata could alter existing command bodies through whitespace changes** → compare the content after the closing delimiter and required separator with the previous generated body byte-for-byte.
 - **Cursor-compatible metadata may be ignored or interpreted differently by other installer destinations** → preserve the body and document that this change guarantees the approved Cursor format only.
 
 ## Migration Plan
 
-1. Extend `commands.xsd` with the required frontmatter subtree and repeatable tool representation.
+1. Extend `commands.xsd` with the required agents-style `metadata` subtree and repeatable tool representation.
 2. Add reviewed metadata to every XML source declared by `commands.xml`.
 3. Update the XSLT to prepend YAML frontmatter while preserving the existing body templates.
 4. Add focused schema, YAML parsing, approved-metadata, ordered-tool, body-parity, inventory, bridge, and installer-asset tests.
 5. Run XML validation and `./mvnw clean verify -pl plinth-skills-generator -am`.
 6. Inspect `.agents/skills/004-commands-installation/assets/commands` for complete, valid output.
 
-Rollback removes the frontmatter subtree, renderer prefix, migrated metadata, and associated tests together; the prior Markdown body generation and Maven bridge then remain intact.
+Rollback removes the XML `metadata` subtree, YAML-frontmatter renderer prefix, migrated metadata, and associated tests together; the prior Markdown body generation and Maven bridge then remain intact.
 
 ## Open Questions
 

--- a/documentation/openspec/changes/add-command-frontmatter-metadata/design.md
+++ b/documentation/openspec/changes/add-command-frontmatter-metadata/design.md
@@ -40,7 +40,7 @@ This is one atomic change. Schema representation, YAML-frontmatter rendering, XM
     <description>One sentence describing what this command does.</description>
     <argument-hint>[optional arguments]</argument-hint>
     <model>inherit</model>
-    <agent>inherit</agent>
+    <agent>robot-architect</agent>
     <tools>
         <tools-list>
             <tool>Read</tool>
@@ -56,7 +56,7 @@ Alternative considered: make the entire subtree optional for incremental migrati
 
 ### Keep metadata values extensible and command-specific
 
-The XSD will enforce element structure and repetition but will not enumerate model, agent, or tool values. Each command source owns its description, argument hint, inherited model/agent selection, and applicable tools. Initial migration will use the approved `model: inherit` and `agent: inherit` values while command-specific descriptions, hints, and tools are reviewed against each command contract.
+The XSD will enforce element structure and repetition but will not enumerate model, agent, or tool values. Each command source owns its description, argument hint, model selection, owning Plinth agent, and applicable tools. Initial migration will use `model: inherit`; each `agent` value will use the exact agent id declared by the command's owning-agent contract and registered in `plinth-agents-generator/src/main/resources/agents.xml`.
 
 Alternative considered: define one global tool list in the inventory or stylesheet. Rejected because `tools/tools-list/tool` is part of each command source and command capabilities can differ.
 

--- a/documentation/openspec/changes/add-command-frontmatter-metadata/design.md
+++ b/documentation/openspec/changes/add-command-frontmatter-metadata/design.md
@@ -11,7 +11,9 @@ Issue [#1075](https://github.com/jabrena/plinth/issues/1075), its complete Funct
 - Represent `description`, `argument-hint`, `model`, `agent`, and a repeatable tool list in every authoritative command XML document.
 - Render valid YAML frontmatter before the existing Markdown heading.
 - Map XML `tools/list-tools/tool` entries to YAML `tools` sequence entries.
-- Preserve every command's existing Markdown content after the frontmatter.
+- Preserve XML tool order in the generated YAML sequence.
+- Preserve every command's existing Markdown content byte-for-byte after the frontmatter.
+- Verify that every generated command contains the maintainer-approved metadata declared by its XML source.
 - Package one frontmatter-enabled asset for every inventoried command in the generated `004-commands-installation` skill.
 - Verify schema validity, rendering, inventory coverage, propagation, and body preservation through the existing Maven reactor build.
 
@@ -62,7 +64,9 @@ Alternative considered: define one global tool list in the inventory or styleshe
 
 The root XSLT template will render an opening delimiter, metadata keys and tool sequence, a closing delimiter, and then the existing heading/body templates. The established rendering of `goal`, `constraints`, `steps`, `output-format`, and `safeguards` remains unchanged.
 
-Generated scalar values must be emitted in a YAML-safe representation. Verification will parse or otherwise validate the complete frontmatter rather than relying only on delimiter checks.
+One named XSLT template will emit metadata scalars in a YAML-safe single-quoted representation and escape embedded apostrophes by doubling them. The stylesheet will iterate over `tools/list-tools/tool` in document order so the YAML sequence is deterministic and preserves the XML order. Tests will cover YAML-significant punctuation and whitespace boundaries instead of relying only on simple values.
+
+Generated frontmatter will be parsed as YAML 1.2 with SnakeYAML Engine in test scope. Tests will assert the parsed keys and values against the XML source, including the ordered tools sequence. The parser is verification infrastructure only and adds no production runtime responsibility.
 
 Alternative considered: embed raw YAML in `goal` CDATA. Rejected because metadata would not be schema-validated, would duplicate formatting across fourteen sources, and would make the tools list opaque to XML processing.
 
@@ -78,8 +82,9 @@ Verification will cover:
 
 - all command XML sources validate against the updated XSD;
 - every inventoried generated Markdown file starts with valid frontmatter;
-- each XML tool value appears in the corresponding YAML `tools` sequence;
-- the Markdown following the closing delimiter preserves the previous command content;
+- every parsed metadata value matches the maintainer-approved value in the corresponding XML source;
+- each XML tool value appears in the corresponding YAML `tools` sequence in the same order;
+- the bytes following the closing delimiter and its required separator match the previous generated command Markdown byte-for-byte;
 - `004-commands-installation/assets/commands` contains exactly one corresponding asset for every inventory entry; and
 - `./mvnw clean verify -pl plinth-skills-generator -am` exercises the integrated path.
 
@@ -96,10 +101,10 @@ Later approved acceptance criteria supersede the earlier direct `.cursor/command
 
 ## Risks / Trade-offs
 
-- **Incorrect YAML escaping could create frontmatter that looks plausible but is invalid** → validate generated metadata as YAML and include representative punctuation in renderer tests.
+- **Incorrect YAML escaping could create frontmatter that looks plausible but is invalid** → parse generated metadata with a test-scoped YAML 1.2 parser and include apostrophes, colons, hashes, brackets, backslashes, and whitespace boundaries in renderer tests.
 - **Command-specific metadata may drift from command behavior** → keep metadata in the same XML source and add per-command contract assertions where routing or tool access matters.
 - **A partial migration could leave installer output inconsistent** → require frontmatter in the XSD and verify every inventory entry.
-- **Prepending metadata could alter existing command bodies through whitespace changes** → compare the content after the closing delimiter with the previous generated body.
+- **Prepending metadata could alter existing command bodies through whitespace changes** → compare the content after the closing delimiter and required separator with the previous generated body byte-for-byte.
 - **Cursor-compatible metadata may be ignored or interpreted differently by other installer destinations** → preserve the body and document that this change guarantees the approved Cursor format only.
 
 ## Migration Plan
@@ -107,7 +112,7 @@ Later approved acceptance criteria supersede the earlier direct `.cursor/command
 1. Extend `commands.xsd` with the required frontmatter subtree and repeatable tool representation.
 2. Add reviewed metadata to every XML source declared by `commands.xml`.
 3. Update the XSLT to prepend YAML frontmatter while preserving the existing body templates.
-4. Add focused schema, renderer, inventory, bridge, and installer-asset tests.
+4. Add focused schema, YAML parsing, approved-metadata, ordered-tool, body-parity, inventory, bridge, and installer-asset tests.
 5. Run XML validation and `./mvnw clean verify -pl plinth-skills-generator -am`.
 6. Inspect `.agents/skills/004-commands-installation/assets/commands` for complete, valid output.
 
@@ -115,5 +120,4 @@ Rollback removes the frontmatter subtree, renderer prefix, migrated metadata, an
 
 ## Open Questions
 
-- Which exact description, argument hint, and tool list is approved for each of the fourteen commands? Implementation must review these values command by command rather than copy one example blindly.
-- Which test-scope YAML validation mechanism best proves syntactic validity without adding a production runtime dependency? This is an implementation choice; the requirement to validate generated YAML is fixed.
+There are no remaining design questions. The maintainer will approve the exact metadata values for each of the fourteen commands during migration, and generated YAML will be verified with SnakeYAML Engine in test scope.

--- a/documentation/openspec/changes/add-command-frontmatter-metadata/proposal.md
+++ b/documentation/openspec/changes/add-command-frontmatter-metadata/proposal.md
@@ -8,8 +8,9 @@ Generated Plinth command Markdown currently begins with the command heading and 
 - Emit valid YAML frontmatter before the existing Markdown heading for every command declared by the command inventory.
 - Preserve the existing Markdown command content after the generated frontmatter.
 - Propagate the generated command files through the existing Maven bridge into `.agents/skills/004-commands-installation/assets/commands`.
-- Add schema, rendering, inventory-coverage, propagation, and content-preservation verification.
-- No breaking consumer change is intended: the command body and file names remain stable, while metadata is prepended for Cursor compatibility.
+- Add schema, rendering, approved-metadata, inventory-coverage, propagation, and byte-for-byte body-preservation verification.
+- Preserve XML tool-list order in the generated YAML sequence and validate the resulting frontmatter with a test-scoped YAML 1.2 parser.
+- No command-body or file-name breaking change is intended; the prepended metadata is guaranteed for Cursor compatibility only.
 
 ## Capabilities
 
@@ -47,4 +48,5 @@ This is one-way derivation. This change does not update or synchronize the sourc
 - The issue shows all frontmatter fields, while the Functional Specification leaves XML required/optional/default cardinalities unresolved. The design resolves this by requiring the complete frontmatter subtree for every command so partial metadata cannot pass schema validation.
 - The Functional Specification mentions direct `.cursor/commands` consumption, while the later approved acceptance criteria establishes the build boundary at `.agents/skills/004-commands-installation/assets/commands`. The later acceptance criteria governs this change; installation into a selected tool directory remains the installer skill's responsibility.
 - The Functional Specification leaves global versus command-specific tool values unresolved. The design resolves this by requiring each command source to declare its own repeatable `tools/list-tools/tool` entries without assuming that all commands use different values.
-- Exact per-command descriptions, argument hints, and tool values, plus the test-scope YAML validation mechanism, remain open for implementation review and are tracked in `design.md` and `tasks.md`.
+- Exact per-command descriptions, argument hints, model, agent, and ordered tool values require maintainer approval during migration and are verified against each command source.
+- Generated frontmatter is parsed in tests with a test-scoped YAML 1.2 parser; this introduces no production runtime dependency.

--- a/documentation/openspec/changes/add-command-frontmatter-metadata/proposal.md
+++ b/documentation/openspec/changes/add-command-frontmatter-metadata/proposal.md
@@ -4,7 +4,7 @@ Generated Plinth command Markdown currently begins with the command heading and 
 
 ## What Changes
 
-- Extend the command XML contract so each command can declare frontmatter metadata, including a structured `tools/list-tools/tool` list.
+- Extend the command XML contract so each command can declare a required `metadata` element, including a structured `tools/tools-list/tool` list used to render YAML frontmatter.
 - Emit valid YAML frontmatter before the existing Markdown heading for every command declared by the command inventory.
 - Preserve the existing Markdown command content after the generated frontmatter.
 - Propagate the generated command files through the existing Maven bridge into `.agents/skills/004-commands-installation/assets/commands`.
@@ -20,7 +20,7 @@ None.
 
 ### Modified Capabilities
 
-- `pml-commands-schema`: Add structured command-frontmatter metadata to the authoritative XML source contract and generated Markdown behavior.
+- `pml-commands-schema`: Add structured command metadata to the authoritative XML source contract and generated YAML-frontmatter behavior.
 - `commands-generator-module`: Require the complete frontmatter-enabled command bundle to propagate into the generated `004-commands-installation` skill assets.
 
 ## Impact
@@ -45,8 +45,8 @@ This is one-way derivation. This change does not update or synchronize the sourc
 
 ## Questions and Conflict Resolution
 
-- The issue shows all frontmatter fields, while the Functional Specification leaves XML required/optional/default cardinalities unresolved. The design resolves this by requiring the complete frontmatter subtree for every command so partial metadata cannot pass schema validation.
+- The issue shows all YAML frontmatter fields, while the Functional Specification leaves XML required/optional/default cardinalities unresolved. The design resolves this by requiring the complete XML `metadata` subtree for every command so partial metadata cannot pass schema validation.
 - The Functional Specification mentions direct `.cursor/commands` consumption, while the later approved acceptance criteria establishes the build boundary at `.agents/skills/004-commands-installation/assets/commands`. The later acceptance criteria governs this change; installation into a selected tool directory remains the installer skill's responsibility.
-- The Functional Specification leaves global versus command-specific tool values unresolved. The design resolves this by requiring each command source to declare its own repeatable `tools/list-tools/tool` entries without assuming that all commands use different values.
+- The Functional Specification leaves global versus command-specific tool values unresolved. The design resolves this by requiring each command source to declare its own repeatable `tools/tools-list/tool` entries without assuming that all commands use different values.
 - Exact per-command descriptions, argument hints, model, agent, and ordered tool values require maintainer approval during migration and are verified against each command source.
 - Generated frontmatter is parsed in tests with a test-scoped YAML 1.2 parser; this introduces no production runtime dependency.

--- a/documentation/openspec/changes/add-command-frontmatter-metadata/proposal.md
+++ b/documentation/openspec/changes/add-command-frontmatter-metadata/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+Generated Plinth command Markdown currently begins with the command heading and omits the YAML frontmatter required for consistent Cursor command metadata. Issue [#1075](https://github.com/jabrena/plinth/issues/1075) establishes that the XML source model, generator, and embedded installer assets must carry that metadata without changing the existing command body.
+
+## What Changes
+
+- Extend the command XML contract so each command can declare frontmatter metadata, including a structured `tools/list-tools/tool` list.
+- Emit valid YAML frontmatter before the existing Markdown heading for every command declared by the command inventory.
+- Preserve the existing Markdown command content after the generated frontmatter.
+- Propagate the generated command files through the existing Maven bridge into `.agents/skills/004-commands-installation/assets/commands`.
+- Add schema, rendering, inventory-coverage, propagation, and content-preservation verification.
+- No breaking consumer change is intended: the command body and file names remain stable, while metadata is prepended for Cursor compatibility.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `pml-commands-schema`: Add structured command-frontmatter metadata to the authoritative XML source contract and generated Markdown behavior.
+- `commands-generator-module`: Require the complete frontmatter-enabled command bundle to propagate into the generated `004-commands-installation` skill assets.
+
+## Impact
+
+- **Source model:** `plinth-commands-generator/src/main/resources/commands.xsd` and every XML command source in the inventory.
+- **Rendering:** `command-to-markdown.xsl` and command renderer/generator tests.
+- **Skill packaging:** the existing `plinth-skills-generator` command bridge, `skills.xml` resource mappings, and generated `004-commands-installation/assets/commands` verification.
+- **Build:** `./mvnw clean verify -pl plinth-skills-generator -am` remains the integrated verification command.
+- **Migration:** all existing command XML documents must acquire the agreed metadata while preserving their generated Markdown bodies.
+- **Cross-tool compatibility:** the frontmatter format is based on the Cursor-compatible structure approved in issue #1075; no claim is made that every field is portable to every command framework.
+
+## Source Artifacts and Derivation
+
+| Source | Authority | Derivation direction |
+|---|---|---|
+| [Issue #1075](https://github.com/jabrena/plinth/issues/1075) | Problem, value, proposed frontmatter structure, and inventory-wide scope | Issue to OpenSpec |
+| [Functional Specification comment](https://github.com/jabrena/plinth/issues/1075#issuecomment-5051702405) | Root cause, constraints, context, assumptions, and quality priorities | Comment to OpenSpec |
+| [Acceptance Criteria comment](https://github.com/jabrena/plinth/issues/1075#issuecomment-5051757491) | Approved observable build and packaging behavior | Comment to OpenSpec |
+| Current command XML, XSD, XSLT, and Maven bridge | Existing implementation boundaries and compatibility baseline | Repository to OpenSpec design |
+
+This is one-way derivation. This change does not update or synchronize the source issue or its comments.
+
+## Questions and Conflict Resolution
+
+- The issue shows all frontmatter fields, while the Functional Specification leaves XML required/optional/default cardinalities unresolved. The design resolves this by requiring the complete frontmatter subtree for every command so partial metadata cannot pass schema validation.
+- The Functional Specification mentions direct `.cursor/commands` consumption, while the later approved acceptance criteria establishes the build boundary at `.agents/skills/004-commands-installation/assets/commands`. The later acceptance criteria governs this change; installation into a selected tool directory remains the installer skill's responsibility.
+- The Functional Specification leaves global versus command-specific tool values unresolved. The design resolves this by requiring each command source to declare its own repeatable `tools/list-tools/tool` entries without assuming that all commands use different values.
+- Exact per-command descriptions, argument hints, and tool values, plus the test-scope YAML validation mechanism, remain open for implementation review and are tracked in `design.md` and `tasks.md`.

--- a/documentation/openspec/changes/add-command-frontmatter-metadata/specs/commands-generator-module/spec.md
+++ b/documentation/openspec/changes/add-command-frontmatter-metadata/specs/commands-generator-module/spec.md
@@ -11,13 +11,15 @@ The build MUST prove that frontmatter-enabled command assets from `plinth-comman
 - **THEN** `assets/commands` contains one Markdown asset for every command listed in `commands.xml`
 - **AND** every embedded command asset begins with valid YAML frontmatter
 - **AND** every embedded command retains its existing Markdown content after the frontmatter
-- **AND** the asset file names and inventory order remain unchanged
+- **AND** the set of asset file names remains unchanged
+- **AND** no filesystem directory order is used as an acceptance condition
 
 #### Scenario: Generated 001 skill lists the command inventory
 
 - **GIVEN** `./mvnw clean verify -pl plinth-skills-generator -am` has been executed
 - **WHEN** generated output under `.agents/skills/001-commands-inventory` is inspected
 - **THEN** `references/001-commands-inventory.md` lists every command row corresponding to `commands.xml`
+- **AND** the generated inventory preserves the command order declared by `commands.xml`
 - **AND** no command from `plinth-commands-generator` is missing from the generated `001` inventory or `004` installer assets
 
 #### Scenario: Propagate command-specific tool metadata
@@ -25,6 +27,7 @@ The build MUST prove that frontmatter-enabled command assets from `plinth-comman
 - **GIVEN** an inventoried command source declares `tools/list-tools/tool` entries
 - **WHEN** the generated `004-commands-installation` asset for that command is inspected
 - **THEN** its YAML frontmatter contains the corresponding `tools` sequence entries
+- **AND** the YAML sequence preserves their XML document order
 - **AND** the bridge does not replace them with a global or stale tool list
 
 #### Scenario: Automated guard fails when frontmatter propagation breaks

--- a/documentation/openspec/changes/add-command-frontmatter-metadata/specs/commands-generator-module/spec.md
+++ b/documentation/openspec/changes/add-command-frontmatter-metadata/specs/commands-generator-module/spec.md
@@ -24,7 +24,7 @@ The build MUST prove that frontmatter-enabled command assets from `plinth-comman
 
 #### Scenario: Propagate command-specific tool metadata
 
-- **GIVEN** an inventoried command source declares `tools/list-tools/tool` entries
+- **GIVEN** an inventoried command source declares `tools/tools-list/tool` entries
 - **WHEN** the generated `004-commands-installation` asset for that command is inspected
 - **THEN** its YAML frontmatter contains the corresponding `tools` sequence entries
 - **AND** the YAML sequence preserves their XML document order

--- a/documentation/openspec/changes/add-command-frontmatter-metadata/specs/commands-generator-module/spec.md
+++ b/documentation/openspec/changes/add-command-frontmatter-metadata/specs/commands-generator-module/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Command-to-skill propagation verification
+
+The build MUST prove that frontmatter-enabled command assets from `plinth-commands-generator` reach generated skills for `001-commands-inventory` and `004-commands-installation` without losing inventory coverage or command content.
+
+#### Scenario: Generated 004 skill packages frontmatter-enabled command assets
+
+- **GIVEN** `./mvnw clean verify -pl plinth-skills-generator -am` has been executed
+- **WHEN** generated output under `.agents/skills/004-commands-installation` is inspected
+- **THEN** `assets/commands` contains one Markdown asset for every command listed in `commands.xml`
+- **AND** every embedded command asset begins with valid YAML frontmatter
+- **AND** every embedded command retains its existing Markdown content after the frontmatter
+- **AND** the asset file names and inventory order remain unchanged
+
+#### Scenario: Generated 001 skill lists the command inventory
+
+- **GIVEN** `./mvnw clean verify -pl plinth-skills-generator -am` has been executed
+- **WHEN** generated output under `.agents/skills/001-commands-inventory` is inspected
+- **THEN** `references/001-commands-inventory.md` lists every command row corresponding to `commands.xml`
+- **AND** no command from `plinth-commands-generator` is missing from the generated `001` inventory or `004` installer assets
+
+#### Scenario: Propagate command-specific tool metadata
+
+- **GIVEN** an inventoried command source declares `tools/list-tools/tool` entries
+- **WHEN** the generated `004-commands-installation` asset for that command is inspected
+- **THEN** its YAML frontmatter contains the corresponding `tools` sequence entries
+- **AND** the bridge does not replace them with a global or stale tool list
+
+#### Scenario: Automated guard fails when frontmatter propagation breaks
+
+- **GIVEN** `plinth-skills-generator` has generator tests for command-backed skills
+- **WHEN** `./mvnw clean verify -pl plinth-skills-generator -am` is executed
+- **THEN** the tests verify inventory parity, frontmatter presence and validity, command-specific tool propagation, and existing body preservation
+- **AND** verification fails when an inventoried asset is removed, renamed, not staged, or loses its required frontmatter

--- a/documentation/openspec/changes/add-command-frontmatter-metadata/specs/pml-commands-schema/spec.md
+++ b/documentation/openspec/changes/add-command-frontmatter-metadata/specs/pml-commands-schema/spec.md
@@ -52,10 +52,19 @@ Command contracts SHALL be authored as XML under `commands/` and transformed to 
 - **WHEN** the command Markdown is generated
 - **THEN** its frontmatter contains a YAML `tools` sequence
 - **AND** every declared XML tool appears as a corresponding YAML sequence entry
+- **AND** the YAML sequence preserves the XML `tool` document order
+
+#### Scenario: Render approved command-specific metadata
+
+- **GIVEN** the maintainer-approved frontmatter values are recorded in each inventoried command XML source
+- **WHEN** the generated frontmatter is parsed as YAML 1.2
+- **THEN** `description`, `argument-hint`, `model`, and `agent` equal the corresponding XML values
+- **AND** `tools` equals the complete ordered `tools/list-tools/tool` sequence from that command source
+- **AND** YAML-significant punctuation in scalar values remains valid and retains its parsed meaning
 
 #### Scenario: Preserve existing Markdown after frontmatter
 
 - **GIVEN** a command has an existing generated Markdown heading and body
 - **WHEN** frontmatter generation is enabled
 - **THEN** the heading and body follow the closing YAML delimiter
-- **AND** their semantic content remains unchanged
+- **AND** after removing the frontmatter and its required separator, the remaining Markdown matches the previous generated command Markdown byte-for-byte

--- a/documentation/openspec/changes/add-command-frontmatter-metadata/specs/pml-commands-schema/spec.md
+++ b/documentation/openspec/changes/add-command-frontmatter-metadata/specs/pml-commands-schema/spec.md
@@ -1,0 +1,61 @@
+## MODIFIED Requirements
+
+### Requirement: Command body XSD (agents parity)
+
+The commands generator SHALL validate individual command contracts with a single no-namespace `commands.xsd` colocated at `plinth-commands-generator/src/main/resources/commands.xsd`, following the same style as `agents.xsd` while adding the command-specific frontmatter contract.
+
+#### Scenario: Validate structural command contract sections
+
+- **GIVEN** a command definition document with required `@id`
+- **WHEN** `commands.xsd` is applied
+- **THEN** the schema requires `frontmatter`, `goal`, and `steps`, with optional `constraints`, `output-format`, and `safeguards` in the defined sequence
+- **AND** `frontmatter` requires `description`, `argument-hint`, `model`, `agent`, and `tools`
+- **AND** `tools` requires `list-tools` containing one or more `tool` elements
+- **AND** optional `output-format` is expressible in the structural sequence
+- **AND** narrative contract content remains authored as Markdown inside `goal` CDATA
+- **AND** documents missing a required section or frontmatter field fail XSD validation
+- **AND** documents declare `xsi:noNamespaceSchemaLocation` pointing at `commands.xsd`
+
+#### Scenario: Keep frontmatter values extensible per command
+
+- **GIVEN** different commands can require different descriptions, argument hints, agents, models, or tools
+- **WHEN** their XML documents validate against `commands.xsd`
+- **THEN** the schema enforces the frontmatter structure and repeating tool representation
+- **AND** the schema does not restrict model, agent, or tool values to a closed enumeration
+- **AND** each command source can declare its own `tools/list-tools/tool` entries
+
+#### Scenario: Align with analysis-design-commands contract fields
+
+- **GIVEN** OpenSpec `analysis-design-commands` requires purpose, accepted inputs, owning agent, associated skills or capabilities, workflow, outputs, and safeguards
+- **WHEN** the command body XSD and XSLT are applied
+- **THEN** frontmatter, workflow, outputs, and safeguards map to structured XML elements; purpose and remaining narrative fields map to Markdown inside `goal` CDATA
+- **AND** kind-specific required or forbidden sections remain enforced by `analysis-design-commands`, `CommandIndexesTest`, and Gherkin rather than Schematron
+- **AND** body `@id` matches the generated Markdown H1 identity
+
+### Requirement: XML sources and generated Markdown
+
+Command contracts SHALL be authored as XML under `commands/` and transformed to frontmatter-enabled Markdown only under `target/`, mirroring agents generation while preserving the existing command body.
+
+#### Scenario: Build-time Markdown generation
+
+- **GIVEN** every command XML source declared by `commands.xml` contains schema-valid frontmatter metadata
+- **WHEN** Maven reaches `process-classes` for `plinth-commands-generator`
+- **THEN** `CommandMarkdownGenerator` writes Markdown to `target/generated-resources/commands` and `target/classes/commands`
+- **AND** every generated file begins with an opening YAML delimiter and ends its frontmatter before the command H1
+- **AND** the generated frontmatter contains `description`, `argument-hint`, `model`, `agent`, and `tools`
+- **AND** hand-authored `commands/*.md` are not present under `src/main/resources/commands/`
+- **AND** `CommandIndexesTest` assertions pass against the generated classpath Markdown
+
+#### Scenario: Map XML tools to YAML tools
+
+- **GIVEN** a command source declares one or more `tools/list-tools/tool` values
+- **WHEN** the command Markdown is generated
+- **THEN** its frontmatter contains a YAML `tools` sequence
+- **AND** every declared XML tool appears as a corresponding YAML sequence entry
+
+#### Scenario: Preserve existing Markdown after frontmatter
+
+- **GIVEN** a command has an existing generated Markdown heading and body
+- **WHEN** frontmatter generation is enabled
+- **THEN** the heading and body follow the closing YAML delimiter
+- **AND** their semantic content remains unchanged

--- a/documentation/openspec/changes/add-command-frontmatter-metadata/specs/pml-commands-schema/spec.md
+++ b/documentation/openspec/changes/add-command-frontmatter-metadata/specs/pml-commands-schema/spec.md
@@ -2,33 +2,34 @@
 
 ### Requirement: Command body XSD (agents parity)
 
-The commands generator SHALL validate individual command contracts with a single no-namespace `commands.xsd` colocated at `plinth-commands-generator/src/main/resources/commands.xsd`, following the same style as `agents.xsd` while adding the command-specific frontmatter contract.
+The commands generator SHALL validate individual command contracts with a single no-namespace `commands.xsd` colocated at `plinth-commands-generator/src/main/resources/commands.xsd`, following the same global-element reference style as `agents.xsd` while adding the command-specific XML metadata contract used to render YAML frontmatter.
 
 #### Scenario: Validate structural command contract sections
 
 - **GIVEN** a command definition document with required `@id`
 - **WHEN** `commands.xsd` is applied
-- **THEN** the schema requires `frontmatter`, `goal`, and `steps`, with optional `constraints`, `output-format`, and `safeguards` in the defined sequence
-- **AND** `frontmatter` requires `description`, `argument-hint`, `model`, `agent`, and `tools`
-- **AND** `tools` requires `list-tools` containing one or more `tool` elements
+- **THEN** the schema requires `metadata`, `goal`, and `steps`, with optional `constraints`, `output-format`, and `safeguards` in the defined sequence
+- **AND** the command and `metadata` sequences compose global elements through `xs:element ref`, following the `agents.xsd` convention
+- **AND** `metadata` requires `description`, `argument-hint`, `model`, `agent`, and `tools`
+- **AND** `tools` requires `tools-list` containing one or more `tool` elements
 - **AND** optional `output-format` is expressible in the structural sequence
 - **AND** narrative contract content remains authored as Markdown inside `goal` CDATA
-- **AND** documents missing a required section or frontmatter field fail XSD validation
+- **AND** documents missing a required section or metadata field fail XSD validation
 - **AND** documents declare `xsi:noNamespaceSchemaLocation` pointing at `commands.xsd`
 
-#### Scenario: Keep frontmatter values extensible per command
+#### Scenario: Keep metadata values extensible per command
 
 - **GIVEN** different commands can require different descriptions, argument hints, agents, models, or tools
 - **WHEN** their XML documents validate against `commands.xsd`
-- **THEN** the schema enforces the frontmatter structure and repeating tool representation
+- **THEN** the schema enforces the metadata structure and repeating tool representation
 - **AND** the schema does not restrict model, agent, or tool values to a closed enumeration
-- **AND** each command source can declare its own `tools/list-tools/tool` entries
+- **AND** each command source can declare its own `tools/tools-list/tool` entries
 
 #### Scenario: Align with analysis-design-commands contract fields
 
 - **GIVEN** OpenSpec `analysis-design-commands` requires purpose, accepted inputs, owning agent, associated skills or capabilities, workflow, outputs, and safeguards
 - **WHEN** the command body XSD and XSLT are applied
-- **THEN** frontmatter, workflow, outputs, and safeguards map to structured XML elements; purpose and remaining narrative fields map to Markdown inside `goal` CDATA
+- **THEN** metadata, workflow, outputs, and safeguards map to structured XML elements; purpose and remaining narrative fields map to Markdown inside `goal` CDATA
 - **AND** kind-specific required or forbidden sections remain enforced by `analysis-design-commands`, `CommandIndexesTest`, and Gherkin rather than Schematron
 - **AND** body `@id` matches the generated Markdown H1 identity
 
@@ -38,7 +39,7 @@ Command contracts SHALL be authored as XML under `commands/` and transformed to 
 
 #### Scenario: Build-time Markdown generation
 
-- **GIVEN** every command XML source declared by `commands.xml` contains schema-valid frontmatter metadata
+- **GIVEN** every command XML source declared by `commands.xml` contains schema-valid XML `metadata`
 - **WHEN** Maven reaches `process-classes` for `plinth-commands-generator`
 - **THEN** `CommandMarkdownGenerator` writes Markdown to `target/generated-resources/commands` and `target/classes/commands`
 - **AND** every generated file begins with an opening YAML delimiter and ends its frontmatter before the command H1
@@ -48,7 +49,7 @@ Command contracts SHALL be authored as XML under `commands/` and transformed to 
 
 #### Scenario: Map XML tools to YAML tools
 
-- **GIVEN** a command source declares one or more `tools/list-tools/tool` values
+- **GIVEN** a command source declares one or more `tools/tools-list/tool` values
 - **WHEN** the command Markdown is generated
 - **THEN** its frontmatter contains a YAML `tools` sequence
 - **AND** every declared XML tool appears as a corresponding YAML sequence entry
@@ -56,10 +57,10 @@ Command contracts SHALL be authored as XML under `commands/` and transformed to 
 
 #### Scenario: Render approved command-specific metadata
 
-- **GIVEN** the maintainer-approved frontmatter values are recorded in each inventoried command XML source
+- **GIVEN** the maintainer-approved YAML-frontmatter values are recorded in each inventoried command XML `metadata` element
 - **WHEN** the generated frontmatter is parsed as YAML 1.2
 - **THEN** `description`, `argument-hint`, `model`, and `agent` equal the corresponding XML values
-- **AND** `tools` equals the complete ordered `tools/list-tools/tool` sequence from that command source
+- **AND** `tools` equals the complete ordered `tools/tools-list/tool` sequence from that command source
 - **AND** YAML-significant punctuation in scalar values remains valid and retains its parsed meaning
 
 #### Scenario: Preserve existing Markdown after frontmatter

--- a/documentation/openspec/changes/add-command-frontmatter-metadata/tasks.md
+++ b/documentation/openspec/changes/add-command-frontmatter-metadata/tasks.md
@@ -1,20 +1,22 @@
 ## 1. Command Metadata Contract
 
-- [ ] 1.1 Review and approve the `description`, `argument-hint`, `model`, `agent`, and command-specific tool values for all fourteen entries in `plinth-commands-generator/src/main/resources/commands.xml`.
+- [ ] 1.1 Review, record, and obtain maintainer approval for the `description`, `argument-hint`, `model`, `agent`, and ordered command-specific tool values for all fourteen entries in `plinth-commands-generator/src/main/resources/commands.xml`.
 - [ ] 1.2 Extend `plinth-commands-generator/src/main/resources/commands.xsd` with the required `frontmatter` subtree and the repeating `tools/list-tools/tool` structure.
 - [ ] 1.3 Add the approved frontmatter metadata to every XML source under `plinth-commands-generator/src/main/resources/commands/` without changing its narrative command contract.
-- [ ] 1.4 Run `xmllint --noout` and schema validation for the updated XSD and all inventoried command XML sources before changing rendering.
+- [ ] 1.4 Add automated XSD contract tests that validate all inventoried sources and prove that missing required fields and zero-tool frontmatter fail while one-tool and multiple-tool frontmatter pass.
+- [ ] 1.5 Run `xmllint --noout` and schema validation for the updated XSD and all inventoried command XML sources before changing rendering.
 
 ## 2. Frontmatter Rendering
 
 - [ ] 2.1 Obtain the repository-required maintainer approval before modifying `plinth-commands-generator/src/main/resources/command-to-markdown.xsl`.
-- [ ] 2.2 Update `command-to-markdown.xsl` to emit valid YAML frontmatter before the command H1 and map each `tools/list-tools/tool` value to the YAML `tools` sequence.
-- [ ] 2.3 Preserve the existing rendering of `goal`, `constraints`, `steps`, `output-format`, and `safeguards` after the closing YAML delimiter.
-- [ ] 2.4 Add focused `plinth-commands-generator` tests that validate required frontmatter fields, YAML syntax, command-specific tool mapping, complete inventory coverage, and preservation of the pre-existing Markdown body.
+- [ ] 2.2 Update `command-to-markdown.xsl` to use one named YAML-scalar template, emit safely single-quoted values with embedded apostrophes doubled, and map each `tools/list-tools/tool` value to the YAML sequence in XML document order.
+- [ ] 2.3 Preserve the existing rendering of `goal`, `constraints`, `steps`, `output-format`, and `safeguards` byte-for-byte after the closing YAML delimiter and its required separator.
+- [ ] 2.4 Add SnakeYAML Engine as a test-scoped YAML 1.2 parser without adding a production runtime dependency.
+- [ ] 2.5 Add focused `plinth-commands-generator` tests that parse and compare all approved metadata values, validate punctuation and whitespace boundaries, assert ordered one-tool and multiple-tool mappings, cover the complete inventory, and compare the post-frontmatter Markdown with the previous generated body byte-for-byte.
 
 ## 3. Installer Asset Propagation
 
-- [ ] 3.1 Extend `plinth-skills-generator` bridge and propagation tests to assert that every generated `004-commands-installation/assets/commands` file contains the corresponding frontmatter-enabled command output.
+- [ ] 3.1 Extend `plinth-skills-generator` bridge and propagation tests to assert that every generated `004-commands-installation/assets/commands` file contains the corresponding frontmatter-enabled command output, including parsed metadata values and ordered tools.
 - [ ] 3.2 Update `CommandInstallerParityTest`, `CommandBridgeTest`, or `CommandSkillPropagationTest` as appropriate so missing, stale, or metadata-stripped command assets fail verification.
 - [ ] 3.3 Confirm that `001-commands-inventory` retains the same command names and order and that `004-commands-installation` retains the same fourteen asset file names.
 - [ ] 3.4 Verify that no generated command Markdown or `.agents/skills` output is edited directly and that the public `skills/` release output remains untouched.
@@ -23,6 +25,6 @@
 
 - [ ] 4.1 Run `./mvnw clean verify -pl plinth-commands-generator` and resolve schema, rendering, and command-contract failures.
 - [ ] 4.2 Run `./mvnw clean verify -pl plinth-skills-generator -am` and confirm the complete command generation and skill-packaging reactor succeeds.
-- [ ] 4.3 Inspect every file under `.agents/skills/004-commands-installation/assets/commands` for valid frontmatter, matching XML tool entries, unchanged Markdown bodies, and exact inventory parity.
+- [ ] 4.3 Use automated tests as the pass/fail gate, then spot-check representative files under `.agents/skills/004-commands-installation/assets/commands` for valid frontmatter, matching ordered XML tool entries, byte-for-byte preserved Markdown bodies, and exact filename parity.
 - [ ] 4.4 Execute only the listed `004-commands-installation.feature` acceptance prompt because that generated skill output changes; record the reason for any skipped prompt.
 - [ ] 4.5 Run `openspec validate --all` from `documentation/` and resolve every validation error before implementation promotion.

--- a/documentation/openspec/changes/add-command-frontmatter-metadata/tasks.md
+++ b/documentation/openspec/changes/add-command-frontmatter-metadata/tasks.md
@@ -1,0 +1,28 @@
+## 1. Command Metadata Contract
+
+- [ ] 1.1 Review and approve the `description`, `argument-hint`, `model`, `agent`, and command-specific tool values for all fourteen entries in `plinth-commands-generator/src/main/resources/commands.xml`.
+- [ ] 1.2 Extend `plinth-commands-generator/src/main/resources/commands.xsd` with the required `frontmatter` subtree and the repeating `tools/list-tools/tool` structure.
+- [ ] 1.3 Add the approved frontmatter metadata to every XML source under `plinth-commands-generator/src/main/resources/commands/` without changing its narrative command contract.
+- [ ] 1.4 Run `xmllint --noout` and schema validation for the updated XSD and all inventoried command XML sources before changing rendering.
+
+## 2. Frontmatter Rendering
+
+- [ ] 2.1 Obtain the repository-required maintainer approval before modifying `plinth-commands-generator/src/main/resources/command-to-markdown.xsl`.
+- [ ] 2.2 Update `command-to-markdown.xsl` to emit valid YAML frontmatter before the command H1 and map each `tools/list-tools/tool` value to the YAML `tools` sequence.
+- [ ] 2.3 Preserve the existing rendering of `goal`, `constraints`, `steps`, `output-format`, and `safeguards` after the closing YAML delimiter.
+- [ ] 2.4 Add focused `plinth-commands-generator` tests that validate required frontmatter fields, YAML syntax, command-specific tool mapping, complete inventory coverage, and preservation of the pre-existing Markdown body.
+
+## 3. Installer Asset Propagation
+
+- [ ] 3.1 Extend `plinth-skills-generator` bridge and propagation tests to assert that every generated `004-commands-installation/assets/commands` file contains the corresponding frontmatter-enabled command output.
+- [ ] 3.2 Update `CommandInstallerParityTest`, `CommandBridgeTest`, or `CommandSkillPropagationTest` as appropriate so missing, stale, or metadata-stripped command assets fail verification.
+- [ ] 3.3 Confirm that `001-commands-inventory` retains the same command names and order and that `004-commands-installation` retains the same fourteen asset file names.
+- [ ] 3.4 Verify that no generated command Markdown or `.agents/skills` output is edited directly and that the public `skills/` release output remains untouched.
+
+## 4. Integrated Validation
+
+- [ ] 4.1 Run `./mvnw clean verify -pl plinth-commands-generator` and resolve schema, rendering, and command-contract failures.
+- [ ] 4.2 Run `./mvnw clean verify -pl plinth-skills-generator -am` and confirm the complete command generation and skill-packaging reactor succeeds.
+- [ ] 4.3 Inspect every file under `.agents/skills/004-commands-installation/assets/commands` for valid frontmatter, matching XML tool entries, unchanged Markdown bodies, and exact inventory parity.
+- [ ] 4.4 Execute only the listed `004-commands-installation.feature` acceptance prompt because that generated skill output changes; record the reason for any skipped prompt.
+- [ ] 4.5 Run `openspec validate --all` from `documentation/` and resolve every validation error before implementation promotion.

--- a/documentation/openspec/changes/add-command-frontmatter-metadata/tasks.md
+++ b/documentation/openspec/changes/add-command-frontmatter-metadata/tasks.md
@@ -1,30 +1,30 @@
 ## 1. Command Metadata Contract
 
 - [ ] 1.1 Review, record, and obtain maintainer approval for the `description`, `argument-hint`, `model`, `agent`, and ordered command-specific tool values for all fourteen entries in `plinth-commands-generator/src/main/resources/commands.xml`.
-- [ ] 1.2 Extend `plinth-commands-generator/src/main/resources/commands.xsd` with the required `frontmatter` subtree and the repeating `tools/list-tools/tool` structure.
-- [ ] 1.3 Add the approved frontmatter metadata to every XML source under `plinth-commands-generator/src/main/resources/commands/` without changing its narrative command contract.
-- [ ] 1.4 Add automated XSD contract tests that validate all inventoried sources and prove that missing required fields and zero-tool frontmatter fail while one-tool and multiple-tool frontmatter pass.
-- [ ] 1.5 Run `xmllint --noout` and schema validation for the updated XSD and all inventoried command XML sources before changing rendering.
+- [x] 1.2 Extend `plinth-commands-generator/src/main/resources/commands.xsd` with the required agents-style `metadata` subtree and the repeating `tools/tools-list/tool` structure.
+- [ ] 1.3 Add the approved YAML-frontmatter values to each XML `metadata` element under `plinth-commands-generator/src/main/resources/commands/` without changing its narrative command contract.
+- [x] 1.4 Add automated XSD contract tests that validate all inventoried sources and prove that missing required fields and zero-tool metadata fail while one-tool and multiple-tool metadata pass.
+- [x] 1.5 Run `xmllint --noout` and schema validation for the updated XSD and all inventoried command XML sources before changing rendering.
 
 ## 2. Frontmatter Rendering
 
-- [ ] 2.1 Obtain the repository-required maintainer approval before modifying `plinth-commands-generator/src/main/resources/command-to-markdown.xsl`.
-- [ ] 2.2 Update `command-to-markdown.xsl` to use one named YAML-scalar template, emit safely single-quoted values with embedded apostrophes doubled, and map each `tools/list-tools/tool` value to the YAML sequence in XML document order.
-- [ ] 2.3 Preserve the existing rendering of `goal`, `constraints`, `steps`, `output-format`, and `safeguards` byte-for-byte after the closing YAML delimiter and its required separator.
-- [ ] 2.4 Add SnakeYAML Engine as a test-scoped YAML 1.2 parser without adding a production runtime dependency.
-- [ ] 2.5 Add focused `plinth-commands-generator` tests that parse and compare all approved metadata values, validate punctuation and whitespace boundaries, assert ordered one-tool and multiple-tool mappings, cover the complete inventory, and compare the post-frontmatter Markdown with the previous generated body byte-for-byte.
+- [x] 2.1 Obtain the repository-required maintainer approval before modifying `plinth-commands-generator/src/main/resources/command-to-markdown.xsl`.
+- [x] 2.2 Update `command-to-markdown.xsl` to use one named YAML-scalar template, emit safely single-quoted values with embedded apostrophes doubled, and map each `tools/tools-list/tool` value to the YAML sequence in XML document order.
+- [x] 2.3 Preserve the existing rendering of `goal`, `constraints`, `steps`, `output-format`, and `safeguards` byte-for-byte after the closing YAML delimiter and its required separator.
+- [x] 2.4 Add SnakeYAML Engine as a test-scoped YAML 1.2 parser without adding a production runtime dependency.
+- [x] 2.5 Add focused `plinth-commands-generator` tests that parse and compare all approved XML-metadata/YAML-frontmatter values, validate punctuation and whitespace boundaries, assert ordered one-tool and multiple-tool mappings, cover the complete inventory, and compare the post-frontmatter Markdown with the previous generated body byte-for-byte.
 
 ## 3. Installer Asset Propagation
 
-- [ ] 3.1 Extend `plinth-skills-generator` bridge and propagation tests to assert that every generated `004-commands-installation/assets/commands` file contains the corresponding frontmatter-enabled command output, including parsed metadata values and ordered tools.
-- [ ] 3.2 Update `CommandInstallerParityTest`, `CommandBridgeTest`, or `CommandSkillPropagationTest` as appropriate so missing, stale, or metadata-stripped command assets fail verification.
-- [ ] 3.3 Confirm that `001-commands-inventory` retains the same command names and order and that `004-commands-installation` retains the same fourteen asset file names.
-- [ ] 3.4 Verify that no generated command Markdown or `.agents/skills` output is edited directly and that the public `skills/` release output remains untouched.
+- [x] 3.1 Extend `plinth-skills-generator` bridge and propagation tests to assert that every generated `004-commands-installation/assets/commands` file contains the corresponding frontmatter-enabled command output, including parsed metadata values and ordered tools.
+- [x] 3.2 Update `CommandInstallerParityTest`, `CommandBridgeTest`, or `CommandSkillPropagationTest` as appropriate so missing, stale, or metadata-stripped command assets fail verification.
+- [x] 3.3 Confirm that `001-commands-inventory` retains the same command names and order and that `004-commands-installation` retains the same fourteen asset file names.
+- [x] 3.4 Verify that no generated command Markdown or `.agents/skills` output is edited directly and that the public `skills/` release output remains untouched.
 
 ## 4. Integrated Validation
 
-- [ ] 4.1 Run `./mvnw clean verify -pl plinth-commands-generator` and resolve schema, rendering, and command-contract failures.
-- [ ] 4.2 Run `./mvnw clean verify -pl plinth-skills-generator -am` and confirm the complete command generation and skill-packaging reactor succeeds.
-- [ ] 4.3 Use automated tests as the pass/fail gate, then spot-check representative files under `.agents/skills/004-commands-installation/assets/commands` for valid frontmatter, matching ordered XML tool entries, byte-for-byte preserved Markdown bodies, and exact filename parity.
-- [ ] 4.4 Execute only the listed `004-commands-installation.feature` acceptance prompt because that generated skill output changes; record the reason for any skipped prompt.
-- [ ] 4.5 Run `openspec validate --all` from `documentation/` and resolve every validation error before implementation promotion.
+- [x] 4.1 Run `./mvnw clean verify -pl plinth-commands-generator` and resolve schema, rendering, and command-contract failures.
+- [x] 4.2 Run `./mvnw clean verify -pl plinth-skills-generator -am` and confirm the complete command generation and skill-packaging reactor succeeds.
+- [x] 4.3 Use automated tests as the pass/fail gate, then spot-check representative files under `.agents/skills/004-commands-installation/assets/commands` for valid frontmatter, matching ordered XML tool entries, byte-for-byte preserved Markdown bodies, and exact filename parity.
+- [x] 4.4 Execute only the listed `004-commands-installation.feature` acceptance prompt because that generated skill output changes; record the reason for any skipped prompt.
+- [x] 4.5 Run `openspec validate --all` from `documentation/` and resolve every validation error before implementation promotion.

--- a/plinth-commands-generator/pom.xml
+++ b/plinth-commands-generator/pom.xml
@@ -13,6 +13,10 @@
 
     <groupId>info.jab.pml</groupId>
     <artifactId>plinth-commands-generator</artifactId>
+
+    <properties>
+        <snakeyaml-engine.version>3.0.1</snakeyaml-engine.version>
+    </properties>
     <packaging>jar</packaging>
 
     <dependencies>
@@ -30,6 +34,12 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.snakeyaml</groupId>
+            <artifactId>snakeyaml-engine</artifactId>
+            <version>${snakeyaml-engine.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/plinth-commands-generator/src/main/resources/command-to-markdown.xsl
+++ b/plinth-commands-generator/src/main/resources/command-to-markdown.xsl
@@ -3,7 +3,7 @@
   Command XML → Cursor slash-command Markdown.
   Mirrors agent-to-markdown.xsl: narrative contract lives in goal CDATA;
   structured elements follow commands.xsd order:
-  goal → constraints → steps → output-format → safeguards
+  metadata → goal → constraints → steps → output-format → safeguards
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 version="1.0"
@@ -13,6 +13,40 @@
   <xsl:strip-space elements="command constraints constraint-list steps output-format output-format-list safeguards safeguards-list"/>
 
   <xsl:template match="/command">
+    <xsl:text>---
+description: </xsl:text>
+    <xsl:call-template name="yaml-single-quoted-scalar">
+      <xsl:with-param name="text" select="metadata/description"/>
+    </xsl:call-template>
+    <xsl:text>
+argument-hint: </xsl:text>
+    <xsl:call-template name="yaml-single-quoted-scalar">
+      <xsl:with-param name="text" select="metadata/argument-hint"/>
+    </xsl:call-template>
+    <xsl:text>
+model: </xsl:text>
+    <xsl:call-template name="yaml-single-quoted-scalar">
+      <xsl:with-param name="text" select="metadata/model"/>
+    </xsl:call-template>
+    <xsl:text>
+agent: </xsl:text>
+    <xsl:call-template name="yaml-single-quoted-scalar">
+      <xsl:with-param name="text" select="metadata/agent"/>
+    </xsl:call-template>
+    <xsl:text>
+tools:
+</xsl:text>
+    <xsl:for-each select="metadata/tools/tools-list/tool">
+      <xsl:text>  - </xsl:text>
+      <xsl:call-template name="yaml-single-quoted-scalar">
+        <xsl:with-param name="text" select="."/>
+      </xsl:call-template>
+      <xsl:text>
+</xsl:text>
+    </xsl:for-each>
+    <xsl:text>---
+
+</xsl:text>
     <xsl:text># </xsl:text>
     <xsl:value-of select="@id"/>
     <xsl:text>
@@ -23,6 +57,31 @@
     <xsl:apply-templates select="steps"/>
     <xsl:apply-templates select="output-format"/>
     <xsl:apply-templates select="safeguards"/>
+  </xsl:template>
+
+  <xsl:template name="yaml-single-quoted-scalar">
+    <xsl:param name="text"/>
+    <xsl:text>'</xsl:text>
+    <xsl:call-template name="yaml-single-quoted-content">
+      <xsl:with-param name="text" select="$text"/>
+    </xsl:call-template>
+    <xsl:text>'</xsl:text>
+  </xsl:template>
+
+  <xsl:template name="yaml-single-quoted-content">
+    <xsl:param name="text"/>
+    <xsl:choose>
+      <xsl:when test="contains($text, &quot;'&quot;)">
+        <xsl:value-of select="substring-before($text, &quot;'&quot;)"/>
+        <xsl:text>''</xsl:text>
+        <xsl:call-template name="yaml-single-quoted-content">
+          <xsl:with-param name="text" select="substring-after($text, &quot;'&quot;)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$text"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <!-- Goal already contains Markdown headings; emit trimmed body with no ## Goal wrapper -->

--- a/plinth-commands-generator/src/main/resources/commands.xsd
+++ b/plinth-commands-generator/src/main/resources/commands.xsd
@@ -3,10 +3,11 @@
            elementFormDefault="qualified">
 
     <!-- Root element for a single command definition document (inventory stays in commands.xml).
-         Sequence aligned with agents.xsd: goal → constraints → steps → output-format → safeguards -->
+         Sequence aligned with agents.xsd: metadata → goal → constraints → steps → output-format → safeguards -->
     <xs:element name="command">
         <xs:complexType>
             <xs:sequence>
+                <xs:element ref="metadata"/>
                 <xs:element ref="goal"/>
                 <xs:element ref="constraints" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element ref="steps"/>
@@ -16,6 +17,42 @@
             <xs:attribute name="id" type="xs:string" use="required"/>
         </xs:complexType>
     </xs:element>
+
+    <xs:element name="metadata">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="description"/>
+                <xs:element ref="argument-hint"/>
+                <xs:element ref="model"/>
+                <xs:element ref="agent"/>
+                <xs:element ref="tools"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <!-- Reuse the global PML vocabulary style used by metadata and agents. -->
+    <xs:element name="description" type="xs:string"/>
+    <xs:element name="argument-hint" type="xs:string"/>
+    <xs:element name="model" type="xs:string"/>
+    <xs:element name="agent" type="xs:string"/>
+
+    <xs:element name="tools">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="tools-list"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="tools-list">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="tool" minOccurs="1" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="tool" type="xs:string"/>
 
     <!-- Mixed text blocks for Markdown-heavy sections (agents-style goal CDATA) -->
     <xs:complexType name="MixedText" mixed="true">

--- a/plinth-commands-generator/src/main/resources/commands/benchmark.xml
+++ b/plinth-commands-generator/src/main/resources/commands/benchmark.xml
@@ -1,7 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <command id="benchmark"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="../commands.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../commands.xsd">
+
+    <metadata>
+        <description>Design and coordinate a reproducible Java performance test.</description>
+        <argument-hint>[target] [objective-or-threshold] [workload] [environment] [preferred-tool]</argument-hint>
+        <model>inherit</model>
+        <agent>inherit</agent>
+        <tools>
+            <tools-list>
+                <tool>Read</tool>
+                <tool>Write</tool>
+                <tool>Edit</tool>
+                <tool>Bash</tool>
+            </tools-list>
+        </tools>
+    </metadata>
 
     <goal><![CDATA[
 Select and coordinate an appropriate Java performance test with reproducible workload, environment, thresholds, and result artifacts.

--- a/plinth-commands-generator/src/main/resources/commands/benchmark.xml
+++ b/plinth-commands-generator/src/main/resources/commands/benchmark.xml
@@ -5,9 +5,9 @@
 
     <metadata>
         <description>Design and coordinate a reproducible Java performance test.</description>
-        <argument-hint>[target] [objective-or-threshold] [workload] [environment] [preferred-tool]</argument-hint>
+        <argument-hint>[target]</argument-hint>
         <model>inherit</model>
-        <agent>inherit</agent>
+        <agent>robot-java-performance</agent>
         <tools>
             <tools-list>
                 <tool>Read</tool>

--- a/plinth-commands-generator/src/main/resources/commands/close-spec.xml
+++ b/plinth-commands-generator/src/main/resources/commands/close-spec.xml
@@ -1,7 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <command id="close-spec"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="../commands.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../commands.xsd">
+
+    <metadata>
+        <description>Archive a completed OpenSpec change by name.</description>
+        <argument-hint>[change-name]</argument-hint>
+        <model>inherit</model>
+        <agent>inherit</agent>
+        <tools>
+            <tools-list>
+                <tool>Read</tool>
+                <tool>Bash</tool>
+            </tools-list>
+        </tools>
+    </metadata>
 
     <goal><![CDATA[
 Archive an OpenSpec change by name, using the OpenSpec CLI, so completed changes can be reconciled and removed from the active change list.

--- a/plinth-commands-generator/src/main/resources/commands/close-spec.xml
+++ b/plinth-commands-generator/src/main/resources/commands/close-spec.xml
@@ -5,9 +5,9 @@
 
     <metadata>
         <description>Archive a completed OpenSpec change by name.</description>
-        <argument-hint>[change-name]</argument-hint>
+        <argument-hint>[openspec-change]</argument-hint>
         <model>inherit</model>
-        <agent>inherit</agent>
+        <agent>robot-architect</agent>
         <tools>
             <tools-list>
                 <tool>Read</tool>

--- a/plinth-commands-generator/src/main/resources/commands/create-acceptance-criteria.xml
+++ b/plinth-commands-generator/src/main/resources/commands/create-acceptance-criteria.xml
@@ -7,7 +7,7 @@
         <description>Derive and post confirmed Gherkin acceptance criteria for an issue.</description>
         <argument-hint>[issue-url]</argument-hint>
         <model>inherit</model>
-        <agent>inherit</agent>
+        <agent>robot-business-analyst</agent>
         <tools>
             <tools-list>
                 <tool>Read</tool>

--- a/plinth-commands-generator/src/main/resources/commands/create-acceptance-criteria.xml
+++ b/plinth-commands-generator/src/main/resources/commands/create-acceptance-criteria.xml
@@ -1,7 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <command id="create-acceptance-criteria"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="../commands.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../commands.xsd">
+
+    <metadata>
+        <description>Derive and post confirmed Gherkin acceptance criteria for an issue.</description>
+        <argument-hint>[issue-url]</argument-hint>
+        <model>inherit</model>
+        <agent>inherit</agent>
+        <tools>
+            <tools-list>
+                <tool>Read</tool>
+                <tool>Bash</tool>
+            </tools-list>
+        </tools>
+    </metadata>
 
     <goal><![CDATA[
 Derive observable Gherkin acceptance criteria from the Functional Specification comment produced by `/explore-problem` and post the confirmed result as a separate comment on the same issue.

--- a/plinth-commands-generator/src/main/resources/commands/create-adr.xml
+++ b/plinth-commands-generator/src/main/resources/commands/create-adr.xml
@@ -1,7 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <command id="create-adr"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="../commands.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../commands.xsd">
+
+    <metadata>
+        <description>Create a repository ADR for an approved architectural decision.</description>
+        <argument-hint>[decision-source] [adr-type]</argument-hint>
+        <model>inherit</model>
+        <agent>inherit</agent>
+        <tools>
+            <tools-list>
+                <tool>Read</tool>
+                <tool>Write</tool>
+                <tool>Edit</tool>
+            </tools-list>
+        </tools>
+    </metadata>
 
     <goal><![CDATA[
 Record an important architectural decision, its context, alternatives, and consequences.

--- a/plinth-commands-generator/src/main/resources/commands/create-adr.xml
+++ b/plinth-commands-generator/src/main/resources/commands/create-adr.xml
@@ -7,7 +7,7 @@
         <description>Create a repository ADR for an approved architectural decision.</description>
         <argument-hint>[decision-source] [adr-type]</argument-hint>
         <model>inherit</model>
-        <agent>inherit</agent>
+        <agent>robot-architect</agent>
         <tools>
             <tools-list>
                 <tool>Read</tool>

--- a/plinth-commands-generator/src/main/resources/commands/create-diagram.xml
+++ b/plinth-commands-generator/src/main/resources/commands/create-diagram.xml
@@ -1,7 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <command id="create-diagram"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="../commands.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../commands.xsd">
+
+    <metadata>
+        <description>Create an architecture or design diagram from selected source artifacts.</description>
+        <argument-hint>[source-artifact] [diagram-type]</argument-hint>
+        <model>inherit</model>
+        <agent>inherit</agent>
+        <tools>
+            <tools-list>
+                <tool>Read</tool>
+                <tool>Write</tool>
+                <tool>Edit</tool>
+            </tools-list>
+        </tools>
+    </metadata>
 
     <goal><![CDATA[
 Create an architecture or design diagram that explains a selected system view.

--- a/plinth-commands-generator/src/main/resources/commands/create-diagram.xml
+++ b/plinth-commands-generator/src/main/resources/commands/create-diagram.xml
@@ -7,7 +7,7 @@
         <description>Create an architecture or design diagram from selected source artifacts.</description>
         <argument-hint>[source-artifact] [diagram-type]</argument-hint>
         <model>inherit</model>
-        <agent>inherit</agent>
+        <agent>robot-architect</agent>
         <tools>
             <tools-list>
                 <tool>Read</tool>

--- a/plinth-commands-generator/src/main/resources/commands/create-feature-branch.xml
+++ b/plinth-commands-generator/src/main/resources/commands/create-feature-branch.xml
@@ -7,7 +7,7 @@
         <description>Create and switch to a conventionally named feature branch.</description>
         <argument-hint>[issue-or-change|type description] [base-reference]</argument-hint>
         <model>inherit</model>
-        <agent>inherit</agent>
+        <agent>robot-tech-lead</agent>
         <tools>
             <tools-list>
                 <tool>Read</tool>

--- a/plinth-commands-generator/src/main/resources/commands/create-feature-branch.xml
+++ b/plinth-commands-generator/src/main/resources/commands/create-feature-branch.xml
@@ -3,6 +3,19 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="../commands.xsd">
 
+    <metadata>
+        <description>Create and switch to a conventionally named feature branch.</description>
+        <argument-hint>[issue-or-change|type description] [base-reference]</argument-hint>
+        <model>inherit</model>
+        <agent>inherit</agent>
+        <tools>
+            <tools-list>
+                <tool>Read</tool>
+                <tool>Bash</tool>
+            </tools-list>
+        </tools>
+    </metadata>
+
     <goal><![CDATA[
 Create and switch the current checkout to a conventionally named local branch for GitHub issue, OpenSpec, analysis, design, documentation, or implementation work.
 

--- a/plinth-commands-generator/src/main/resources/commands/create-spec.xml
+++ b/plinth-commands-generator/src/main/resources/commands/create-spec.xml
@@ -5,9 +5,9 @@
 
     <metadata>
         <description>Create or update OpenSpec artifacts from approved source material.</description>
-        <argument-hint>[issue|design|adr|plan|existing-change]</argument-hint>
+        <argument-hint>[issue-url]</argument-hint>
         <model>inherit</model>
-        <agent>inherit</agent>
+        <agent>robot-architect</agent>
         <tools>
             <tools-list>
                 <tool>Read</tool>

--- a/plinth-commands-generator/src/main/resources/commands/create-spec.xml
+++ b/plinth-commands-generator/src/main/resources/commands/create-spec.xml
@@ -3,6 +3,21 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="../commands.xsd">
 
+    <metadata>
+        <description>Create or update OpenSpec artifacts from approved source material.</description>
+        <argument-hint>[issue|design|adr|plan|existing-change]</argument-hint>
+        <model>inherit</model>
+        <agent>inherit</agent>
+        <tools>
+            <tools-list>
+                <tool>Read</tool>
+                <tool>Write</tool>
+                <tool>Edit</tool>
+                <tool>Bash</tool>
+            </tools-list>
+        </tools>
+    </metadata>
+
     <goal><![CDATA[
 Create or update one or more OpenSpec changes from the available issue, design, ADR, plan, or existing OpenSpec artifacts.
 

--- a/plinth-commands-generator/src/main/resources/commands/create-worktree.xml
+++ b/plinth-commands-generator/src/main/resources/commands/create-worktree.xml
@@ -3,6 +3,19 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="../commands.xsd">
 
+    <metadata>
+        <description>Create an isolated Git worktree on a new conventionally named branch.</description>
+        <argument-hint>[issue-or-change|type description] [target-path] [base-reference]</argument-hint>
+        <model>inherit</model>
+        <agent>inherit</agent>
+        <tools>
+            <tools-list>
+                <tool>Read</tool>
+                <tool>Bash</tool>
+            </tools-list>
+        </tools>
+    </metadata>
+
     <goal><![CDATA[
 Always create a new branch and linked Git worktree for isolated or parallel work without changing the current checkout.
 

--- a/plinth-commands-generator/src/main/resources/commands/create-worktree.xml
+++ b/plinth-commands-generator/src/main/resources/commands/create-worktree.xml
@@ -7,7 +7,7 @@
         <description>Create an isolated Git worktree on a new conventionally named branch.</description>
         <argument-hint>[issue-or-change|type description] [target-path] [base-reference]</argument-hint>
         <model>inherit</model>
-        <agent>inherit</agent>
+        <agent>robot-tech-lead</agent>
         <tools>
             <tools-list>
                 <tool>Read</tool>

--- a/plinth-commands-generator/src/main/resources/commands/explore-design.xml
+++ b/plinth-commands-generator/src/main/resources/commands/explore-design.xml
@@ -3,6 +3,21 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="../commands.xsd">
 
+    <metadata>
+        <description>Refine an issue or OpenSpec change's technical design before implementation.</description>
+        <argument-hint>[issue|openspec-change]</argument-hint>
+        <model>inherit</model>
+        <agent>inherit</agent>
+        <tools>
+            <tools-list>
+                <tool>Read</tool>
+                <tool>Write</tool>
+                <tool>Edit</tool>
+                <tool>Bash</tool>
+            </tools-list>
+        </tools>
+    </metadata>
+
     <goal><![CDATA[
 Improve and refine the technical approach for an issue or OpenSpec change after initial specification—with alternatives, trade-offs, compatibility review, rollout controls, and verification strategy—before implementation.
 

--- a/plinth-commands-generator/src/main/resources/commands/explore-design.xml
+++ b/plinth-commands-generator/src/main/resources/commands/explore-design.xml
@@ -4,10 +4,10 @@
          xsi:noNamespaceSchemaLocation="../commands.xsd">
 
     <metadata>
-        <description>Refine an issue or OpenSpec change's technical design before implementation.</description>
-        <argument-hint>[issue|openspec-change]</argument-hint>
+        <description>Refine the technical design of an issue or OpenSpec change before implementation.</description>
+        <argument-hint>[openspec-change]</argument-hint>
         <model>inherit</model>
-        <agent>inherit</agent>
+        <agent>robot-architect</agent>
         <tools>
             <tools-list>
                 <tool>Read</tool>

--- a/plinth-commands-generator/src/main/resources/commands/explore-problem.xml
+++ b/plinth-commands-generator/src/main/resources/commands/explore-problem.xml
@@ -7,7 +7,7 @@
         <description>Analyze an issue through five lenses and post a Functional Specification.</description>
         <argument-hint>[issue-url]</argument-hint>
         <model>inherit</model>
-        <agent>inherit</agent>
+        <agent>robot-business-analyst</agent>
         <tools>
             <tools-list>
                 <tool>Read</tool>

--- a/plinth-commands-generator/src/main/resources/commands/explore-problem.xml
+++ b/plinth-commands-generator/src/main/resources/commands/explore-problem.xml
@@ -3,6 +3,19 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="../commands.xsd">
 
+    <metadata>
+        <description>Analyze an issue through five lenses and post a Functional Specification.</description>
+        <argument-hint>[issue-url]</argument-hint>
+        <model>inherit</model>
+        <agent>inherit</agent>
+        <tools>
+            <tools-list>
+                <tool>Read</tool>
+                <tool>Bash</tool>
+            </tools-list>
+        </tools>
+    </metadata>
+
     <goal><![CDATA[
 Evaluate an issue through five points of view — problem framing, root cause analysis, assumption analysis, context mapping, and quality attribute discovery — and post the resulting Functional Specification as a new comment on the issue.
 

--- a/plinth-commands-generator/src/main/resources/commands/implement-spec.xml
+++ b/plinth-commands-generator/src/main/resources/commands/implement-spec.xml
@@ -5,9 +5,9 @@
 
     <metadata>
         <description>Deliver an approved plan or OpenSpec change through controlled implementation.</description>
-        <argument-hint>[approved-plan|openspec-change] [task-or-group] [constraints]</argument-hint>
+        <argument-hint>[openspec-change]</argument-hint>
         <model>inherit</model>
-        <agent>inherit</agent>
+        <agent>robot-tech-lead</agent>
         <tools>
             <tools-list>
                 <tool>Read</tool>

--- a/plinth-commands-generator/src/main/resources/commands/implement-spec.xml
+++ b/plinth-commands-generator/src/main/resources/commands/implement-spec.xml
@@ -3,6 +3,21 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="../commands.xsd">
 
+    <metadata>
+        <description>Deliver an approved plan or OpenSpec change through controlled implementation.</description>
+        <argument-hint>[approved-plan|openspec-change] [task-or-group] [constraints]</argument-hint>
+        <model>inherit</model>
+        <agent>inherit</agent>
+        <tools>
+            <tools-list>
+                <tool>Read</tool>
+                <tool>Write</tool>
+                <tool>Edit</tool>
+                <tool>Bash</tool>
+            </tools-list>
+        </tools>
+    </metadata>
+
     <goal><![CDATA[
 Deliver an approved implementation plan or validated OpenSpec task list through controlled implementation.
 

--- a/plinth-commands-generator/src/main/resources/commands/profile.xml
+++ b/plinth-commands-generator/src/main/resources/commands/profile.xml
@@ -3,6 +3,21 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="../commands.xsd">
 
+    <metadata>
+        <description>Coordinate a reproducible Java profiling and optimization lifecycle.</description>
+        <argument-hint>[application-or-module] [issue|plan|openspec-change|suspected-problem] [runtime-command] [workload]</argument-hint>
+        <model>inherit</model>
+        <agent>inherit</agent>
+        <tools>
+            <tools-list>
+                <tool>Read</tool>
+                <tool>Write</tool>
+                <tool>Edit</tool>
+                <tool>Bash</tool>
+            </tools-list>
+        </tools>
+    </metadata>
+
     <goal><![CDATA[
 Coordinate a Java profiling lifecycle from reproducible baseline through evidence-backed optimization verification.
 

--- a/plinth-commands-generator/src/main/resources/commands/profile.xml
+++ b/plinth-commands-generator/src/main/resources/commands/profile.xml
@@ -5,9 +5,9 @@
 
     <metadata>
         <description>Coordinate a reproducible Java profiling and optimization lifecycle.</description>
-        <argument-hint>[application-or-module] [issue|plan|openspec-change|suspected-problem] [runtime-command] [workload]</argument-hint>
+        <argument-hint>[target]</argument-hint>
         <model>inherit</model>
-        <agent>inherit</agent>
+        <agent>robot-java-performance</agent>
         <tools>
             <tools-list>
                 <tool>Read</tool>

--- a/plinth-commands-generator/src/main/resources/commands/review-alignment.xml
+++ b/plinth-commands-generator/src/main/resources/commands/review-alignment.xml
@@ -3,6 +3,18 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="../commands.xsd">
 
+    <metadata>
+        <description>Review analysis and design artifacts for implementation readiness.</description>
+        <argument-hint>[artifact] [artifact ...]</argument-hint>
+        <model>inherit</model>
+        <agent>inherit</agent>
+        <tools>
+            <tools-list>
+                <tool>Read</tool>
+            </tools-list>
+        </tools>
+    </metadata>
+
     <goal><![CDATA[
 Review available analysis and design artifacts for consistency, traceability, completeness, and implementation readiness.
 

--- a/plinth-commands-generator/src/main/resources/commands/review-alignment.xml
+++ b/plinth-commands-generator/src/main/resources/commands/review-alignment.xml
@@ -7,7 +7,7 @@
         <description>Review analysis and design artifacts for implementation readiness.</description>
         <argument-hint>[artifact] [artifact ...]</argument-hint>
         <model>inherit</model>
-        <agent>inherit</agent>
+        <agent>robot-business-analyst</agent>
         <tools>
             <tools-list>
                 <tool>Read</tool>

--- a/plinth-commands-generator/src/main/resources/commands/update-issue.xml
+++ b/plinth-commands-generator/src/main/resources/commands/update-issue.xml
@@ -5,9 +5,9 @@
 
     <metadata>
         <description>Update an issue description with structured, evidence-backed content.</description>
-        <argument-hint>[issue] [source] [tracker]</argument-hint>
+        <argument-hint>[issue-url]</argument-hint>
         <model>inherit</model>
-        <agent>inherit</agent>
+        <agent>robot-business-analyst</agent>
         <tools>
             <tools-list>
                 <tool>Read</tool>

--- a/plinth-commands-generator/src/main/resources/commands/update-issue.xml
+++ b/plinth-commands-generator/src/main/resources/commands/update-issue.xml
@@ -3,6 +3,19 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="../commands.xsd">
 
+    <metadata>
+        <description>Update an issue description with structured, evidence-backed content.</description>
+        <argument-hint>[issue] [source] [tracker]</argument-hint>
+        <model>inherit</model>
+        <agent>inherit</agent>
+        <tools>
+            <tools-list>
+                <tool>Read</tool>
+                <tool>Bash</tool>
+            </tools-list>
+        </tools>
+    </metadata>
+
     <goal><![CDATA[
 Update an existing project issue description with structured, evidence-backed content.
 

--- a/plinth-commands-generator/src/test/java/info/jab/pml/CommandFrontmatterTest.java
+++ b/plinth-commands-generator/src/test/java/info/jab/pml/CommandFrontmatterTest.java
@@ -1,0 +1,174 @@
+package info.jab.pml;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Command Frontmatter Tests")
+class CommandFrontmatterTest {
+
+    private static final String FRONTMATTER_END = "---\n\n";
+    private static final Map<String, String> LEGACY_BODY_SHA_256 = legacyBodyHashes();
+    private static final Map<String, ExpectedMetadata> APPROVED_METADATA = approvedMetadata();
+
+    @Test
+    @DisplayName("Generated frontmatter must equal every inventoried XML metadata contract")
+    void should_renderApprovedMetadata_when_allCommandsAreGenerated() throws Exception {
+        for (String source : CommandIndexes.commandSources().toList()) {
+            Document command = loadXml("commands/" + source);
+            String markdown = CommandMarkdownRenderer.render(command);
+            Map<String, Object> frontmatter = parseFrontmatter(markdown);
+            Element metadata = (Element) command.getElementsByTagName("metadata").item(0);
+            ExpectedMetadata expected = Objects.requireNonNull(
+                APPROVED_METADATA.get(command.getDocumentElement().getAttribute("id")),
+                "Approved metadata must exist for every command"
+            );
+
+            assertThat(frontmatter)
+                .as("Frontmatter keys for %s", source)
+                .containsOnlyKeys("description", "argument-hint", "model", "agent", "tools");
+            assertThat(frontmatter.get("description")).isEqualTo(text(metadata, "description"));
+            assertThat(frontmatter.get("argument-hint")).isEqualTo(text(metadata, "argument-hint"));
+            assertThat(frontmatter.get("model")).isEqualTo(text(metadata, "model"));
+            assertThat(frontmatter.get("agent")).isEqualTo(text(metadata, "agent"));
+            assertThat(frontmatter.get("tools")).isEqualTo(elements(metadata, "tool"));
+            assertThat(frontmatter.get("description")).isEqualTo(expected.description());
+            assertThat(frontmatter.get("argument-hint")).isEqualTo(expected.argumentHint());
+            assertThat(frontmatter.get("model")).isEqualTo("inherit");
+            assertThat(frontmatter.get("agent")).isEqualTo("inherit");
+            assertThat(frontmatter.get("tools")).isEqualTo(expected.tools());
+        }
+        assertThat(APPROVED_METADATA).hasSize(14);
+    }
+
+    @Test
+    @DisplayName("YAML scalars must preserve punctuation, backslashes, apostrophes, and boundary spaces")
+    void should_preserveYamlSignificantCharacters_when_frontmatterIsRendered() throws Exception {
+        String xml = "<command id=\"yaml-boundaries\"><metadata>"
+            + "<description>  Plan: team's #1 [work] \\ path  </description>"
+            + "<argument-hint>[issue: 'value']</argument-hint><model>inherit</model><agent>inherit</agent>"
+            + "<tools><tools-list><tool>Read</tool><tool>Custom: Tool #1</tool></tools-list></tools>"
+            + "</metadata><goal>Goal</goal><steps/></command>";
+
+        Map<String, Object> metadata = parseFrontmatter(CommandMarkdownRenderer.render(
+            InventoryXmlLoader.parse(new java.io.ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)))));
+
+        assertThat(metadata.get("description")).isEqualTo("  Plan: team's #1 [work] \\ path  ");
+        assertThat(metadata.get("argument-hint")).isEqualTo("[issue: 'value']");
+        assertThat(metadata.get("tools")).isEqualTo(List.of("Read", "Custom: Tool #1"));
+    }
+
+    @Test
+    @DisplayName("Frontmatter must not change any byte in the legacy Markdown body")
+    void should_preserveLegacyBodyByteForByte_when_frontmatterIsPrepended() throws Exception {
+        for (String source : CommandIndexes.commandSources().toList()) {
+            String commandFile = CommandIndexes.toMarkdownFileName(source);
+            String body = bodyAfterFrontmatter(CommandMarkdownRenderer.render(loadXml("commands/" + source)));
+
+            assertThat(sha256(body))
+                .as("Legacy Markdown body hash for %s", commandFile)
+                .isEqualTo(LEGACY_BODY_SHA_256.get(commandFile));
+        }
+    }
+
+    static Map<String, Object> parseFrontmatter(String markdown) {
+        assertThat(markdown).startsWith("---\n");
+        int end = markdown.indexOf(FRONTMATTER_END, 4);
+        assertThat(end).isGreaterThan(3);
+        String yaml = markdown.substring(4, end);
+        Object loaded = new Load(LoadSettings.builder().build()).loadFromString(yaml);
+        assertThat(loaded).isInstanceOf(Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> metadata = (Map<String, Object>) loaded;
+        return metadata;
+    }
+
+    static String bodyAfterFrontmatter(String markdown) {
+        int end = markdown.indexOf(FRONTMATTER_END, 4);
+        assertThat(end).isGreaterThan(3);
+        return markdown.substring(end + FRONTMATTER_END.length());
+    }
+
+    private static Document loadXml(String resource) throws Exception {
+        try (InputStream stream = CommandFrontmatterTest.class.getClassLoader().getResourceAsStream(resource)) {
+            if (stream == null) {
+                throw new IllegalStateException("Missing command resource: " + resource);
+            }
+            return InventoryXmlLoader.parse(stream);
+        }
+    }
+
+    private static String text(Element parent, String name) {
+        return parent.getElementsByTagName(name).item(0).getTextContent();
+    }
+
+    private static List<String> elements(Element parent, String name) {
+        var nodes = parent.getElementsByTagName(name);
+        return java.util.stream.IntStream.range(0, nodes.getLength())
+            .mapToObj(index -> nodes.item(index).getTextContent())
+            .toList();
+    }
+
+    private static String sha256(String value) throws Exception {
+        return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256")
+            .digest(value.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private static Map<String, String> legacyBodyHashes() {
+        Map<String, String> hashes = new LinkedHashMap<>();
+        hashes.put("benchmark.md", "b5efb1f94fb883a495267ee8263e75012a29b49d1c74d7725120e69347fabef0");
+        hashes.put("close-spec.md", "54832426a9211ed0382c3416d134487f84a2e4a8cc8f0d25ad566956fbb7475c");
+        hashes.put("create-acceptance-criteria.md", "a7c712ff5e6ee58a6749929be852a9262dcb3058f66b2beb133f3499b1297121");
+        hashes.put("create-adr.md", "cb963c08544fbd51736b9ddf54d726d6af2195c0c8e85008b5e250444c14fd65");
+        hashes.put("create-diagram.md", "b82650b24c655922d990e695124a8ca6d6cc6c4a2556aa276c989d5ca0796d5c");
+        hashes.put("create-feature-branch.md", "6114d012e3c6d5140231831aa2907adb53dbcfc5c2ec6ef5fe4e5710ee0d7e20");
+        hashes.put("create-spec.md", "c9409cfa88a30ae8ff613834f22890c26eb9a47edea497f10ed57bf124fb4cf0");
+        hashes.put("create-worktree.md", "2f744fa6ded845ca31be3ecdf0df1cbd3cb6c90e03dae910535d9cf8ee5f9f25");
+        hashes.put("explore-design.md", "192d877d65ea77c76645e1371666ac8a9bd2a78d44faaf58cf30aa6d625adc7c");
+        hashes.put("explore-problem.md", "bf0b8c1acd2f79b79c5958124c06297a62d5faecbaa0933541808fdd49213cf2");
+        hashes.put("implement-spec.md", "2ae28a480c28405205e38ee502138c9e695b3f07b5911ede7450154d5f1a2b30");
+        hashes.put("profile.md", "98e107c4a577b9c745ca0639b4929b5e223b04668e78ff00138fd0f07657c060");
+        hashes.put("review-alignment.md", "df4e45038ac1ebcead4a6bbd2b6f6d05603254596d8fb6da075e9156be0143d5");
+        hashes.put("update-issue.md", "7766e1ae872b034570b1c183b2a2695722ab64a4bfbecefcc0567f540333ef41");
+        return Map.copyOf(hashes);
+    }
+
+    private static Map<String, ExpectedMetadata> approvedMetadata() {
+        Map<String, ExpectedMetadata> metadata = new LinkedHashMap<>();
+        metadata.put("benchmark", expected("Design and coordinate a reproducible Java performance test.",
+            "[target] [objective-or-threshold] [workload] [environment] [preferred-tool]", "Read", "Write", "Edit", "Bash"));
+        metadata.put("close-spec", expected("Archive a completed OpenSpec change by name.", "[change-name]", "Read", "Bash"));
+        metadata.put("create-acceptance-criteria", expected("Derive and post confirmed Gherkin acceptance criteria for an issue.", "[issue-url]", "Read", "Bash"));
+        metadata.put("create-adr", expected("Create a repository ADR for an approved architectural decision.", "[decision-source] [adr-type]", "Read", "Write", "Edit"));
+        metadata.put("create-diagram", expected("Create an architecture or design diagram from selected source artifacts.", "[source-artifact] [diagram-type]", "Read", "Write", "Edit"));
+        metadata.put("create-feature-branch", expected("Create and switch to a conventionally named feature branch.", "[issue-or-change|type description] [base-reference]", "Read", "Bash"));
+        metadata.put("create-spec", expected("Create or update OpenSpec artifacts from approved source material.", "[issue|design|adr|plan|existing-change]", "Read", "Write", "Edit", "Bash"));
+        metadata.put("create-worktree", expected("Create an isolated Git worktree on a new conventionally named branch.", "[issue-or-change|type description] [target-path] [base-reference]", "Read", "Bash"));
+        metadata.put("explore-design", expected("Refine an issue or OpenSpec change's technical design before implementation.", "[issue|openspec-change]", "Read", "Write", "Edit", "Bash"));
+        metadata.put("explore-problem", expected("Analyze an issue through five lenses and post a Functional Specification.", "[issue-url]", "Read", "Bash"));
+        metadata.put("implement-spec", expected("Deliver an approved plan or OpenSpec change through controlled implementation.", "[approved-plan|openspec-change] [task-or-group] [constraints]", "Read", "Write", "Edit", "Bash"));
+        metadata.put("profile", expected("Coordinate a reproducible Java profiling and optimization lifecycle.", "[application-or-module] [issue|plan|openspec-change|suspected-problem] [runtime-command] [workload]", "Read", "Write", "Edit", "Bash"));
+        metadata.put("review-alignment", expected("Review analysis and design artifacts for implementation readiness.", "[artifact] [artifact ...]", "Read"));
+        metadata.put("update-issue", expected("Update an issue description with structured, evidence-backed content.", "[issue] [source] [tracker]", "Read", "Bash"));
+        return Map.copyOf(metadata);
+    }
+
+    private static ExpectedMetadata expected(String description, String argumentHint, String... tools) {
+        return new ExpectedMetadata(description, argumentHint, List.of(tools));
+    }
+
+    private record ExpectedMetadata(String description, String argumentHint, List<String> tools) {}
+}

--- a/plinth-commands-generator/src/test/java/info/jab/pml/CommandFrontmatterTest.java
+++ b/plinth-commands-generator/src/test/java/info/jab/pml/CommandFrontmatterTest.java
@@ -48,7 +48,7 @@ class CommandFrontmatterTest {
             assertThat(frontmatter.get("description")).isEqualTo(expected.description());
             assertThat(frontmatter.get("argument-hint")).isEqualTo(expected.argumentHint());
             assertThat(frontmatter.get("model")).isEqualTo("inherit");
-            assertThat(frontmatter.get("agent")).isEqualTo("inherit");
+            assertThat(frontmatter.get("agent")).isEqualTo(expected.agent());
             assertThat(frontmatter.get("tools")).isEqualTo(expected.tools());
         }
         assertThat(APPROVED_METADATA).hasSize(14);
@@ -148,27 +148,28 @@ class CommandFrontmatterTest {
 
     private static Map<String, ExpectedMetadata> approvedMetadata() {
         Map<String, ExpectedMetadata> metadata = new LinkedHashMap<>();
-        metadata.put("benchmark", expected("Design and coordinate a reproducible Java performance test.",
-            "[target] [objective-or-threshold] [workload] [environment] [preferred-tool]", "Read", "Write", "Edit", "Bash"));
-        metadata.put("close-spec", expected("Archive a completed OpenSpec change by name.", "[change-name]", "Read", "Bash"));
-        metadata.put("create-acceptance-criteria", expected("Derive and post confirmed Gherkin acceptance criteria for an issue.", "[issue-url]", "Read", "Bash"));
-        metadata.put("create-adr", expected("Create a repository ADR for an approved architectural decision.", "[decision-source] [adr-type]", "Read", "Write", "Edit"));
-        metadata.put("create-diagram", expected("Create an architecture or design diagram from selected source artifacts.", "[source-artifact] [diagram-type]", "Read", "Write", "Edit"));
-        metadata.put("create-feature-branch", expected("Create and switch to a conventionally named feature branch.", "[issue-or-change|type description] [base-reference]", "Read", "Bash"));
-        metadata.put("create-spec", expected("Create or update OpenSpec artifacts from approved source material.", "[issue|design|adr|plan|existing-change]", "Read", "Write", "Edit", "Bash"));
-        metadata.put("create-worktree", expected("Create an isolated Git worktree on a new conventionally named branch.", "[issue-or-change|type description] [target-path] [base-reference]", "Read", "Bash"));
-        metadata.put("explore-design", expected("Refine an issue or OpenSpec change's technical design before implementation.", "[issue|openspec-change]", "Read", "Write", "Edit", "Bash"));
-        metadata.put("explore-problem", expected("Analyze an issue through five lenses and post a Functional Specification.", "[issue-url]", "Read", "Bash"));
-        metadata.put("implement-spec", expected("Deliver an approved plan or OpenSpec change through controlled implementation.", "[approved-plan|openspec-change] [task-or-group] [constraints]", "Read", "Write", "Edit", "Bash"));
-        metadata.put("profile", expected("Coordinate a reproducible Java profiling and optimization lifecycle.", "[application-or-module] [issue|plan|openspec-change|suspected-problem] [runtime-command] [workload]", "Read", "Write", "Edit", "Bash"));
-        metadata.put("review-alignment", expected("Review analysis and design artifacts for implementation readiness.", "[artifact] [artifact ...]", "Read"));
-        metadata.put("update-issue", expected("Update an issue description with structured, evidence-backed content.", "[issue] [source] [tracker]", "Read", "Bash"));
+        metadata.put("benchmark", expected("robot-java-performance",
+            "Design and coordinate a reproducible Java performance test.",
+            "[target]", "Read", "Write", "Edit", "Bash"));
+        metadata.put("close-spec", expected("robot-architect", "Archive a completed OpenSpec change by name.", "[openspec-change]", "Read", "Bash"));
+        metadata.put("create-acceptance-criteria", expected("robot-business-analyst", "Derive and post confirmed Gherkin acceptance criteria for an issue.", "[issue-url]", "Read", "Bash"));
+        metadata.put("create-adr", expected("robot-architect", "Create a repository ADR for an approved architectural decision.", "[decision-source] [adr-type]", "Read", "Write", "Edit"));
+        metadata.put("create-diagram", expected("robot-architect", "Create an architecture or design diagram from selected source artifacts.", "[source-artifact] [diagram-type]", "Read", "Write", "Edit"));
+        metadata.put("create-feature-branch", expected("robot-tech-lead", "Create and switch to a conventionally named feature branch.", "[issue-or-change|type description] [base-reference]", "Read", "Bash"));
+        metadata.put("create-spec", expected("robot-architect", "Create or update OpenSpec artifacts from approved source material.", "[issue-url]", "Read", "Write", "Edit", "Bash"));
+        metadata.put("create-worktree", expected("robot-tech-lead", "Create an isolated Git worktree on a new conventionally named branch.", "[issue-or-change|type description] [target-path] [base-reference]", "Read", "Bash"));
+        metadata.put("explore-design", expected("robot-architect", "Refine the technical design of an issue or OpenSpec change before implementation.", "[openspec-change]", "Read", "Write", "Edit", "Bash"));
+        metadata.put("explore-problem", expected("robot-business-analyst", "Analyze an issue through five lenses and post a Functional Specification.", "[issue-url]", "Read", "Bash"));
+        metadata.put("implement-spec", expected("robot-tech-lead", "Deliver an approved plan or OpenSpec change through controlled implementation.", "[openspec-change]", "Read", "Write", "Edit", "Bash"));
+        metadata.put("profile", expected("robot-java-performance", "Coordinate a reproducible Java profiling and optimization lifecycle.", "[target]", "Read", "Write", "Edit", "Bash"));
+        metadata.put("review-alignment", expected("robot-business-analyst", "Review analysis and design artifacts for implementation readiness.", "[artifact] [artifact ...]", "Read"));
+        metadata.put("update-issue", expected("robot-business-analyst", "Update an issue description with structured, evidence-backed content.", "[issue-url]", "Read", "Bash"));
         return Map.copyOf(metadata);
     }
 
-    private static ExpectedMetadata expected(String description, String argumentHint, String... tools) {
-        return new ExpectedMetadata(description, argumentHint, List.of(tools));
+    private static ExpectedMetadata expected(String agent, String description, String argumentHint, String... tools) {
+        return new ExpectedMetadata(agent, description, argumentHint, List.of(tools));
     }
 
-    private record ExpectedMetadata(String description, String argumentHint, List<String> tools) {}
+    private record ExpectedMetadata(String agent, String description, String argumentHint, List<String> tools) {}
 }

--- a/plinth-commands-generator/src/test/java/info/jab/pml/CommandSchemaTest.java
+++ b/plinth-commands-generator/src/test/java/info/jab/pml/CommandSchemaTest.java
@@ -1,0 +1,146 @@
+package info.jab.pml;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.XMLConstants;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Command Schema Tests")
+class CommandSchemaTest {
+
+    private final Schema schema = loadSchema();
+
+    @Test
+    @DisplayName("Every inventoried command source must satisfy commands.xsd")
+    void should_validateAllCommandSources_when_inventoryIsLoaded() {
+        CommandIndexes.commandSources().forEach(source -> assertThatCode(() -> validateResource("commands/" + source))
+            .as("Schema-valid command source: %s", source)
+            .doesNotThrowAnyException());
+    }
+
+    @Test
+    @DisplayName("Metadata must contain every required frontmatter scalar")
+    void should_rejectMissingRequiredField_when_metadataIsValidated() {
+        String xml = validCommand("<description>Description</description>"
+            + "<argument-hint>[input]</argument-hint>"
+            + "<model>inherit</model>"
+            + "<tools><tools-list><tool>Read</tool></tools-list></tools>");
+
+        assertThatThrownBy(() -> validate(xml)).isInstanceOf(SAXException.class);
+    }
+
+    @Test
+    @DisplayName("Metadata must contain at least one tool")
+    void should_rejectZeroTools_when_metadataIsValidated() {
+        assertThatThrownBy(() -> validate(validCommand(metadataScalars()
+            + "<tools><tools-list/></tools>")))
+            .isInstanceOf(SAXException.class);
+    }
+
+    @Test
+    @DisplayName("Metadata accepts one or multiple extensible tools")
+    void should_acceptOneAndMultipleTools_when_metadataIsValidated() {
+        assertThatCode(() -> validate(validCommand(metadataScalars()
+            + "<tools><tools-list><tool>Read</tool></tools-list></tools>")))
+            .doesNotThrowAnyException();
+        assertThatCode(() -> validate(validCommand(metadataScalars()
+            + "<tools><tools-list><tool>Custom Read</tool><tool>Edit</tool></tools-list></tools>")))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Metadata must compose the global agents-style element vocabulary by reference")
+    void should_referenceGlobalElements_when_metadataSchemaIsInspected() throws Exception {
+        Document schemaDocument;
+        try (var stream = CommandSchemaTest.class.getClassLoader().getResourceAsStream("commands.xsd")) {
+            if (stream == null) {
+                throw new IllegalStateException("Missing commands.xsd");
+            }
+            schemaDocument = InventoryXmlLoader.parse(stream);
+        }
+
+        assertThatCode(() -> globalElement(schemaDocument, "metadata")).doesNotThrowAnyException();
+        assertThat(sequenceReferences(globalElement(schemaDocument, "metadata")))
+            .containsExactly("description", "argument-hint", "model", "agent", "tools");
+        assertThat(sequenceReferences(globalElement(schemaDocument, "tools")))
+            .containsExactly("tools-list");
+        assertThat(sequenceReferences(globalElement(schemaDocument, "tools-list")))
+            .containsExactly("tool");
+        assertThat(List.of("description", "argument-hint", "model", "agent", "tool"))
+            .allSatisfy(name -> assertThat(globalElement(schemaDocument, name))
+                .as("Global PML-style declaration for %s", name)
+                .isNotNull());
+    }
+
+    private static String metadataScalars() {
+        return "<description>Description</description>"
+            + "<argument-hint>[input]</argument-hint>"
+            + "<model>custom-model</model>"
+            + "<agent>custom-agent</agent>";
+    }
+
+    private static String validCommand(String metadata) {
+        return "<command id=\"test\"><metadata>" + metadata
+            + "</metadata><goal>Goal</goal><steps/></command>";
+    }
+
+    private void validateResource(String resource) throws Exception {
+        try (var stream = CommandSchemaTest.class.getClassLoader().getResourceAsStream(resource)) {
+            if (stream == null) {
+                throw new IllegalStateException("Missing command resource: " + resource);
+            }
+            schema.newValidator().validate(new StreamSource(stream));
+        }
+    }
+
+    private void validate(String xml) throws Exception {
+        schema.newValidator().validate(new StreamSource(new StringReader(xml)));
+    }
+
+    private static Schema loadSchema() {
+        try {
+            SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            return factory.newSchema(CommandSchemaTest.class.getClassLoader().getResource("commands.xsd"));
+        } catch (SAXException e) {
+            throw new IllegalStateException("Cannot load commands.xsd", e);
+        }
+    }
+
+    private static Element globalElement(Document document, String name) {
+        Element root = document.getDocumentElement();
+        for (Node child = root.getFirstChild(); child != null; child = child.getNextSibling()) {
+            if (child instanceof Element element
+                && element.getNodeName().endsWith(":element")
+                && name.equals(element.getAttribute("name"))) {
+                return element;
+            }
+        }
+        throw new IllegalStateException("Missing global XSD element: " + name);
+    }
+
+    private static List<String> sequenceReferences(Element globalElement) {
+        Element sequence = (Element) globalElement.getElementsByTagName("xs:sequence").item(0);
+        List<String> references = new ArrayList<>();
+        for (Node child = sequence.getFirstChild(); child != null; child = child.getNextSibling()) {
+            if (child instanceof Element element && element.hasAttribute("ref")) {
+                references.add(element.getAttribute("ref"));
+            }
+        }
+        return List.copyOf(references);
+    }
+}

--- a/plinth-skills-generator/src/test/java/info/jab/pml/CommandBridgeTest.java
+++ b/plinth-skills-generator/src/test/java/info/jab/pml/CommandBridgeTest.java
@@ -1,6 +1,8 @@
 package info.jab.pml;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -14,9 +16,15 @@ class CommandBridgeTest {
     void should_stageAllCommandAssets_when_generateResourcesBridgeRuns() {
         CommandIndexes.commandFiles().forEach(commandFile -> {
             String resource = "skill-references/assets/commands/" + commandFile;
-            assertThat(getTestResource(resource))
-                .withFailMessage("Bridged command asset missing on classpath: %s", resource)
-                .isNotNull();
+            String bridged = loadResource(resource);
+            String generated = loadResource("commands/" + commandFile);
+
+            assertThat(bridged)
+                .withFailMessage("Bridged command asset must exactly match generated output: %s", resource)
+                .startsWith("---\n")
+                .contains("\ntools:\n")
+                .contains("\n---\n\n# ")
+                .isEqualTo(generated);
         });
     }
 
@@ -29,5 +37,16 @@ class CommandBridgeTest {
 
     private InputStream getTestResource(String resourceName) {
         return CommandBridgeTest.class.getClassLoader().getResourceAsStream(resourceName);
+    }
+
+    private String loadResource(String resourceName) {
+        try (var stream = getTestResource(resourceName)) {
+            assertThat(stream)
+                .withFailMessage("Resource not found: %s", resourceName)
+                .isNotNull();
+            return new String(Objects.requireNonNull(stream).readAllBytes(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load resource: " + resourceName, e);
+        }
     }
 }

--- a/plinth-skills-generator/src/test/java/info/jab/pml/CommandSkillPropagationTest.java
+++ b/plinth-skills-generator/src/test/java/info/jab/pml/CommandSkillPropagationTest.java
@@ -1,6 +1,7 @@
 package info.jab.pml;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +31,11 @@ class CommandSkillPropagationTest {
 
             assertThat(output.resourceFiles())
                 .withFailMessage("Generated 004 missing asset %s", assetPath)
-                .containsKey(assetPath);
+                .containsEntry(assetPath, loadBridgedCommand(commandFile));
+            assertThat(output.resourceFiles().get(assetPath))
+                .startsWith("---\n")
+                .contains("\ntools:\n")
+                .contains("\n---\n\n# " + commandName + "\n");
             assertThat(reference)
                 .withFailMessage("Generated 004 reference missing link to %s", assetPath)
                 .contains("](../" + assetPath + ")");
@@ -48,7 +53,10 @@ class CommandSkillPropagationTest {
 
         String reference = output.referenceMds().get("001-commands-inventory");
         String templateAssetPath = "assets/java-commands-inventory-template.md";
-        String template = output.resourceFiles().get(templateAssetPath);
+        String template = Objects.requireNonNull(
+            output.resourceFiles().get(templateAssetPath),
+            "Generated 001 inventory template must exist"
+        );
 
         assertThat(output.resourceFiles())
             .withFailMessage("Generated 001 missing asset %s", templateAssetPath)
@@ -66,6 +74,16 @@ class CommandSkillPropagationTest {
                 .withFailMessage("Generated 001 reference must not embed command /%s", commandName)
                 .doesNotContain("`/" + commandName + "`");
         });
+
+        int previousPosition = -1;
+        for (String commandFile : CommandIndexes.commandFiles().toList()) {
+            String commandName = commandFile.substring(0, commandFile.length() - ".md".length());
+            int position = template.indexOf("`/" + commandName + "`");
+            assertThat(position)
+                .withFailMessage("Generated 001 inventory order differs at /%s", commandName)
+                .isGreaterThan(previousPosition);
+            previousPosition = position;
+        }
     }
 
     private String loadBridgedCommand(String commandFile) {


### PR DESCRIPTION
# Rationale for this change

Generated Plinth command Markdown currently has no YAML frontmatter. This PR plans the work required by #1075 to add Cursor-compatible command metadata at the authoritative XML layer while preserving the existing command bodies and Maven packaging flow.

# What changes are included in this PR?

- Adds an OpenSpec proposal for command frontmatter metadata.
- Defines the XML contract for `description`, `argument-hint`, `model`, `agent`, and an ordered, command-specific `tools` list.
- Specifies YAML rendering, escaping, inventory-wide coverage, and byte-for-byte preservation of existing Markdown bodies.
- Defines propagation requirements for the generated `001-commands-inventory` and `004-commands-installation` skills.
- Documents implementation tasks, validation gates, migration steps, rollback, risks, and resolved design decisions.
- Clarifies that generated assets remain local under `.agents/skills` unless the release profile is explicitly selected.

## Commit summary

- `docs(openspec): plan command frontmatter metadata` — creates the OpenSpec change with its proposal, design, capability specifications, and implementation checklist.
- `docs(openspec): refine command frontmatter design` — tightens the design around required metadata, command-specific ordered tools, YAML 1.2 parsing, safe scalar escaping, body preservation, build boundaries, and acceptance validation.

# Are these changes tested?

This PR contains OpenSpec planning documentation only, so no runtime implementation tests apply yet. The plan defines the required XML, generator, propagation, Maven reactor, OpenSpec, and targeted skill acceptance validations for the implementation phase.

# Are there any user-facing changes?

No immediate user-facing behavior changes are included. Once implemented, generated command files will gain Cursor-compatible YAML frontmatter while retaining their existing names and Markdown command bodies.

Closes #1075.
