### PR TITLE
fix(skills): pin maven-dependency-plugin per-invocation in 111-java-maven-dependencies

### DIFF
--- a/plinth-skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-archunit.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-archunit.xml
@@ -28,31 +28,18 @@ Add ArchUnit only when the user selects architecture testing support in the SKIL
 
     <steps>
         <step number="1">
-            <step-title>Add selected version property</step-title>
+            <step-title>Add ArchUnit JUnit 5 dependency with the Maven dependency plugin</step-title>
             <step-content><![CDATA[
-```xml
-<archunit.version>1.4.1</archunit.version>
+```bash
+./mvnw org.apache.maven.plugins:maven-dependency-plugin:3.11.0:add -Dgav=com.tngtech.archunit:archunit-junit5:1.4.1 -Dscope=test -DuseProperty=true -DpropertyName=archunit.version
 ```
+
+Invoking the plugin with an explicit `groupId:artifactId:version:goal` coordinate pins the version for this one invocation without adding a permanent `pluginManagement` entry to the POM — versions before 3.11.0 do not have the `add` goal. This adds the dependency directly to `pom.xml` with `test` scope and creates a matching `archunit.version` property. `-DuseProperty=true` is required — `align` auto-detection does not reliably create the property even when the project already follows a `${x.version}` convention. `-DpropertyName=archunit.version` is required — without it, the property name is derived from the artifactId (`archunit-junit5.version`) instead of the shorter conventional name.
 
 
 ]]></step-content>
         </step>
         <step number="2">
-            <step-title>Add ArchUnit JUnit 5 dependency</step-title>
-            <step-content><![CDATA[
-```xml
-<dependency>
-    <groupId>com.tngtech.archunit</groupId>
-    <artifactId>archunit-junit5</artifactId>
-    <version>${archunit.version}</version>
-    <scope>test</scope>
-</dependency>
-```
-
-
-]]></step-content>
-        </step>
-        <step number="3">
             <step-title>Validate architecture tests</step-title>
             <step-content><![CDATA[
 After adding ArchUnit, recommend running:

--- a/plinth-skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-javamoney.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-javamoney.xml
@@ -32,51 +32,26 @@ JavaMoney reference: https://javamoney.github.io/
 
     <steps>
         <step number="1">
-            <step-title>Add selected version property</step-title>
+            <step-title>Add JavaMoney dependency with the Maven dependency plugin</step-title>
             <step-content><![CDATA[
-For application modules that need a JSR 354 implementation, add:
+For application modules, add Moneta, the JSR 354 reference implementation (`pom` type):
 
-```xml
-<javamoney-moneta.version>1.4.5</javamoney-moneta.version>
+```bash
+./mvnw org.apache.maven.plugins:maven-dependency-plugin:3.11.0:add -Dgav=org.javamoney:moneta:pom:1.4.5 -DuseProperty=true -DpropertyName=javamoney-moneta.version
 ```
 
-For API-only modules, add `money-api.version` only when the module should compile against the JSR 354 API without providing a runtime implementation:
+For API-only modules, add the API dependency instead, only when the module should compile against the JSR 354 API without providing a runtime implementation:
 
-```xml
-<money-api.version>1.1</money-api.version>
+```bash
+./mvnw org.apache.maven.plugins:maven-dependency-plugin:3.11.0:add -Dgav=javax.money:money-api:1.1 -DuseProperty=true -DpropertyName=money-api.version
 ```
+
+Invoking the plugin with an explicit `groupId:artifactId:version:goal` coordinate pins the version for this one invocation without adding a permanent `pluginManagement` entry to the POM — versions before 3.11.0 do not have the `add` goal. Each command adds the dependency directly to `pom.xml` and creates a matching version property (`javamoney-moneta.version` or `money-api.version`). `-DuseProperty=true` is required — `align` auto-detection does not reliably create the property even when the project already follows a `${x.version}` convention. `-DpropertyName` is required for the Moneta command — without it, the property name is derived from the artifactId (`moneta.version`) instead of the conventional `javamoney-moneta.version`.
 
 
 ]]></step-content>
         </step>
         <step number="2">
-            <step-title>Add JavaMoney dependency</step-title>
-            <step-content><![CDATA[
-For application modules, add Moneta, the JSR 354 reference implementation:
-
-```xml
-<dependency>
-    <groupId>org.javamoney</groupId>
-    <artifactId>moneta</artifactId>
-    <version>${javamoney-moneta.version}</version>
-    <type>pom</type>
-</dependency>
-```
-
-For API-only modules, add the API dependency instead:
-
-```xml
-<dependency>
-    <groupId>javax.money</groupId>
-    <artifactId>money-api</artifactId>
-    <version>${money-api.version}</version>
-</dependency>
-```
-
-
-]]></step-content>
-        </step>
-        <step number="3">
             <step-title>Report domain-modeling trade-offs</step-title>
             <step-content><![CDATA[
 Mention JavaMoney provides the Java Money and Currency API (JSR 354) and Moneta reference implementation. Recommend JavaMoney when the project needs monetary amounts, currencies, formatting, currency conversion, or precision-safe calculations.

--- a/plinth-skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-jspecify.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-jspecify.xml
@@ -29,29 +29,25 @@ Configure nullness analysis only when selected by the user. This reference owns 
 
     <steps>
         <step number="1">
-            <step-title>Add selected version properties</step-title>
+            <step-title>Add JSpecify dependency with the Maven dependency plugin</step-title>
             <step-content><![CDATA[
-Add only the properties needed by the user's selections:
-
-```xml
-<jspecify.version>1.0.0</jspecify.version>
-<error-prone.version>2.35.1</error-prone.version>
-<nullaway.version>0.12.0</nullaway.version>
+```bash
+./mvnw org.apache.maven.plugins:maven-dependency-plugin:3.11.0:add -Dgav=org.jspecify:jspecify:1.0.0 -Dscope=provided -DuseProperty=true -DpropertyName=jspecify.version
 ```
+
+Invoking the plugin with an explicit `groupId:artifactId:version:goal` coordinate pins the version for this one invocation without adding a permanent `pluginManagement` entry to the POM — versions before 3.11.0 do not have the `add` goal. This adds the dependency directly to `pom.xml` with `provided` scope and creates a matching `jspecify.version` property. `-DuseProperty=true` is required — `align` auto-detection does not reliably create the property even when the project already follows a `${x.version}` convention.
 
 
 ]]></step-content>
         </step>
         <step number="2">
