### PR TITLE
test(skills-generator): cache remote schema across parameterized cases

### DIFF
--- a/plinth-skills-generator/src/test/java/info/jab/pml/RemoteSchemaValidationTest.java
+++ b/plinth-skills-generator/src/test/java/info/jab/pml/RemoteSchemaValidationTest.java
@@ -10,6 +10,7 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -19,6 +20,17 @@ class RemoteSchemaValidationTest {
 
     //TODO: Use maven-central ASAP
     private static final String REMOTE_XSD = "https://jabrena.github.io/pml/schemas/0.8.0/pml.xsd";
+
+    private static Schema schema;
+
+    @BeforeAll
+    static void loadRemoteSchema() throws Exception {
+        SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
+        schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
+
+        schema = schemaFactory.newSchema(URI.create(REMOTE_XSD).toURL());
+    }
 
     private static Stream<String> provideXmlFileNames() {
         return SkillReferences.xmlFilenames();
@@ -33,11 +45,6 @@ class RemoteSchemaValidationTest {
                 throw new IllegalStateException("Test resource not found: " + resourcePath);
             }
 
-            SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-            schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
-            schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
-
-            Schema schema = schemaFactory.newSchema(URI.create(REMOTE_XSD).toURL());
             Validator validator = schema.newValidator();
 
             Source source = new StreamSource(xml);


### PR DESCRIPTION
## Summary
- `RemoteSchemaValidationTest` was fetching and parsing the remote `pml.xsd` schema from `SchemaFactory.newSchema(...)` inside the parameterized test body, so every one of the 199 skill-reference XML cases triggered its own network fetch of the same schema.
- Hoisted schema loading into a `@BeforeAll` static method so the remote XSD is fetched and parsed once per test class run; each case still gets its own `Validator` via `schema.newValidator()`.

## Test plan
- [x] `./mvnw -q -pl plinth-skills-generator test -Dtest=RemoteSchemaValidationTest`
- [x] `./mvnw -q -pl plinth-skills-generator -am clean verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)