-            <step-title>Add JSpecify dependency when selected</step-title>
+            <step-title>Add Error Prone + NullAway version properties when selected</step-title>
             <step-content><![CDATA[
+Add these properties only when enhanced compiler analysis was selected. `error-prone.version` and `nullaway.version` configure `annotationProcessorPaths` entries inside the compiler plugin, not a top-level dependency, so `dependency:add` does not manage them — add them by hand:
+
 ```xml
-<dependency>
-    <groupId>org.jspecify</groupId>
-    <artifactId>jspecify</artifactId>
-    <version>${jspecify.version}</version>
-    <scope>provided</scope>
-</dependency>
+<error-prone.version>2.35.1</error-prone.version>
+<nullaway.version>0.12.0</nullaway.version>
 ```
 
 

--- a/plinth-skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-vavr.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-vavr.xml
@@ -27,30 +27,18 @@ Add VAVR only when the user selects functional programming support in the SKILL.
 
     <steps>
         <step number="1">
-            <step-title>Add selected version property</step-title>
+            <step-title>Add VAVR dependency with the Maven dependency plugin</step-title>
             <step-content><![CDATA[
-```xml
-<vavr.version>0.10.6</vavr.version>
+```bash
+./mvnw org.apache.maven.plugins:maven-dependency-plugin:3.11.0:add -Dgav=io.vavr:vavr:0.10.6 -DuseProperty=true -DpropertyName=vavr.version
 ```
+
+Invoking the plugin with an explicit `groupId:artifactId:version:goal` coordinate pins the version for this one invocation without adding a permanent `pluginManagement` entry to the POM — versions before 3.11.0 do not have the `add` goal. This adds the dependency directly to `pom.xml` using default compile scope and creates a matching `vavr.version` property. `-DuseProperty=true` is required — `align` auto-detection does not reliably create the property even when the project already follows a `${x.version}` convention.
 
 
 ]]></step-content>
         </step>
         <step number="2">
-            <step-title>Add VAVR dependency</step-title>
-            <step-content><![CDATA[
-```xml
-<dependency>
-    <groupId>io.vavr</groupId>
-    <artifactId>vavr</artifactId>
-    <version>${vavr.version}</version>
-</dependency>
-```
-
-
-]]></step-content>
-        </step>
-        <step number="3">
             <step-title>Report common usage</step-title>
             <step-content><![CDATA[
 Mention VAVR is useful for `Try`, `Either`, and immutable collections. Recommend adding examples only if the user asks or if the change introduces VAVR into existing code.


### PR DESCRIPTION
## Summary
- While reviewing PR #1056 (which switches `111-java-maven-dependencies` skill references from manual `<dependency>` XML blocks to `./mvnw dependency:add`), executing the acceptance tests in `plinth-skills-generator/src/test/resources/gherkin/skills/111-java-maven-dependencies.feature` against `examples/maven/maven-demo` surfaced gaps in the documented commands for ArchUnit, VAVR, JavaMoney, and JSpecify:
  - The default resolved `maven-dependency-plugin` version (3.7.0) doesn't have the `add` goal — it requires 3.11.0+.
  - Even with 3.11.0, `align` auto-detection did not reliably create a `${x.version}` property, even when the project already followed that convention — required an explicit `-DuseProperty=true`.
  - For ArchUnit and JavaMoney (Moneta), the auto-derived property name came from the artifactId (e.g. `archunit-junit5.version`) rather than the documented shorter name (`archunit.version`) — required an explicit `-DpropertyName=...`.
- Fixed by invoking the plugin with an explicit `groupId:artifactId:version:goal` coordinate (`org.apache.maven.plugins:maven-dependency-plugin:3.11.0:add`) plus `-DuseProperty=true -DpropertyName=...`. This pins the version for just that one invocation without requiring a permanent `pluginManagement` entry in the target project's `pom.xml`.

## Test plan
- [x] `xmllint --noout` on all 4 edited XML files
- [x] `./mvnw clean install -pl plinth-skills-generator -am` regenerates the skill successfully
- [x] Re-ran all 4 scenarios in `111-java-maven-dependencies.feature` against `examples/maven/maven-demo` using the corrected commands literally (no manual flag correction): JSpecify+Error Prone/NullAway, VAVR, ArchUnit, JavaMoney — all pom.xml properties/dependencies/plugin config match expected, `./mvnw validate`/`clean verify` behave as specified, and `examples/maven/maven-demo` was reset to a clean baseline after each run

🤖 Generated with [Claude Code](https://claude.com/claude-code)