### PR TITLE
docs(changelog): add 0.18.0 release notes

### DIFF
--- a/.cursor/agents/robot-architect.md
+++ b/.cursor/agents/robot-architect.md
@@ -4,7 +4,7 @@ description: Java architecture specialist. Explores design alternatives, records
 license: Apache-2.0
 metadata:
   author: Juan Antonio Breña Moral
-  version: 0.18.0-SNAPSHOT
+  version: 0.18.0
 model: inherit
 ---
 

--- a/.cursor/agents/robot-business-analyst.md
+++ b/.cursor/agents/robot-business-analyst.md
@@ -4,7 +4,7 @@ description: Business analyst. Creates or updates structured GitHub, Jira, or Az
 license: Apache-2.0
 metadata:
   author: Juan Antonio Breña Moral
-  version: 0.18.0-SNAPSHOT
+  version: 0.18.0
 model: inherit
 ---
 

--- a/.cursor/agents/robot-java-coder.md
+++ b/.cursor/agents/robot-java-coder.md
@@ -4,7 +4,7 @@ description: Implementation specialist for Java projects. Use when writing code,
 license: Apache-2.0
 metadata:
   author: Juan Antonio Breña Moral
-  version: 0.18.0-SNAPSHOT
+  version: 0.18.0
 model: inherit
 ---
 

--- a/.cursor/agents/robot-java-micronaut-coder.md
+++ b/.cursor/agents/robot-java-micronaut-coder.md
@@ -4,7 +4,7 @@ description: Implementation specialist for Micronaut projects. Use when writing 
 license: Apache-2.0
 metadata:
   author: Juan Antonio Breña Moral
-  version: 0.18.0-SNAPSHOT
+  version: 0.18.0
 model: inherit
 ---
 

--- a/.cursor/agents/robot-java-performance.md
+++ b/.cursor/agents/robot-java-performance.md
@@ -4,7 +4,7 @@ description: Java performance coordinator. Profiles applications, designs benchm
 license: Apache-2.0
 metadata:
   author: Juan Antonio Breña Moral
-  version: 0.18.0-SNAPSHOT
+  version: 0.18.0
 model: inherit
 ---
 

--- a/.cursor/agents/robot-java-quarkus-coder.md
+++ b/.cursor/agents/robot-java-quarkus-coder.md
@@ -4,7 +4,7 @@ description: Implementation specialist for Quarkus projects. Use when writing re
 license: Apache-2.0
 metadata:
   author: Juan Antonio Breña Moral
-  version: 0.18.0-SNAPSHOT
+  version: 0.18.0
 model: inherit
 ---
 

--- a/.cursor/agents/robot-java-spring-boot-coder.md
+++ b/.cursor/agents/robot-java-spring-boot-coder.md
@@ -4,7 +4,7 @@ description: Implementation specialist for Spring Boot projects. Use when writin
 license: Apache-2.0
 metadata:
   author: Juan Antonio Breña Moral
-  version: 0.18.0-SNAPSHOT
+  version: 0.18.0
 model: inherit
 ---
 

--- a/.cursor/agents/robot-no-java.md
+++ b/.cursor/agents/robot-no-java.md
@@ -4,7 +4,7 @@ description: Default implementation specialist for non-Java projects. Use when a
 license: Apache-2.0
 metadata:
   author: Juan Antonio Breña Moral
-  version: 0.18.0-SNAPSHOT
+  version: 0.18.0
 model: inherit
 ---
 

--- a/.cursor/agents/robot-tech-lead.md
+++ b/.cursor/agents/robot-tech-lead.md
@@ -4,7 +4,7 @@ description: Tech lead for Java Enterprise Development. Coordinates implementati
 license: Apache-2.0
 metadata:
   author: Juan Antonio Breña Moral
-  version: 0.18.0-SNAPSHOT
+  version: 0.18.0
 model: inherit
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] 2026-07-27
+
+### Added
+
+- **Benchmark**:
+  - Project benchmark harness under `benchmarks/` with reproducible scenario scorecards, including result samples generated with GitHub Copilot, Claude Sonnet 4.5, and Opus (#1012, #1052, #1057, #1068)
+
+- **Skills**:
+  - Five-lens problem exploration skills — problem framing, root cause analysis, assumption analysis, context mapping, and quality attribute discovery (`@021-problem-framing`, `@022-root-cause-analysis`, `@023-assumption-analysis`, `@024-context-mapping`, `@025-quality-attribute-discovery`) (#1071)
+  - BDD design skill (`@058-design-bdd`) (#1060)
+  - ATDD alignment review skill for classifying and reporting alignment between OpenSpec goals, acceptance criteria, and implementation/verification tasks (`@059-design-atdd`) (#1062)
+
+- **Agents & commands**:
+  - `/explore-problem` command to analyze an issue through five lenses and post a Functional Specification (#1043, #1071, #1076)
+  - Generated YAML frontmatter metadata for all commands (#1075, #1081)
+  - `create-spec` now reads complete issue context before drafting specs (#1078)
+  - Moved planning ownership from Tech Lead to the Architect agent; decoupled `/explore-design` from `create-spec` (#1024, #1026, #1028)
+  - Added an `implement-spec` readiness gate (#1080)
+  - `/close-spec` command to archive a completed OpenSpec change (#1041)
+
+- **PML & generators**:
+  - Extracted `plinth-commands-generator` and `plinth-agents-generator` as standalone modules (mirroring `plinth-skills-generator`), each with its own XSD schema (`commands.xsd`, `agents.xsd`), manifest, and propagation/bridge tests; renamed the parent Maven artifact to `plinth` (#1035, #1036, #1037, #1038, #992, #993, #1042)
+
 ## [0.17.0] 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PML & generators**:
   - Extracted `plinth-commands-generator` and `plinth-agents-generator` as standalone modules (mirroring `plinth-skills-generator`), each with its own XSD schema (`commands.xsd`, `agents.xsd`), manifest, and propagation/bridge tests; renamed the parent Maven artifact to `plinth` (#1035, #1036, #1037, #1038, #992, #993, #1042)
 
+### Removed
+
+- **Skills**:
+  - Removed the `034-architecture-design-exploration` skill; its steps were absorbed directly into the `/explore-design` command now that the command runs after `/create-spec` instead of standing in as the first design step (#1024, #1026, #1028)
+
 ## [0.17.0] 2026-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ Turn an idea into an actionable change with user stories, GitHub Issues or Jira,
 **Technical Specification:**
 
 ```
-/create-adr
+/create-adr (Optional)
 @robot-architect
     @030-architecture-adr-general
 
-/create-diagram
+/create-diagram (Optional)
 @robot-architect
     @033-architecture-diagrams
 
@@ -154,6 +154,9 @@ MCP Servers
     MongoDB
     JavaDocs
     Serena-LSP
+
+/close-spec
+@robot-architect
 ```
 
 ### Operate

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 <a href="https://trendshift.io/repositories/15013" target="_blank"><img src="https://trendshift.io/api/badge/repositories/15013" alt="jabrena%2Fcursor-rules-java | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
-[![Stargazers over time](https://starchart.cc/jabrena/plinth.svg?variant=adaptive)](https://starchart.cc/jabrena/plinth)
-
 [![CI Builds](https://github.com/jabrena/plinth/actions/workflows/maven.yaml/badge.svg)](https://github.com/jabrena/plinth/actions/workflows/maven.yaml)
 
 > **Languages:** [Español](./README_ES.md) · [中文](./README_ZH.md)
@@ -20,10 +18,9 @@ An opinionated AI-native workflow for evolving modern Java Enterprise `SDLC` pra
 
 ## Project at a glance
 
-- 11 Commands
+- 13 Commands
 - 9 Agents
-- 119 Skills
-- ~226 development hours
+- 125 Skills
 
 ## Latest Updates
 
@@ -76,6 +73,8 @@ Commands compose the workflow by routing work to the right agent and skill set:
 
 Turn an idea into an actionable change with user stories, GitHub Issues or Jira, ADRs, diagrams, AI plan mode, and OpenSpec.
 
+**Functional Specification:**
+
 ```text
 /update-issue
 @robot-business-analyst
@@ -83,31 +82,49 @@ Turn an idea into an actionable change with user stories, GitHub Issues or Jira,
     @044-planning-jira
     @045-planning-azure-devops
     @014-agile-user-story
+
+/explore-problem
+@robot-business-analyst
+    @021-problem-framing
+    @022-root-cause-analysis
+    @023-assumption-analysis
+    @024-context-mapping
+    @025-quality-attribute-discovery
+
+/create-acceptance-criteria
+@robot-business-analyst
+    @058-design-bdd
+```
+
+**Technical Specification:**
+
+```
 /create-adr
 @robot-architect
     @030-architecture-adr-general
-    @031-architecture-adr-functional-requirements
-    @032-architecture-adr-non-functional-requirements
+
 /create-diagram
 @robot-architect
     @033-architecture-diagrams
 
 /create-spec
-@robot-tech-lead
+@robot-architect
     @042-planning-openspec
+
+/explore-design
+@robot-architect
     @051-design-two-steps-methods
     @052-design-hamburger-method
     @053-design-simple-rules
     @054-design-tdd
     @055-design-parallel-change
     @056-design-avoid-breaking-changes
+    @057-design-feature-toggles
+    @059-design-atdd
     @121-java-object-oriented-design
     @122-java-type-design
     @123-java-design-patterns
     @130-java-testing-strategies
-/explore-design
-@robot-architect
-    @034-architecture-design-exploration
 
 MCP Servers
     Jbang-Quarkus-JDBC

--- a/README_ES.md
+++ b/README_ES.md
@@ -2,8 +2,6 @@
 
 <a href="https://trendshift.io/repositories/15013" target="_blank"><img src="https://trendshift.io/api/badge/repositories/15013" alt="jabrena%2Fcursor-rules-java | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
-[![Stargazers over time](https://starchart.cc/jabrena/plinth.svg?variant=adaptive)](https://starchart.cc/jabrena/plinth)
-
 [![CI Builds](https://github.com/jabrena/plinth/actions/workflows/maven.yaml/badge.svg)](https://github.com/jabrena/plinth/actions/workflows/maven.yaml)
 
 > **Idiomas:** [English](./README.md) · [中文](./README_ZH.md)
@@ -23,7 +21,6 @@ Un flujo de trabajo nativo de IA, con criterio propio, para evolucionar las prá
 - 13 Commands
 - 9 Agents
 - 125 Skills
-- ~226 horas de desarrollo
 
 ## Últimas actualizaciones
 
@@ -72,117 +69,118 @@ Los `System prompts/rules` actuales están deprecados y se eliminarán en `v0.18
 
 Los commands componen el flujo de trabajo dirigiendo cada tarea al agente y al conjunto de skills adecuados:
 
-```text
-Analysis & Design
-  /update-issue
-    @robot-business-analyst
-      @043-planning-github-issues
-      @044-planning-jira
-      @045-planning-azure-devops
-      @014-agile-user-story
-  /explore-problem
-    @robot-business-analyst
-      @021-problem-framing
-      @022-root-cause-analysis
-      @023-assumption-analysis
-      @024-context-mapping
-      @025-quality-attribute-discovery
-  /create-adr
-    @robot-architect
-      @030-architecture-adr-general
-      @031-architecture-adr-functional-requirements
-      @032-architecture-adr-non-functional-requirements
-  /create-diagram
-    @robot-architect
-      @033-architecture-diagrams
-
-  /create-spec
-    @robot-architect
-      @042-planning-openspec
-  /explore-design
-    @robot-architect
-      @051-design-two-steps-methods
-      @052-design-hamburger-method
-      @053-design-simple-rules
-      @054-design-tdd
-      @055-design-parallel-change
-      @056-design-avoid-breaking-changes
-      @057-design-feature-toggles
-      @059-design-atdd
-      @121-java-object-oriented-design
-      @122-java-type-design
-      @123-java-design-patterns
-      @130-java-testing-strategies
-
-Build
-  /implement-spec
-      @robot-tech-lead
-      /create-feature-branch
-      /create-worktree
-      @robot-java-coder
-      @robot-java-spring-boot-coder
-      @robot-java-quarkus-coder
-      @robot-java-micronaut-coder
-      @robot-no-java
-
-  MCP Servers
-    Jbang-Quarkus-JDBC
-    MongoDB
-    JavaDocs
-    Serena-LSP
-
-Operate
-  /profile
-    @robot-java-performance
-      @161-java-profiling-detect
-      @162-java-profiling-analyze
-      @163-java-profiling-refactor
-      @164-java-profiling-verify
-  /benchmark
-    @robot-java-performance
-      @151-java-performance-jmeter
-      @152-java-performance-gatling
-
-MCP Servers
-  Jbang-Quarkus-JDBC
-  MongoDB
-  JavaDocs
-  Serena-LSP
-  Grafana
-```
-
 ### Análisis y diseño
 
 Convierte una idea en un cambio accionable mediante user stories, GitHub Issues o Jira, ADRs, diagramas, AI plan mode y OpenSpec.
 
-| Recurso | Opciones disponibles |
-| --- | --- |
-| **Commands** | [`/update-issue`](./.cursor/commands/update-issue.md) · `/create-adr` · `/create-diagram` · `/create-spec` · `/explore-design` |
-| **Agents** | `@robot-business-analyst` · `@robot-architect` · `@robot-tech-lead` |
-| **Skills** | [014-agile-user-story](https://www.skills.sh/jabrena/plinth/014-agile-user-story) · [030-architecture-adr-general](https://www.skills.sh/jabrena/plinth/030-architecture-adr-general) · [031-architecture-adr-functional-requirements](https://www.skills.sh/jabrena/plinth/031-architecture-adr-functional-requirements) · [032-architecture-adr-non-functional-requirements](https://www.skills.sh/jabrena/plinth/032-architecture-adr-non-functional-requirements) · [033-architecture-diagrams](https://www.skills.sh/jabrena/plinth/033-architecture-diagrams) · [034-architecture-design-exploration](https://www.skills.sh/jabrena/plinth/034-architecture-design-exploration) · [041-planning-plan-mode](https://www.skills.sh/jabrena/plinth/041-planning-plan-mode) · [042-planning-openspec](https://www.skills.sh/jabrena/plinth/042-planning-openspec) · [043-planning-github-issues](https://www.skills.sh/jabrena/plinth/043-planning-github-issues) · [044-planning-jira](https://www.skills.sh/jabrena/plinth/044-planning-jira) · [051-design-two-steps-methods](https://www.skills.sh/jabrena/plinth/051-design-two-steps-methods) · [052-design-hamburger-method](https://www.skills.sh/jabrena/plinth/052-design-hamburger-method) · [053-design-simple-rules](https://www.skills.sh/jabrena/plinth/053-design-simple-rules) · [056-design-avoid-breaking-changes](https://www.skills.sh/jabrena/plinth/056-design-avoid-breaking-changes) · [200-agents-md](https://www.skills.sh/jabrena/plinth/200-agents-md) |
-| **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) |
+**Especificación funcional:**
+
+```text
+/update-issue
+@robot-business-analyst
+    @043-planning-github-issues
+    @044-planning-jira
+    @045-planning-azure-devops
+    @014-agile-user-story
+
+/explore-problem
+@robot-business-analyst
+    @021-problem-framing
+    @022-root-cause-analysis
+    @023-assumption-analysis
+    @024-context-mapping
+    @025-quality-attribute-discovery
+
+/create-acceptance-criteria
+@robot-business-analyst
+    @058-design-bdd
+```
+
+**Especificación técnica:**
+
+```
+/create-adr (Opcional)
+@robot-architect
+    @030-architecture-adr-general
+
+/create-diagram (Opcional)
+@robot-architect
+    @033-architecture-diagrams
+
+/create-spec
+@robot-architect
+    @042-planning-openspec
+
+/explore-design
+@robot-architect
+    @051-design-two-steps-methods
+    @052-design-hamburger-method
+    @053-design-simple-rules
+    @054-design-tdd
+    @055-design-parallel-change
+    @056-design-avoid-breaking-changes
+    @057-design-feature-toggles
+    @059-design-atdd
+    @121-java-object-oriented-design
+    @122-java-type-design
+    @123-java-design-patterns
+    @130-java-testing-strategies
+
+MCP Servers
+    Jbang-Quarkus-JDBC
+    MongoDB
+    JavaDocs
+    Serena-LSP
+    Grafana
+```
 
 ### Construir
 
 Implementa y mejora aplicaciones Java con orientación sobre Maven, diseño, programación, pruebas, seguridad, documentación, Spring Boot, Quarkus, Micronaut, OpenAPI y WireMock.
 
-| Recurso | Opciones disponibles |
-| --- | --- |
-| **Commands** | [`/create-feature-branch`](./.cursor/commands/create-feature-branch.md) · [`/create-worktree`](./.cursor/commands/create-worktree.md) · [`/implement-spec`](./.cursor/commands/implement-spec.md) |
-| **Agents** | `@robot-tech-lead` · `@robot-no-java` · `@robot-java-coder` · `@robot-java-spring-boot-coder` · `@robot-java-quarkus-coder` · `@robot-java-micronaut-coder` |
-| **Skills** | [110-java-maven-best-practices](https://www.skills.sh/jabrena/plinth/110-java-maven-best-practices) · [111-java-maven-dependencies](https://www.skills.sh/jabrena/plinth/111-java-maven-dependencies) · [121-java-object-oriented-design](https://www.skills.sh/jabrena/plinth/121-java-object-oriented-design) · [124-java-secure-coding](https://www.skills.sh/jabrena/plinth/124-java-secure-coding) · [143-java-functional-exception-handling](https://www.skills.sh/jabrena/plinth/143-java-functional-exception-handling) |
-| **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [JavaDocs](https://www.javadocs.dev/mcp) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) |
+```text
+/implement-spec
+@robot-tech-lead
+    /create-feature-branch
+    /create-worktree
+    @robot-java-coder
+    @robot-java-spring-boot-coder
+    @robot-java-quarkus-coder
+    @robot-java-micronaut-coder
+    @robot-no-java
+
+MCP Servers
+    Jbang-Quarkus-JDBC
+    MongoDB
+    JavaDocs
+    Serena-LSP
+
+/close-spec
+@robot-architect
+```
 
 ### Operar
 
 Mide y mejora el comportamiento en producción mediante observabilidad, profiling, benchmarking y pruebas de rendimiento.
 
-| Recurso | Opciones disponibles |
-| --- | --- |
-| **Commands** | [`/profile`](./.cursor/commands/profile.md) · [`/benchmark`](./.cursor/commands/benchmark.md) |
-| **Agents** | `@robot-java-performance` |
-| **Skills** | [151-java-performance-jmeter](https://www.skills.sh/jabrena/plinth/151-java-performance-jmeter) · [161-java-profiling-detect](https://www.skills.sh/jabrena/plinth/161-java-profiling-detect) · [162-java-profiling-analyze](https://www.skills.sh/jabrena/plinth/162-java-profiling-analyze) · [163-java-profiling-refactor](https://www.skills.sh/jabrena/plinth/163-java-profiling-refactor) · [164-java-profiling-verify](https://www.skills.sh/jabrena/plinth/164-java-profiling-verify) |
-| **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) · [Grafana](https://grafana.com/docs/grafana/latest/developer-resources/mcp/) |
+```text
+/profile
+@robot-java-performance
+    @161-java-profiling-detect
+    @162-java-profiling-analyze
+    @163-java-profiling-refactor
+    @164-java-profiling-verify
+/benchmark
+@robot-java-performance
+    @151-java-performance-jmeter
+    @152-java-performance-gatling
+
+MCP Servers
+    Jbang-Quarkus-JDBC
+    MongoDB
+    Serena-LSP
+    Grafana
+```
 
 ### Cumplimiento (Alpha)
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -20,9 +20,9 @@ Un flujo de trabajo nativo de IA, con criterio propio, para evolucionar las prá
 
 ## Proyecto de un vistazo
 
-- 11 Commands
+- 13 Commands
 - 9 Agents
-- 119 Skills
+- 125 Skills
 - ~226 horas de desarrollo
 
 ## Últimas actualizaciones
@@ -80,6 +80,13 @@ Analysis & Design
       @044-planning-jira
       @045-planning-azure-devops
       @014-agile-user-story
+  /explore-problem
+    @robot-business-analyst
+      @021-problem-framing
+      @022-root-cause-analysis
+      @023-assumption-analysis
+      @024-context-mapping
+      @025-quality-attribute-discovery
   /create-adr
     @robot-architect
       @030-architecture-adr-general
@@ -90,21 +97,22 @@ Analysis & Design
       @033-architecture-diagrams
 
   /create-spec
-    @robot-tech-lead
+    @robot-architect
       @042-planning-openspec
+  /explore-design
+    @robot-architect
       @051-design-two-steps-methods
       @052-design-hamburger-method
       @053-design-simple-rules
       @054-design-tdd
       @055-design-parallel-change
       @056-design-avoid-breaking-changes
+      @057-design-feature-toggles
+      @059-design-atdd
       @121-java-object-oriented-design
       @122-java-type-design
       @123-java-design-patterns
       @130-java-testing-strategies
-  /explore-design
-    @robot-architect
-      @034-architecture-design-exploration
 
 Build
   /implement-spec

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -2,8 +2,6 @@
 
 <a href="https://trendshift.io/repositories/15013" target="_blank"><img src="https://trendshift.io/api/badge/repositories/15013" alt="jabrena%2Fcursor-rules-java | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
-[![Stargazers over time](https://starchart.cc/jabrena/plinth.svg?variant=adaptive)](https://starchart.cc/jabrena/plinth)
-
 [![CI Builds](https://github.com/jabrena/plinth/actions/workflows/maven.yaml/badge.svg)](https://github.com/jabrena/plinth/actions/workflows/maven.yaml)
 
 > **语言：** [English](./README.md) · [Español](./README_ES.md)
@@ -23,7 +21,6 @@
 - 13 Commands
 - 9 Agents
 - 125 Skills
-- ~226 开发小时
 
 ## 最新动态
 
@@ -72,117 +69,118 @@ npx skills add jabrena/plinth --skill '*' --agent github-copilot -y
 
 Commands 通过把工作路由到合适的 agent 与 skill 集合来组合完整工作流：
 
-```text
-Analysis & Design
-  /update-issue
-    @robot-business-analyst
-      @043-planning-github-issues
-      @044-planning-jira
-      @045-planning-azure-devops
-      @014-agile-user-story
-  /explore-problem
-    @robot-business-analyst
-      @021-problem-framing
-      @022-root-cause-analysis
-      @023-assumption-analysis
-      @024-context-mapping
-      @025-quality-attribute-discovery
-  /create-adr
-    @robot-architect
-      @030-architecture-adr-general
-      @031-architecture-adr-functional-requirements
-      @032-architecture-adr-non-functional-requirements
-  /create-diagram
-    @robot-architect
-      @033-architecture-diagrams
-
-  /create-spec
-    @robot-architect
-      @042-planning-openspec
-  /explore-design
-    @robot-architect
-      @051-design-two-steps-methods
-      @052-design-hamburger-method
-      @053-design-simple-rules
-      @054-design-tdd
-      @055-design-parallel-change
-      @056-design-avoid-breaking-changes
-      @057-design-feature-toggles
-      @059-design-atdd
-      @121-java-object-oriented-design
-      @122-java-type-design
-      @123-java-design-patterns
-      @130-java-testing-strategies
-
-Build
-  /implement-spec
-      @robot-tech-lead
-      /create-feature-branch
-      /create-worktree
-      @robot-java-coder
-      @robot-java-spring-boot-coder
-      @robot-java-quarkus-coder
-      @robot-java-micronaut-coder
-      @robot-no-java
-
-  MCP Servers
-    Jbang-Quarkus-JDBC
-    MongoDB
-    JavaDocs
-    Serena-LSP
-
-Operate
-  /profile
-    @robot-java-performance
-      @161-java-profiling-detect
-      @162-java-profiling-analyze
-      @163-java-profiling-refactor
-      @164-java-profiling-verify
-  /benchmark
-    @robot-java-performance
-      @151-java-performance-jmeter
-      @152-java-performance-gatling
-
-MCP Servers
-  Jbang-Quarkus-JDBC
-  MongoDB
-  JavaDocs
-  Serena-LSP
-  Grafana
-```
-
 ### 分析与设计
 
 通过 user stories、GitHub Issues 或 Jira、ADR、图表、AI plan mode 和 OpenSpec，将想法转化为可执行的变更。
 
-| 资源 | 可用选项 |
-| --- | --- |
-| **Commands** | [`/update-issue`](./.cursor/commands/update-issue.md) · `/create-adr` · `/create-diagram` · `/create-spec` · `/explore-design` |
-| **Agents** | `@robot-business-analyst` · `@robot-architect` · `@robot-tech-lead` |
-| **Skills** | [014-agile-user-story](https://www.skills.sh/jabrena/plinth/014-agile-user-story) · [030-architecture-adr-general](https://www.skills.sh/jabrena/plinth/030-architecture-adr-general) · [031-architecture-adr-functional-requirements](https://www.skills.sh/jabrena/plinth/031-architecture-adr-functional-requirements) · [032-architecture-adr-non-functional-requirements](https://www.skills.sh/jabrena/plinth/032-architecture-adr-non-functional-requirements) · [033-architecture-diagrams](https://www.skills.sh/jabrena/plinth/033-architecture-diagrams) · [034-architecture-design-exploration](https://www.skills.sh/jabrena/plinth/034-architecture-design-exploration) · [041-planning-plan-mode](https://www.skills.sh/jabrena/plinth/041-planning-plan-mode) · [042-planning-openspec](https://www.skills.sh/jabrena/plinth/042-planning-openspec) · [043-planning-github-issues](https://www.skills.sh/jabrena/plinth/043-planning-github-issues) · [044-planning-jira](https://www.skills.sh/jabrena/plinth/044-planning-jira) · [051-design-two-steps-methods](https://www.skills.sh/jabrena/plinth/051-design-two-steps-methods) · [052-design-hamburger-method](https://www.skills.sh/jabrena/plinth/052-design-hamburger-method) · [053-design-simple-rules](https://www.skills.sh/jabrena/plinth/053-design-simple-rules) · [056-design-avoid-breaking-changes](https://www.skills.sh/jabrena/plinth/056-design-avoid-breaking-changes) · [200-agents-md](https://www.skills.sh/jabrena/plinth/200-agents-md) |
-| **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) |
+**功能规格：**
+
+```text
+/update-issue
+@robot-business-analyst
+    @043-planning-github-issues
+    @044-planning-jira
+    @045-planning-azure-devops
+    @014-agile-user-story
+
+/explore-problem
+@robot-business-analyst
+    @021-problem-framing
+    @022-root-cause-analysis
+    @023-assumption-analysis
+    @024-context-mapping
+    @025-quality-attribute-discovery
+
+/create-acceptance-criteria
+@robot-business-analyst
+    @058-design-bdd
+```
+
+**技术规格：**
+
+```
+/create-adr (可选)
+@robot-architect
+    @030-architecture-adr-general
+
+/create-diagram (可选)
+@robot-architect
+    @033-architecture-diagrams
+
+/create-spec
+@robot-architect
+    @042-planning-openspec
+
+/explore-design
+@robot-architect
+    @051-design-two-steps-methods
+    @052-design-hamburger-method
+    @053-design-simple-rules
+    @054-design-tdd
+    @055-design-parallel-change
+    @056-design-avoid-breaking-changes
+    @057-design-feature-toggles
+    @059-design-atdd
+    @121-java-object-oriented-design
+    @122-java-type-design
+    @123-java-design-patterns
+    @130-java-testing-strategies
+
+MCP Servers
+    Jbang-Quarkus-JDBC
+    MongoDB
+    JavaDocs
+    Serena-LSP
+    Grafana
+```
 
 ### 构建
 
 借助 Maven、设计、编码、测试、安全、文档、Spring Boot、Quarkus、Micronaut、OpenAPI 和 WireMock 指南，实现并改进 Java 应用程序。
 
-| 资源 | 可用选项 |
-| --- | --- |
-| **Commands** | [`/create-feature-branch`](./.cursor/commands/create-feature-branch.md) · [`/create-worktree`](./.cursor/commands/create-worktree.md) · [`/implement-spec`](./.cursor/commands/implement-spec.md) |
-| **Agents** | `@robot-tech-lead` · `@robot-no-java` · `@robot-java-coder` · `@robot-java-spring-boot-coder` · `@robot-java-quarkus-coder` · `@robot-java-micronaut-coder` |
-| **Skills** | [110-java-maven-best-practices](https://www.skills.sh/jabrena/plinth/110-java-maven-best-practices) · [111-java-maven-dependencies](https://www.skills.sh/jabrena/plinth/111-java-maven-dependencies) · [121-java-object-oriented-design](https://www.skills.sh/jabrena/plinth/121-java-object-oriented-design) · [124-java-secure-coding](https://www.skills.sh/jabrena/plinth/124-java-secure-coding) · [143-java-functional-exception-handling](https://www.skills.sh/jabrena/plinth/143-java-functional-exception-handling) |
-| **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [JavaDocs](https://www.javadocs.dev/mcp) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) |
+```text
+/implement-spec
+@robot-tech-lead
+    /create-feature-branch
+    /create-worktree
+    @robot-java-coder
+    @robot-java-spring-boot-coder
+    @robot-java-quarkus-coder
+    @robot-java-micronaut-coder
+    @robot-no-java
+
+MCP Servers
+    Jbang-Quarkus-JDBC
+    MongoDB
+    JavaDocs
+    Serena-LSP
+
+/close-spec
+@robot-architect
+```
 
 ### 运维
 
 通过可观测性、profiling、benchmarking 和性能测试来衡量并改进生产行为。
 
-| 资源 | 可用选项 |
-| --- | --- |
-| **Commands** | [`/profile`](./.cursor/commands/profile.md) · [`/benchmark`](./.cursor/commands/benchmark.md) |
-| **Agents** | `@robot-java-performance` |
-| **Skills** | [151-java-performance-jmeter](https://www.skills.sh/jabrena/plinth/151-java-performance-jmeter) · [161-java-profiling-detect](https://www.skills.sh/jabrena/plinth/161-java-profiling-detect) · [162-java-profiling-analyze](https://www.skills.sh/jabrena/plinth/162-java-profiling-analyze) · [163-java-profiling-refactor](https://www.skills.sh/jabrena/plinth/163-java-profiling-refactor) · [164-java-profiling-verify](https://www.skills.sh/jabrena/plinth/164-java-profiling-verify) |
-| **MCP Servers** | [Jbang-Quarkus-JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/README.md) · [MongoDB](https://github.com/mongodb-js/mongodb-mcp-server) · [Serena-LSP](https://oraios.github.io/serena/01-about/000_intro.html) · [Grafana](https://grafana.com/docs/grafana/latest/developer-resources/mcp/) |
+```text
+/profile
+@robot-java-performance
+    @161-java-profiling-detect
+    @162-java-profiling-analyze
+    @163-java-profiling-refactor
+    @164-java-profiling-verify
+/benchmark
+@robot-java-performance
+    @151-java-performance-jmeter
+    @152-java-performance-gatling
+
+MCP Servers
+    Jbang-Quarkus-JDBC
+    MongoDB
+    Serena-LSP
+    Grafana
+```
 
 ### 合规 (Alpha)
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -20,9 +20,9 @@
 
 ## 项目概览
 
-- 11 Commands
+- 13 Commands
 - 9 Agents
-- 119 Skills
+- 125 Skills
 - ~226 开发小时
 
 ## 最新动态
@@ -80,6 +80,13 @@ Analysis & Design
       @044-planning-jira
       @045-planning-azure-devops
       @014-agile-user-story
+  /explore-problem
+    @robot-business-analyst
+      @021-problem-framing
+      @022-root-cause-analysis
+      @023-assumption-analysis
+      @024-context-mapping
+      @025-quality-attribute-discovery
   /create-adr
     @robot-architect
       @030-architecture-adr-general
@@ -90,21 +97,22 @@ Analysis & Design
       @033-architecture-diagrams
 
   /create-spec
-    @robot-tech-lead
+    @robot-architect
       @042-planning-openspec
+  /explore-design
+    @robot-architect
       @051-design-two-steps-methods
       @052-design-hamburger-method
       @053-design-simple-rules
       @054-design-tdd
       @055-design-parallel-change
       @056-design-avoid-breaking-changes
+      @057-design-feature-toggles
+      @059-design-atdd
       @121-java-object-oriented-design
       @122-java-type-design
       @123-java-design-patterns
       @130-java-testing-strategies
-  /explore-design
-    @robot-architect
-      @034-architecture-design-exploration
 
 Build
   /implement-spec

--- a/documentation/MAINTENANCE.md
+++ b/documentation/MAINTENANCE.md
@@ -8,11 +8,11 @@ Some **User prompts** designed to help in the maintenance of this repository.
 
 ```bash
 # Maven command to update the maven version to next minor version
-./mvnw versions:set -DnewVersion=0.18.0-SNAPSHOT
+./mvnw versions:set -DnewVersion=0.19.0-SNAPSHOT
 ./mvnw versions:commit
 
 #Bump to a new snapshot
-@skill-resources/src/main/resources/ update version to 0.18.0-SNAPSHOT finally regenerate local skills with ./mvnw clean install -pl plinth-skills-generator
+@skill-resources/src/main/resources/ update version to 0.19.0-SNAPSHOT finally regenerate local skills with ./mvnw clean install -pl plinth-skills-generator -am
 
 #Update the XML Schema to latest version
 @skill-resources/src/main/resources/ update all XML Schema with XSD Configuration pointing to PML 0.8.0 and regenerate local skills with ./mvnw clean install -pl plinth-skills-generator
@@ -34,7 +34,7 @@ Review that the list doesn´t any broken link to @/.cursor with .md files
 Can you update the current changelog for 0.18.0 comparing git commits in relation to 0.17.0 tag. Use  @https://keepachangelog.com/en/1.1.0/  rules
 
 #Bump to a new snapshot
-@resources/ update version to 0.17.0 and pom.xml, maven modules and finally regenerate local skills with ./mvnw clean install -pl plinth-skills-generator
+Update version to 0.18.0 for all XML files and pom.xml in all maven modules and finally regenerate local skills with ./mvnw clean install -pl plinth-skills-generator -am
 
 ```
 
@@ -77,30 +77,17 @@ cd target && npx skills add jabrena/plinth --all --agent cursor && cd ..
 Can you update the current changelog for 0.14.0 comparing git commits in relation to 0.13.0 tag. Use  @https://keepachangelog.com/en/1.1.0/  rules
 
 # Maven command to update the maven version to next minor version
-./mvnw versions:set -DnewVersion=0.17.0
+./mvnw versions:set -DnewVersion=0.18.0
 ./mvnw versions:commit
 
 # Prompt to update the project to a new version
-Update xml files from @resources/ and update the version to 0.17.0 removing Snapshot.
-Update @pom.xml with the new version 0.15.0-SNAPSHOT Regenerate local skills with ./mvnw clean install -pl plinth-skills-generator. If preparing release output, refresh skills/ with ./mvnw clean install -pl plinth-skills-generator -P release
-
-Update md files from @resources/ and update the version to 0.15.0 removing Snapshot.
-Update @pom.xml with the new version 0.15.0-SNAPSHOT Regenerate local skills with ./mvnw clean install -pl plinth-skills-generator. If preparing release output, refresh skills/ with ./mvnw clean install -pl plinth-skills-generator -P release
-
-## Note: Refactor a bit more to include all pom.xml
+Update xml files from @resources/ and update the version to 0.18.0 removing Snapshot.
+./mvnw clean verify -pl plinth-skills-generator -am
 
 ## Tagging process
 git tag --list
-git tag 0.16.0
+git tag 0.18.0
 git push --tags
-```
-
----
-
-## Add a new Skills
-
-```bash
-review if exist a new id in @plinth-skills-generator/src/main/resources/skills.xml to review compare with the content of @plinth-skills-generator/src/main/resources/skill-indexes and if exist add a new skill summary in @plinth-skills-generator/src/main/resources/skill-indexes. to elaborate the skill, review the `reference-list/reference` relation declared for that id in @plinth-skills-generator/src/main/resources/skills.xml. when finish, validate local generation with ./mvnw clean install -pl plinth-skills-generator and validate release skills with npx skill-check skills after running ./mvnw clean install -pl plinth-skills-generator -P release
 ```
 
 ## Improve skills

--- a/documentation/MAINTENANCE.md
+++ b/documentation/MAINTENANCE.md
@@ -31,7 +31,7 @@ Can you analyze the last Java version, Java 26 from @All-JEPS.md if exist some J
 Review that the list doesn´t any broken link to @/.cursor with .md files
 
 # Prompt to provide a release changelog
-Can you update the current changelog for 0.17.0 comparing git commits in relation to 0.16.0 tag. Use  @https://keepachangelog.com/en/1.1.0/  rules
+Can you update the current changelog for 0.18.0 comparing git commits in relation to 0.17.0 tag. Use  @https://keepachangelog.com/en/1.1.0/  rules
 
 #Bump to a new snapshot
 @resources/ update version to 0.17.0 and pom.xml, maven modules and finally regenerate local skills with ./mvnw clean install -pl plinth-skills-generator

--- a/markdown-validator/pom.xml
+++ b/markdown-validator/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>info.jab</groupId>
         <artifactId>plinth</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plinth-agents-generator/pom.xml
+++ b/plinth-agents-generator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>info.jab</groupId>
         <artifactId>plinth</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plinth-agents-generator/src/main/resources/agents/robot-architect.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-architect.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>robot-architect</title>
         <description>Java architecture specialist. Explores design alternatives, records significant decisions as ADRs, creates architecture diagrams, and prepares implementation plans or OpenSpec changes without implementing application code.</description>

--- a/plinth-agents-generator/src/main/resources/agents/robot-business-analyst.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-business-analyst.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>robot-business-analyst</title>
         <description>Business analyst. Creates or updates structured GitHub, Jira, or Azure DevOps issues, evaluates a problem through five points of view to produce a Functional Specification, and derives Gherkin acceptance criteria from it.</description>

--- a/plinth-agents-generator/src/main/resources/agents/robot-java-coder.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-java-coder.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>robot-java-coder</title>
         <description>Implementation specialist for Java projects. Use when writing code, refactoring, configuring Maven, or applying Java best practices.</description>

--- a/plinth-agents-generator/src/main/resources/agents/robot-java-micronaut-coder.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-java-micronaut-coder.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>robot-java-micronaut-coder</title>
         <description>Implementation specialist for Micronaut projects. Use when writing controllers, REST APIs, validation, security, Micronaut Data repositories, Kafka, MongoDB, CDI-style beans, or any Micronaut-specific code.</description>

--- a/plinth-agents-generator/src/main/resources/agents/robot-java-performance.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-java-performance.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>robot-java-performance</title>
         <description>Java performance coordinator. Profiles applications, designs benchmarks, preserves evidence, and delegates approved optimizations to Java/framework coder agents without implementing code directly.</description>

--- a/plinth-agents-generator/src/main/resources/agents/robot-java-quarkus-coder.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-java-quarkus-coder.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>robot-java-quarkus-coder</title>
         <description>Implementation specialist for Quarkus projects. Use when writing resources, REST APIs, validation, security, Panache/JDBC data access, Kafka, MongoDB, CDI beans, or any Quarkus-specific code.</description>

--- a/plinth-agents-generator/src/main/resources/agents/robot-java-spring-boot-coder.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-java-spring-boot-coder.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>robot-java-spring-boot-coder</title>
         <description>Implementation specialist for Spring Boot projects. Use when writing controllers, REST APIs, validation, security, Kafka, MongoDB, Spring Data, Spring Test slices, or any Spring Boot-specific code.</description>

--- a/plinth-agents-generator/src/main/resources/agents/robot-no-java.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-no-java.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>robot-no-java</title>
         <description>Default implementation specialist for non-Java projects. Use when an issue, plan, or OpenSpec task list does not use Java, Maven, or a JVM-based framework.</description>

--- a/plinth-agents-generator/src/main/resources/agents/robot-tech-lead.xml
+++ b/plinth-agents-generator/src/main/resources/agents/robot-tech-lead.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>robot-tech-lead</title>
         <description>Tech lead for Java Enterprise Development. Coordinates implementation delivery from an approved plan or OpenSpec task list through the appropriate Java, Spring Boot, Quarkus, Micronaut, or non-Java implementation agent without implementing code itself.</description>

--- a/plinth-commands-generator/pom.xml
+++ b/plinth-commands-generator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>info.jab</groupId>
         <artifactId>plinth</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plinth-skills-generator/pom.xml
+++ b/plinth-skills-generator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>info.jab</groupId>
         <artifactId>plinth</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plinth-skills-generator/src/main/resources/skill-indexes/001-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/001-skill.xml
@@ -4,7 +4,7 @@
       id="001-commands-inventory">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to generate a checklist document with embedded commands inventory, following the embedded template exactly and producing INVENTORY-COMMANDS-JAVA.md in the project root. This should trigger for requests such as Create embedded commands inventory checklist; Generate INVENTORY-COMMANDS-JAVA.md; Use @001-commands-inventory; Inventory embedded Java project commands; List command files bundled for Java agents.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/002-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/002-skill.xml
@@ -4,7 +4,7 @@
       id="002-agents-inventory">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to generate a checklist document with embedded agents inventory, following the embedded template exactly and producing INVENTORY-AGENTS-JAVA.md in the project root. This should trigger for requests such as Create embedded agents inventory checklist; Generate INVENTORY-AGENTS-JAVA.md; Use @002-agents-inventory; Inventory embedded Java agent definitions; List generated agent roles for Java development.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/003-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/003-skill.xml
@@ -4,7 +4,7 @@
       id="003-skills-inventory">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to generate a checklist document with Java system prompts from skills.xml, following the embedded section template and producing INVENTORY-SKILLS-JAVA.md. This should trigger for requests such as Create Java system prompts checklist; Generate INVENTORY-SKILLS-JAVA.md; Use @003-skills-inventory; Inventory Java cursor rule skills; List available Java system prompt skills.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/004-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/004-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to install the embedded project commands into command directories (.github/commands, .claude/commands, .cursor/command, .codex/commands), selecting the destination interactively and copying the embedded command definitions from project assets. This should trigger for requests such as Install embedded commands; Bootstrap .cursor/command; Bootstrap .claude/commands; Copy project commands; Install project command suite.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/005-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/005-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to install the embedded robot agents into .github/agents, .claude/agents, .cursor/agents, or .codex/agents, selecting the destination interactively and copying the embedded agent definitions from project assets. This should trigger for requests such as Install embedded agents; Bootstrap .github/agents; Bootstrap .cursor/agents; Bootstrap .claude/agents; Bootstrap .codex/agents; Copy robot agents.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/012-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/012-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Guides the creation of agile epics with comprehensive definition including business value, success criteria, and breakdown into user stories. Use when the user wants to create an agile epic, define large bodies of work, break down features into user stories, or document strategic initiatives. This should trigger for requests such as Create an agile epic; Write an epic; I need to create an epic; Define an epic; Epic definition.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/013-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/013-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Guides the creation of detailed agile feature documentation from an existing epic. Use when the user wants to split an epic into feature files, derive features with scope and acceptance criteria, or plan feature documentation for stakeholders or engineering. This should trigger for requests such as Create features from an epic; Split epic into features; Feature files from epic; Derive features from epic; Break down an agile epic into deliverable features.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/014-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/014-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Guides the creation of agile user stories. Use when the user wants to create a user story. This should trigger for requests such as Create a user story; Write a user story; I need to write a user story; Split feature requirements into user stories.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/021-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/021-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when a problem or issue needs explicit framing before deeper analysis begins — establishing the Problem statement, Current state, Desired state, Stakeholders, and Success criteria. This should trigger when an issue's Problem Framing point of view needs evaluation, or when a maintainer directly asks to frame a problem before root-cause analysis, design, or planning begins.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/022-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/022-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when a framed problem needs root-cause investigation rather than a symptom-level fix, applying Five Whys, Fishbone (Ishikawa), Current Reality Tree, and constraint identification. This should trigger when an issue's Root Cause Analysis point of view needs evaluation, or when a maintainer directly asks to find the root cause of a problem before proposing a fix.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/023-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/023-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when a framed and root-caused problem needs its assumptions made explicit before design or planning begins — explicit Assumptions, Unknowns, and a Validation plan. This should trigger when an issue's Assumption Analysis point of view needs evaluation, or when a maintainer directly asks to surface hidden assumptions and unknowns before committing to an approach.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/024-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/024-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when a problem under exploration needs its surrounding system context identified before design begins — Existing systems, Integrations, Ownership, and External dependencies. This should trigger when an issue's Context Mapping point of view needs evaluation, or when a maintainer directly asks to map the systems, integrations, owners, and external dependencies relevant to a problem.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/025-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/025-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when a problem under exploration needs its quality attributes (non-functional requirements) identified and prioritized before architecture and design begin. This should trigger when an issue's Quality Attribute Discovery point of view needs evaluation, or when a maintainer directly asks to discover and prioritize candidate quality attributes for a problem, before any ADR or design work starts.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/030-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/030-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to generate Architecture Decision Records (ADRs) for a Java project through an interactive, conversational process that systematically gathers context, stakeholders, options, and outcomes to produce well-structured ADR documents. This should trigger for requests such as Generate ADR; Create Architecture Decision Record; Document architecture decision; Architecture Decision Record for Java.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/031-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/031-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Facilitates conversational discovery to create Architectural Decision Records (ADRs) for functional requirements covering CLI, REST/HTTP APIs, or both. Use when the user wants to document command-line or HTTP service architecture, capture functional requirements, create ADRs for CLI or API projects, or design interfaces with documented decisions. This should trigger for requests such as Create ADR for functional requirements; Document functional requirements; Capture functional requirements; Generate functional requirements in an ADR; Decide CLI versus REST functional requirements for an ADR.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/032-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/032-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Facilitates conversational discovery to create Architectural Decision Records (ADRs) for non-functional requirements using the ISO/IEC 25010:2023 quality model. Use when the user wants to document quality attributes, NFR decisions, security/performance/scalability architecture, or design systems with measurable quality criteria. This should trigger for requests such as Create ADR for Non-functional requirements; Document Non-functional requirements; Capture Non-functional requirements; Generate Non-functional requirements in an ADR; Create ADR for performance scalability or security requirements.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/033-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/033-skill.xml
@@ -6,7 +6,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to generate Java project diagrams — including UML sequence diagrams, UML class diagrams, C4 model diagrams, UML state machine diagrams, UML Deployment Diagrams, ER (Entity Relationship) diagrams, and bounded-context diagrams — through a modular, step-based interactive process that adapts to your specific visualization needs. This should trigger for requests such as Generate UML diagram; Create sequence diagram; Create class diagram; Create state machine diagram; Create deployment diagram; Create C4 diagram; Create bounded-context diagram; Create context-map diagram.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/041-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/041-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when creating or refining a structured Java implementation plan from trusted issue summaries, approved designs, ADRs, OpenSpec changes, existing plans, or a valid combination. The plan records its source artifacts and derivation direction and can remain the execution artifact without requiring OpenSpec. This should trigger for requests such as Create a plan from an issue; Create a plan from OpenSpec; Design an implementation plan; Refine an existing plan.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/042-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/042-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when creating or updating OpenSpec change artifacts from an issue, implementation plan, approved design, ADRs, existing OpenSpec artifacts, or a valid combination. The workflow assesses whether the scope is one change or multiple changes, records sources and derivation direction, and prevents silent synchronization. This should trigger for requests such as Create an OpenSpec change from an issue; Convert a plan into OpenSpec; Update an existing OpenSpec change; Split broad requirements into reviewable OpenSpec changes.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/043-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/043-skill.xml
@@ -4,7 +4,7 @@
       id="043-planning-github-issues">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need GitHub CLI (`gh`) installation/authentication guidance and an operator-only GitHub issue inventory workflow. The agent does not ingest GitHub issue, milestone, body, comment, title, label, or summary text; requirements analysis must use repository-owned planning artifacts, with issue numbers only for traceability. This should trigger for requests such as GitHub issue inventory workflow; GitHub CLI setup for issues; Prepare issue traceability lists; Analyze repository planning artifacts linked to GitHub issues.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/044-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/044-skill.xml
@@ -4,7 +4,7 @@
       id="044-planning-jira">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need Jira CLI (`jira`) installation/authentication guidance and a maintainer-authored Jira issue inventory workflow. The agent does not ingest raw Jira issue or JQL output directly; it asks the Jira project maintainer/operator to author sanitized issue summaries before analysis or @014-agile-user-story handoff. This should trigger for requests such as jira issue list; List Jira issues; Jira JQL issue query; Jira CLI issue workflow.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/045-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/045-skill.xml
@@ -7,7 +7,7 @@
       <author>Juan Antonio Breña Moral</author>
       <author>Leandro Loureiro</author>
     </authors>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need Azure DevOps CLI guidance to verify installation, configure organization and project context, discover work item IDs by optional WIQL filters, and execute safe work-item create/update operations. Uses an interactive install gate - if `az` or the Azure DevOps extension is missing, ask whether to show installation guidance before any work item commands. This should trigger for requests such as Azure DevOps work item list; List Azure Boards work item IDs; Azure DevOps WIQL query; Azure DevOps CLI planning workflow.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/051-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/051-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when a complex or risky code change should be split into Kent Beck's two-step method by first making the change easy through behavior-preserving preparatory refactoring, then making the intended behavior change once the design supports it. This should trigger for requests such as Apply two-step change; Make this risky change safer; Refactor before changing behavior; Separate preparation from behavior change.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/052-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/052-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when a large feature, story, plan, or spec idea needs to be split into small vertical slices with the Hamburger Method. This should trigger for requests such as Split this oversized story; Find the smallest useful slice; Break this feature into vertical slices; Apply the Hamburger Method; Turn this broad plan into tracked slices.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/053-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/053-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when Java design, refactoring, or implementation tradeoffs should be evaluated with Kent Beck's simple design rules, including passes the tests, reveals intention, has no duplication, and has the fewest elements. This should trigger for requests such as Apply simple design rules; Review this design with Beck's rules; Choose between these refactoring options; Keep this Java design simple.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/054-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/054-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when Java implementation work should be guided by Test-Driven Development, including maintaining a test list, choosing the next behavior, writing a failing test first, implementing only enough production code to pass, and refactoring while keeping tests green. This should trigger for requests such as Apply TDD; Use test-driven development; Drive this Java change with tests; Write the failing test first; Red-green-refactor this feature.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/055-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/055-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when a database schema or data-meaning change needs Parallel Change, including expand, migrate, and contract sequencing for column renames, type or data reinterpretation, large-table backfills, relationship-table changes, enum/status transitions, timezone/default changes, and index or uniqueness changes. This should trigger before framework-specific Flyway implementation guidance when deciding whether a migration needs a compatibility window or whether a simpler migration is sufficient.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/056-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/056-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to review a plan, OpenSpec change, specification, or implementation proposal for breaking-change risk across commands, skills, generated outputs, XML sources, README/docs, tests, CI, APIs, schemas, configuration, data, migration, and release guidance. This should trigger for requests such as Review breaking changes in this spec; Check compatibility risks; Avoid breaking changes in this OpenSpec change; Review migration impact before release; Assess command and skill compatibility.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/057-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/057-skill.xml
@@ -8,7 +8,7 @@
       <author>Juan Antonio Breña Moral</author>
       <author>Sangwon Park</author>
     </authors>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when designing, implementing, reviewing, testing, or cleaning up feature toggles, feature flags, kill switches, runtime configuration gates, canary controls, staged rollouts, experiments, or temporary compatibility switches in Java enterprise systems. This should trigger for requests such as Design a feature toggle strategy; Review this feature flag; Add a kill switch safely; Test toggle on and off paths; Clean up an expired feature toggle; Plan controlled rollout and rollback behavior.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/058-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/058-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when a Java change needs independent Behavior-Driven Development guidance from trusted behavior facts through concrete examples and observable scenarios, with focused clarification when behavior is pending or ambiguous. This should trigger for requests such as Apply BDD; Facilitate behavior examples; Discover scenarios with Given When Then; Review these examples for shared domain language; Complete BDD discovery as a self-contained interaction.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/059-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/059-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing whether an OpenSpec change's execution goal, acceptance criteria, and implementation or verification tasks are aligned. This should trigger for requests such as Review this OpenSpec change with ATDD; Check acceptance criteria against tasks; Find acceptance criteria without task coverage; Detect tasks that diverge from the execution goal; Explain what is missing, vague, ambiguous, partial, absent, or divergent in this OpenSpec change.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/110-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/110-skill.xml
@@ -4,7 +4,7 @@
       id="110-java-maven-best-practices">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to review, improve, or troubleshoot a Maven pom.xml file — including dependency management with BOMs, plugin configuration, version centralization, multi-module project structure, build profiles, or any situation where you want to align your Maven setup with industry best practices. This should trigger for requests such as Review pom.xml to improve it; Apply Maven best practices to pom.xml; Improve Maven POM configuration; Review Maven dependency management and plugin configuration; Modernize Maven build conventions for a Java project.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/111-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/111-skill.xml
@@ -6,7 +6,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or evaluate Maven dependencies that improve code quality or domain modeling — including nullness annotations (JSpecify), static analysis (Error Prone + NullAway), functional programming (VAVR), architecture testing (ArchUnit), or money and currency support (JavaMoney) — and want a consultative, question-driven approach that adds only what you actually need. This should trigger for requests such as Add Maven dependencies; Add JSpecify nullness dependencies; Add Error Prone NullAway dependencies; Add VAVR functional dependencies; Add ArchUnit architecture testing dependencies; Add JavaMoney dependencies.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/112-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/112-skill.xml
@@ -6,7 +6,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or configure Maven plugins in your pom.xml — including quality tools (enforcer, surefire, failsafe, jacoco, pitest, spotbugs, pmd), security scanning (OWASP), code formatting (Spotless), version management, container image build (Jib), build information tracking, and benchmarking (JMH) — through a consultative, modular step-by-step approach that only adds what you actually need. This should trigger for requests such as Add Maven plugins in pom.xml; Improve Maven plugins in pom.xml; Configure Maven quality plugins in pom.xml; Add Maven build lifecycle plugins for Java verification; Review Maven plugin versions and executions.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/113-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/113-skill.xml
@@ -4,7 +4,7 @@
       id="113-java-maven-documentation">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to create a DEVELOPER.md file for a Maven project — combining a fixed base template with dynamic sections derived from allowlisted Maven POM structure, including a Plugin Goals Reference, Maven Profiles table, and Submodules table for multi-module projects. This should trigger for requests such as Create DEVELOPER.md; Generate DEVELOPER.md; Maven project documentation; Add Maven documentation; Plugin goals reference.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/114-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/114-skill.xml
@@ -4,7 +4,7 @@
       id="114-java-maven-search">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Routes Maven version questions to the right workflow by choosing project-local update report interpretation for a user’s own pom.xml, or Maven artifact discovery from maintainer-approved structured evidence. Use when interpreting dependency, plugin, or property update reports; finding Maven coordinates; verifying groupId artifactId version; browsing versions from approved evidence; or constructing artifact URLs without fetching remote content.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/121-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/121-skill.xml
@@ -4,7 +4,7 @@
       id="121-java-object-oriented-design">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, improving, or refactoring Java object-oriented design, including applying SOLID, DRY, or YAGNI; improving classes and interfaces; correcting encapsulation, inheritance, or polymorphism; resolving God Class, Feature Envy, or Data Clumps; and improving object creation, methods, or exception contracts. Triggers include review Java OOD, refactor Java OOD, improve Java OOD, fix OOP misuse, and identify Java code smells.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/122-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/122-skill.xml
@@ -4,7 +4,7 @@
       id="122-java-type-design">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to review, improve, or refactor Java code for type design quality — including establishing clear type hierarchies, applying consistent naming conventions, eliminating primitive obsession with domain-specific value objects, leveraging generic type parameters, creating type-safe wrappers, designing fluent interfaces, ensuring precision-appropriate numeric types (BigDecimal for financial calculations), and improving type contrast through interfaces and method signature alignment. This should trigger for requests such as Review Java code for type design; Improve type design in Java code; Fix primitive obsession in Java code; Create value objects in Java code.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/123-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/123-skill.xml
@@ -4,7 +4,7 @@
       id="123-java-design-patterns">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to select, review, or implement Java design and integration patterns — including classic Java design patterns, REST API patterns, Kafka and event-driven patterns, database and persistence patterns, and cross-cutting integration patterns. This should trigger for requests such as Apply Java design patterns; Review REST API patterns; Design Kafka event-driven patterns; Improve database persistence patterns; Add resilient integration patterns.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/124-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/124-skill.xml
@@ -4,7 +4,7 @@
       id="124-java-secure-coding">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to apply Java secure coding best practices — including validating untrusted inputs, defending against injection attacks with parameterized queries, minimizing attack surface via least privilege, applying strong cryptographic algorithms, handling exceptions securely without exposing sensitive data, managing secrets at runtime, avoiding unsafe deserialization, and encoding output to prevent XSS. This should trigger for requests such as Review Java code for secure coding; Find input validation risks in Java code; Review Java code for injection vulnerabilities; Improve secure error handling in Java services; Harden Java code against common security flaws.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/125-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/125-skill.xml
@@ -4,7 +4,7 @@
       id="125-java-concurrency">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to apply Java concurrency best practices — including thread safety fundamentals, ExecutorService thread pool management, concurrent design patterns like Producer-Consumer, asynchronous programming with CompletableFuture, immutability and safe publication, deadlock avoidance, virtual threads, structured concurrency, scoped values, backpressure, cancellation discipline, and observability for concurrent systems. This should trigger for requests such as Review Java code for concurrency; Review Java code for thread safety; Fix race conditions in Java concurrency code; Choose ExecutorService or virtual threads in Java; Improve synchronization and shared mutable state handling; Apply structured concurrency for related Java subtasks.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/126-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/126-skill.xml
@@ -4,7 +4,7 @@
       id="126-java-exception-handling">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to apply Java exception handling best practices — including using specific exception types, managing resources with try-with-resources, securing exception messages, preserving error context via exception chaining, validating inputs early with fail-fast principles, handling thread interruption correctly, documenting exceptions with @throws, enforcing logging policy, translating exceptions at API boundaries, managing retries and idempotency, enforcing timeouts, attaching suppressed exceptions, and propagating failures in async/reactive code. This should trigger for requests such as Exception handling; Use try-with-resources in Java code; Create exception chaining in Java code; Apply fail-fast validation in Java code; Review Java exception taxonomy and propagation.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/128-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/128-skill.xml
@@ -4,7 +4,7 @@
       id="128-java-generics">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to review, improve, or refactor Java code for generics quality — including avoiding raw types, applying the PECS (Producer Extends Consumer Super) principle for wildcards, using bounded type parameters, designing effective generic methods, leveraging the diamond operator, understanding type erasure implications, handling generic inheritance correctly, preventing heap pollution with @SafeVarargs, and integrating generics with modern Java features like Records, sealed types, and pattern matching. This should trigger for requests such as Improve the code with Generics; Apply Generics; Refactor the code with Generics; Improve generic type safety in Java APIs; Fix raw types and unchecked casts in Java code.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/130-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/130-skill.xml
@@ -4,7 +4,7 @@
       id="130-java-testing-strategies">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to apply testing strategies for Java code — RIGHT-BICEP to guide test creation, A-TRIP for test quality characteristics, or CORRECT for verifying boundary conditions. This should trigger for requests such as Review Java code for testing strategies; Apply RIGHT-BICEP testing strategies in Java code; Apply A-TRIP testing strategies in Java code; Apply CORRECT boundary condition verification in Java code.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/131-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/131-skill.xml
@@ -4,7 +4,7 @@
       id="131-java-testing-unit-testing">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to review, improve, or write Java unit tests — including migrating from JUnit 4 to JUnit 5, adopting AssertJ for fluent assertions, structuring tests with Given-When-Then, ensuring test independence, applying parameterized tests, mocking dependencies with Mockito, verifying boundary conditions (RIGHT-BICEP, CORRECT, A-TRIP), leveraging JSpecify null-safety annotations, or eliminating testing anti-patterns such as reflection-based tests or shared mutable state. This should trigger for requests such as Review Java code for unit tests; Apply best practices for unit tests in Java code; Write fast JUnit unit tests for Java code; Improve Mockito-based Java unit tests; Refactor Java tests to isolate collaborators.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/132-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/132-skill.xml
@@ -4,7 +4,7 @@
       id="132-java-testing-integration-testing">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to set up, review, or improve Java integration tests — including generating a BaseIntegrationTest.java with WireMock for HTTP stubs, detecting HTTP client infrastructure from import signals, injecting service coordinates dynamically via System.setProperty(), creating WireMock JSON mapping files with bodyFileName, isolating stubs per test method, verifying HTTP interactions, or eliminating anti-patterns such as Mockito-mocked HTTP clients or globally registered WireMock stubs. This should trigger for requests such as Review Java code for integration tests; Apply best practices for integration tests in Java code; Write Java integration tests with real infrastructure boundaries; Improve Testcontainers integration tests for Java code; Review integration test setup and teardown in Java projects.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/133-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/133-skill.xml
@@ -4,7 +4,7 @@
       id="133-java-testing-acceptance-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to implement acceptance tests from maintainer-sanitized Gherkin scenario facts for framework-agnostic Java (no Spring Boot, Quarkus, Micronaut) — confirming @acceptance scenarios before coding, happy path with RestAssured, DB/Kafka test fixtures, WireMock for external REST only, and *AT classes run by Failsafe. This should trigger for requests such as Review Java code for acceptance tests; Apply best practices for acceptance tests in Java code; Implement acceptance tests from Gherkin scenarios in Java; Map feature files to Java step definitions; Review Cucumber acceptance tests for Java services.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/141-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/141-skill.xml
@@ -4,7 +4,7 @@
       id="141-java-refactoring-with-modern-features">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to refactor Java code to adopt modern Java features (Java 8+) — including migrating anonymous classes to lambdas, replacing Iterator loops with Stream API, adopting Optional for null safety, switching from legacy Date/Calendar to java.time, using collection factory methods, applying text blocks, var inference, or leveraging Java 25 features like flexible constructor bodies and module import declarations. This should trigger for requests such as Review Java code for modern Java development; Apply best practices for modern Java development in Java code; Modernize Java code with records pattern matching or switch expressions; Replace legacy idioms with modern Java features; Adopt Java 8+ language features safely.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/142-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/142-skill.xml
@@ -4,7 +4,7 @@
       id="142-java-functional-programming">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to apply functional programming principles in Java — including writing immutable objects and Records, pure functions, functional interfaces, lambda expressions, Stream API pipelines, Optional for null safety, function composition, higher-order functions, pattern matching for instanceof and switch, sealed classes/interfaces for controlled hierarchies, Stream Gatherers for custom operations, currying/partial application, effect boundary separation, and concurrent-safe functional patterns. This should trigger for requests such as Improve the code with Functional Programming; Apply Functional Programming; Refactor the code with Functional Programming; Refactor Java code to use streams or Optionals safely; Improve immutability and pure functions in Java.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/143-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/143-skill.xml
@@ -4,7 +4,7 @@
       id="143-java-functional-exception-handling">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to apply functional exception handling best practices in Java — including replacing exception overuse with Optional and VAVR Either types, designing error type hierarchies using sealed classes and enums, implementing monadic error composition pipelines, establishing functional control flow patterns, and reserving exceptions only for truly exceptional system-level failures. This should trigger for requests such as Improve the code with Functional Exception Handling; Apply Functional Exception Handling; Refactor the code with Functional Exception Handling; Model Java errors with Result or Either types; Replace exception-heavy flows with functional error handling.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/144-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/144-skill.xml
@@ -4,7 +4,7 @@
       id="144-java-data-oriented-programming">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to apply data-oriented programming best practices in Java — including separating code (behavior) from data structures using records, designing immutable data with pure transformation functions, keeping data flat and denormalized with ID-based references, starting with generic data structures converting to specific types when needed, ensuring data integrity through pure validation functions, and creating flexible generic data access layers. This should trigger for requests such as Improve the code with Data-Oriented Programming; Apply Data-Oriented Programming; Refactor the code with Data-Oriented Programming; Model Java data with records and pure functions; Separate Java behavior from immutable data structures; Validate data integrity with pure Java functions.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/145-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/145-skill.xml
@@ -4,7 +4,7 @@
       id="145-java-refactoring-high-performance">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to refactor Java code for high performance — including memory/allocation reduction, CPU hot-path optimization, and syntax/API/control-flow improvements. This should trigger for requests such as Review Java code for high performance; Optimize Java hot path; Reduce Java allocations; Improve Java latency/throughput.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/151-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/151-skill.xml
@@ -4,7 +4,7 @@
       id="151-java-performance-jmeter">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to set up JMeter performance testing for a Java project — including creating the run-jmeter.sh script from the exact template, configuring load tests with loops, threads, and ramp-up, or running performance tests from the project root with custom or default settings. This should trigger for requests such as Improve the code with JMeter performance testing; Apply JMeter performance testing; Refactor the code with JMeter performance testing; Add JMeter support; Create a JMeter test plan for a Java service.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/152-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/152-skill.xml
@@ -4,7 +4,7 @@
       id="152-java-performance-gatling">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to set up Gatling performance testing for a Java Maven project — including adding Gatling dependencies and the Gatling Maven plugin, creating Java simulations, running gatling:test, configuring a simulation class, and reviewing generated reports. This should trigger for requests such as Add Gatling performance testing; Apply Gatling performance testing; Create a Gatling simulation; Add Gatling support; Review Gatling performance test assertions and feeders.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/161-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/161-skill.xml
@@ -4,7 +4,7 @@
       id="161-java-profiling-detect">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to set up Java application profiling to detect and measure performance issues — including trusted preinstalled async-profiler v4.x setup, problem-driven profiling (CPU, memory, threading, GC, I/O), interactive profiling scripts, JFR integration with Java 25 (JEP 518, JEP 520), or collecting profiling data with flamegraphs and JFR recordings. This should trigger for requests such as Improve the code with profiling; Apply Profiling; Refactor the code with profiling; Add profiling support; Collect JFR or async-profiler data for Java performance.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/162-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/162-skill.xml
@@ -4,7 +4,7 @@
       id="162-java-profiling-analyze">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to analyze Java profiling data collected during the detection phase — including interpreting flamegraphs, memory allocation patterns, CPU hotspots, threading issues, systematic problem categorization, evidence documentation with profiling-problem-analysis and profiling-solutions markdown files, or prioritizing fixes using Impact/Effort scoring. This should trigger for requests such as Analyze JFR profile; Analyze the profile; Analyze the performance; Analyze the memory; Analyze the threading; Analyze GC logs from profiling; Prioritize Java profiling bottlenecks by impact.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/163-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/163-skill.xml
@@ -4,7 +4,7 @@
       id="163-java-profiling-refactor">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to refactor Java code based on trusted profiling analysis findings — including reviewing repository-owned or maintainer-sanitized docs/profiling-problem-analysis and docs/profiling-solutions files, identifying specific performance bottlenecks, and implementing targeted code changes to address CPU, memory, or threading issues. This should trigger for requests such as Refactor the code with profiling; Apply profiling; Optimize hot path; Reduce allocations found in profiling; Fix CPU bottlenecks from profiling analysis.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/164-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/164-skill.xml
@@ -4,7 +4,7 @@
       id="164-java-profiling-verify">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to verify Java performance optimizations by comparing profiling results before and after refactoring — including baseline validation, post-refactoring report generation, quantitative before/after metrics comparison, side-by-side flamegraph analysis, regression detection, or creating profiling-comparison-analysis and profiling-final-results documentation. This should trigger for requests such as Verify performance fix; Verify the performance; Verify the memory; Verify the threading; Compare before and after profiling results; Check for performance regressions after refactoring.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/170-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/170-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to generate or improve Java project documentation — including README.md files, package-info.java files, and Javadoc enhancements — through a modular, step-based interactive process that adapts to your specific documentation needs. This should trigger for requests such as Improve the code with documentation; Apply documentation; Refactor the code with documentation; Generate README or developer documentation for a Java project; Document Java APIs architecture or project workflows.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/181-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/181-skill.xml
@@ -4,7 +4,7 @@
       id="181-java-observability-logging">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to implement or improve Java logging and observability — including selecting SLF4J with Logback/Log4j2, applying proper log levels (ERROR, WARN, INFO, DEBUG, TRACE), parameterized logging, correlation context, secure logging without sensitive data exposure, environment-specific configuration, log aggregation, monitoring, and alerting. This should trigger for requests such as Improve logging; Apply logging; Refactor logging; Add logging support; Review SLF4J structured logging in Java code.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/182-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/182-skill.xml
@@ -4,7 +4,7 @@
       id="182-java-observability-metrics-micrometer">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to implement or improve Java metrics observability with Micrometer — including meter design, naming/tag conventions, cardinality control, timers/counters/gauges/distribution summaries, percentiles/histograms, Actuator/Prometheus integration, and metrics validation through tests. This should trigger for requests such as Improve metrics; Apply Micrometer; Add metrics observability; Refactor Micrometer instrumentation; Add Micrometer timers counters or gauges to Java services.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/183-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/183-skill.xml
@@ -4,7 +4,7 @@
       id="183-java-observability-tracing-opentelemetry">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to implement or improve distributed tracing with OpenTelemetry in Java — including trace/span modeling, context propagation, semantic conventions, span attributes/events/status, sampling strategy, baggage usage, privacy safeguards, and backend integration with OTLP collectors. This should trigger for requests such as Improve tracing; Apply OpenTelemetry tracing; Add distributed tracing; Refactor tracing instrumentation; Instrument Java services with OpenTelemetry spans.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/200-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/200-skill.xml
@@ -5,7 +5,7 @@
       interactive="true">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to generate an AGENTS.md file for a Java repository — covering project conventions, tech stack, file structure, commands, Git workflow, and contributor boundaries — through a modular, step-based interactive process that adapts to your specific project needs. This should trigger for requests such as Create AGENTS.md; Update AGENTS.md file; Add agent instructions; Generate contributor instructions for Java agents; Document repository conventions in AGENTS.md.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/300-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/300-skill.xml
@@ -4,7 +4,7 @@
       id="300-frameworks-spring-boot-create-project">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to create a new Maven-based Spring Boot 4.0.x project using SDKMAN-managed Java and Spring Boot CLI tooling. This should trigger for requests such as Create a Spring Boot Maven project; Bootstrap Spring Boot project with SDKMAN; Generate a new Spring Boot service; Create Spring Boot 4 Maven project; Scaffold Spring Boot service with Java 25.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/301-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/301-skill.xml
@@ -4,7 +4,7 @@
       id="301-frameworks-spring-boot-core">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to review, improve, or build Spring Boot 4.0.x applications — including proper usage of @SpringBootApplication, component annotations (@Controller, @Service, @Repository), bean definition and scoping, configuration classes and @ConfigurationProperties (with @Validated), component scanning, conditional configuration and profiles, constructor injection, @Primary and @Qualifier for multiple beans of the same type, bean minimization, graceful shutdown, virtual threads, Jakarta EE namespace consistency, and scheduled tasks. This should trigger for requests such as Review Java code for Spring Boot application; Apply best practices for Spring Boot application in Java code; Improve Spring Boot configuration properties and beans; Review Spring Boot component scanning and profiles; Tune Spring Boot graceful shutdown or virtual threads.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/302-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/302-skill.xml
@@ -4,7 +4,7 @@
       id="302-frameworks-spring-boot-rest">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve REST APIs with Spring Boot — including HTTP methods, resource URIs, status codes, DTOs, versioning, deprecation and sunset headers, content negotiation (JSON and vendor media types), ISO-8601 instants in DTOs, pagination/sorting/filtering, Bean Validation at the boundary, idempotency, ETag concurrency, HTTP caching, error handling, security, contract-first OpenAPI (OpenAPI Generator), controller advice, and problem details for errors. This should trigger for requests such as Review Java code for Spring Boot REST API; Apply best practices for Spring Boot REST API in Java code; Design Spring Boot REST controllers and DTOs; Add Problem Details error responses in Spring Boot REST; Improve pagination validation or idempotency in Spring APIs.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/303-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/303-skill.xml
@@ -4,7 +4,7 @@
       id="303-frameworks-spring-boot-validation">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve validation in Spring Boot applications — including Bean Validation on request DTOs, @Valid/@Validated at API boundaries, constraint groups, custom constraints, @ConfigurationProperties validation, nested DTO validation, and consistent validation error handling. This should trigger for requests such as Add validation support in Spring Boot; Review Spring Boot validation rules; Improve request validation in Spring Boot REST APIs; Add custom Bean Validation constraints in Spring Boot; Validate configuration properties in Spring Boot.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/304-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/304-skill.xml
@@ -4,7 +4,7 @@
       id="304-frameworks-spring-boot-security">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve security in Spring Boot applications — including SecurityFilterChain, OAuth2/JWT resource server patterns, form login basics, method security (@PreAuthorize), CSRF and CORS for APIs, session fixation, security headers, exception handling, password encoding, and sensitive-data-safe logging. This should trigger for requests such as Add Spring Boot security support; Review Spring Boot security configuration; Improve API authorization in Spring Boot; Add JWT resource server security in Spring Boot; Harden Spring Boot security headers and CSRF settings.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/305-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/305-skill.xml
@@ -4,7 +4,7 @@
       id="305-frameworks-spring-boot-modulith">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve modular monoliths with Spring Modulith in Spring Boot applications - including application module package structure, ApplicationModules verification, named interfaces, allowed dependencies, domain events, @ApplicationModuleTest, Scenario-based module tests, generated documentation, actuator exposure, observability, and event publication registry choices. This should trigger for requests such as Add Spring Modulith to a Spring Boot application; Review Spring Modulith module boundaries; Improve modular monolith architecture in Spring Boot; Add @ApplicationModuleTest tests; Generate Spring Modulith documentation.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/311-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/311-skill.xml
@@ -4,7 +4,7 @@
       id="311-frameworks-spring-jdbc">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to write or review programmatic JDBC with Spring — including JdbcClient (Spring Framework 7+) as the default API, JdbcTemplate only where batch/streaming APIs require JdbcOperations, NamedParameterJdbcTemplate for legacy named-param code, parameterized SQL, RowMapper mapping to records, batch operations, transactions, safe handling of generated keys, DataAccessException handling, read-only transactions, streaming large result sets, and @JdbcTest slice testing. This should trigger for requests such as Review Java code for Spring JDBC (JdbcTemplate, JdbcClient, NamedParameterJdbcTemplate); Apply best practices for Spring JDBC data access in Java code; Detect and fix SQL injection risks in JDBC code; Improve transaction boundaries or exception handling for JDBC operations; Review JdbcClient usage in Spring Framework 7.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/312-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/312-skill.xml
@@ -4,7 +4,7 @@
       id="312-frameworks-spring-data-jdbc">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to use Spring Data JDBC with Java records — including entity design with records, repository pattern, immutable updates, aggregate relationships, custom queries, transaction management, and avoiding N+1 problems. This should trigger for requests such as Review Java code for Spring Data JDBC; Apply best practices for Spring Data JDBC in Java code; Model Spring Data JDBC aggregates with Java records; Review Spring Data JDBC repositories and aggregate boundaries; Improve optimistic locking or domain events in Spring Data JDBC.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/313-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/313-skill.xml
@@ -4,7 +4,7 @@
       id="313-frameworks-spring-db-migrations-flyway">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or review Flyway database migrations in a Spring Boot application — Maven dependencies, db/migration scripts, spring.flyway.* configuration, baseline and validation, and alignment with JDBC or Spring Data JDBC. This should trigger for requests such as Add or review Flyway migrations in a Spring Boot project; Configure spring.flyway or db/migration layout; Add versioned Flyway SQL migrations for Spring Boot; Review Spring Boot database migration ordering; Fix repeatable Flyway migrations in a Spring project.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/314-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/314-skill.xml
@@ -4,7 +4,7 @@
       id="314-frameworks-spring-kafka">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design or implement Kafka messaging in Spring Boot — including topic design, producer/consumer implementation, JSON serialization with Boot factory customizers, Testcontainers `@ServiceConnection` integration tests, retries and dead-letter topics, idempotency, and error handling. This should trigger for requests such as Add Kafka in Spring Boot; Review Spring Kafka consumers; Improve retries and DLT in Spring Kafka; Configure Spring Kafka topics serializers or listener containers; Add Spring Kafka dead-letter topic handling.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/315-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/315-skill.xml
@@ -4,7 +4,7 @@
       id="315-frameworks-spring-mongodb">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design or implement MongoDB data access in Spring Boot — including document modeling, Spring Data Mongo repositories/templates, indexing, optimistic concurrency, and error handling. This should trigger for requests such as Add MongoDB in Spring Boot; Review Spring Data Mongo design; Improve error handling for Mongo writes; Model MongoDB documents for a Spring Boot service; Configure Spring Data MongoDB indexes or transactions.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/316-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/316-skill.xml
@@ -4,7 +4,7 @@
       id="316-frameworks-spring-mongodb-migrations-mongock">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or review Mongock MongoDB data migrations in a Spring Boot application — including Maven coordinates, Spring Data MongoDB drivers, migration scan packages, @ChangeUnit classes, lock/transaction settings, and optional policy-approved MongoDB integration verification. This should trigger for requests such as Add Mongock migrations in Spring Boot; Review Spring MongoDB data migrations; Configure Mongock change units for Spring Data MongoDB; Create Mongock change units for Spring Boot MongoDB; Review Mongock migration ordering in a Spring service.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/321-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/321-skill.xml
@@ -4,7 +4,7 @@
       id="321-frameworks-spring-boot-testing-unit-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to write unit tests for Spring Boot applications — including pure unit tests with @ExtendWith(MockitoExtension.class) for @Service/@Component, slice tests with @WebMvcTest and @MockitoBean for controllers, @JsonTest for JSON serialization, parameterized tests with @CsvSource/@MethodSource, test profiles, and @TestConfiguration. For framework-agnostic Java use @131-java-testing-unit-testing. For integration tests use @322-frameworks-spring-boot-testing-integration-tests. This should trigger for requests such as Review Java code for Spring Boot unit tests; Apply best practices for Spring Boot unit tests in Java code; Write Mockito-first unit tests for Spring Boot services; Avoid unnecessary @SpringBootTest in Spring unit tests; Review Spring Boot slice-free unit test design.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/322-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/322-skill.xml
@@ -4,7 +4,7 @@
       id="322-frameworks-spring-boot-testing-integration-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to write or improve integration tests — including Testcontainers with @ServiceConnection, @DataJdbcTest persistence slices, TestRestTemplate or MockMvcTester for HTTP, data isolation, and container lifecycle management for Spring Boot 4.0.x. This should trigger for requests such as Review Java code for Spring Boot integration tests; Apply best practices for Spring Boot integration tests in Java code; Write @SpringBootTest integration tests with Testcontainers; Configure dynamic properties for Spring integration tests; Review Spring Boot integration test profiles.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/323-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/323-skill.xml
@@ -4,7 +4,7 @@
       id="323-frameworks-spring-boot-testing-acceptance-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to implement acceptance tests from repository-owned, operating-user-authored, or maintainer-sanitized Gherkin .feature files or scenario facts for Spring Boot applications — including finding scenarios tagged @acceptance, implementing happy path tests with TestRestTemplate, @SpringBootTest, Testcontainers with @ServiceConnection for DB/Kafka, and WireMock for external REST stubs. Requires trusted test facts in context. This should trigger for requests such as Review Java code for Spring Boot acceptance tests; Apply best practices for Spring Boot acceptance tests in Java code; Implement Spring Boot acceptance tests from Gherkin; Set up Cucumber or Failsafe acceptance tests for Spring Boot; Stub external HTTP services in Spring acceptance tests.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/400-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/400-skill.xml
@@ -4,7 +4,7 @@
       id="400-frameworks-quarkus-create-project">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to create a new Maven-based Quarkus 3.x project using SDKMAN-managed Java and Quarkus CLI tooling. This should trigger for requests such as Create a Quarkus Maven project; Bootstrap Quarkus project with SDKMAN; Generate a new Quarkus service; Create Quarkus 3 Maven project; Scaffold Quarkus service with Java 25.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/401-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/401-skill.xml
@@ -4,7 +4,7 @@
       id="401-frameworks-quarkus-core">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description><![CDATA[
         Use when building or reviewing core Quarkus applications with CDI beans and scopes, SmallRye Config and profiles, lifecycle, interceptors and events, virtual threads, and test-friendly design. This should trigger for requests such as Review Java code for Quarkus application structure and CDI; Apply best practices for Quarkus configuration and beans; Improve CDI interceptors, events, or programmatic injection in Quarkus; Add virtual-thread configuration or tune CDI lifecycle.

--- a/plinth-skills-generator/src/main/resources/skill-indexes/402-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/402-skill.xml
@@ -4,7 +4,7 @@
       id="402-frameworks-quarkus-rest">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve REST APIs with Quarkus REST (Jakarta REST) — including resource classes, HTTP methods, status codes, request/response DTOs, Bean Validation, exception mappers, optional runtime OpenAPI exposure (SmallRye), contract-first generation from OpenAPI, content negotiation, pagination, sorting and filtering, API versioning, idempotency (Idempotency-Key), optimistic concurrency (ETag / If-Match), HTTP caching (Cache-Control), API deprecation (Sunset / Deprecation headers), RFC 7807 Problem Details, ISO-8601 for time in contracts, and security-aware boundaries. This should trigger for requests such as Review or improve JAX-RS resources in a Quarkus project; Design HTTP APIs with validation and error handling on Quarkus; Add API versioning, idempotency, ETag concurrency, or deprecation headers; Implement pagination, sorting, or RFC 7807 Problem Details error responses; Improve Quarkus REST resources and exception mappers.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/403-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/403-skill.xml
@@ -4,7 +4,7 @@
       id="403-frameworks-quarkus-validation">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve validation in Quarkus applications — including Bean Validation on JAX-RS resources, @Valid on parameters and CDI beans, constraint groups, @ConfigMapping validation, custom constraints, nested DTO validation, and ExceptionMapper-based error mapping. This should trigger for requests such as Add validation support in Quarkus; Review Quarkus validation rules; Improve request validation in Quarkus REST APIs; Add custom validation constraints in Quarkus; Validate Quarkus @ConfigMapping properties.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/404-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/404-skill.xml
@@ -4,7 +4,7 @@
       id="404-frameworks-quarkus-security">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve security in Quarkus applications — including Quarkus Security with JWT/OIDC, basic auth, @RolesAllowed / @Authenticated / @PermitAll, SecurityIdentity, permission checks, path-based authorization in configuration, exception mapping for auth failures, and sensitive-data-safe logging. This should trigger for requests such as Add Quarkus security support; Review Quarkus security configuration; Improve API authorization in Quarkus; Add JWT/OIDC security in Quarkus; Harden Quarkus authorization rules.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/411-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/411-skill.xml
@@ -4,7 +4,7 @@
       id="411-frameworks-quarkus-jdbc">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need programmatic JDBC in Quarkus — Agroal DataSource, parameterized SQL, transactions, batching, and Dev Services. This should trigger for requests such as Review JDBC or SQL data access in a Quarkus project; Improve transactions and parameter binding for Quarkus JDBC; Translate SQLException to domain exceptions or stream large result sets; Fix CDI self-invocation bypassing @Transactional in Quarkus; Review Agroal DataSource usage in Quarkus JDBC.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/412-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/412-skill.xml
@@ -4,7 +4,7 @@
       id="412-frameworks-quarkus-panache">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description><![CDATA[
         Use when you need data access with Quarkus Hibernate ORM Panache — including PanacheEntity / PanacheEntityBase, PanacheRepository, named queries, JPQL, native SQL, DTO projections (project(Class)), pagination (Page.of()), N+1 avoidance (JOIN FETCH), optimistic locking (@Version / OptimisticLockException), @NamedQuery for validated reusable queries, transactions, @TestTransaction for test isolation, and immutable-friendly patterns. This is the Quarkus analogue to Spring Data for relational persistence.

--- a/plinth-skills-generator/src/main/resources/skill-indexes/413-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/413-skill.xml
@@ -4,7 +4,7 @@
       id="413-frameworks-quarkus-db-migrations-flyway">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or review Flyway database migrations in a Quarkus application — quarkus-flyway extension, db/migration scripts, quarkus.flyway.* configuration, migrate-at-start, and alignment with JDBC or Panache. This should trigger for requests such as Add or review Flyway migrations in a Quarkus project; Configure quarkus-flyway or db/migration layout; Add versioned Flyway SQL migrations for Quarkus; Review Quarkus database migration ordering; Configure Flyway clean migrate or baselines in Quarkus.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/414-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/414-skill.xml
@@ -4,7 +4,7 @@
       id="414-frameworks-quarkus-kafka">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need Kafka messaging in Quarkus with SmallRye Reactive Messaging — including channel/topic design, build-time Jackson serialization, typed @Channel/@Incoming, ack/failure strategies, retries/DLQ, idempotency, Dev Services, and Testcontainers integration tests. This should trigger for requests such as Add Kafka in Quarkus; Review Reactive Messaging consumers; Improve failure handling for Quarkus Kafka; Configure Quarkus Reactive Messaging Kafka channels; Add Quarkus Kafka failure strategy or DLQ handling.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/415-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/415-skill.xml
@@ -4,7 +4,7 @@
       id="415-frameworks-quarkus-mongodb">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need MongoDB persistence in Quarkus — including Panache Mongo entities/repositories, document design, indexes, transactions where applicable, and error handling. This should trigger for requests such as Add MongoDB in Quarkus; Review Quarkus Mongo Panache design; Improve Mongo error handling in Quarkus services; Model MongoDB documents for a Quarkus service; Configure Quarkus MongoDB clients codecs or transactions.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/416-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/416-skill.xml
@@ -4,7 +4,7 @@
       id="416-frameworks-quarkus-mongodb-migrations-mongock">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or review Mongock MongoDB data migrations in a Quarkus application — including the Quarkiverse Mongock extension, Quarkus MongoDB client configuration, migrate-at-start, @ChangeUnit classes, lock/transaction settings, and Quarkus test verification. This should trigger for requests such as Add Mongock migrations in Quarkus; Configure quarkus-mongock; Review Quarkus MongoDB data migrations; Create Mongock change units for Quarkus MongoDB; Review Mongock migration ordering in a Quarkus service.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/421-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/421-skill.xml
@@ -4,7 +4,7 @@
       id="421-frameworks-quarkus-testing-unit-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to write fast unit tests for Quarkus applications — including pure tests with @ExtendWith(MockitoExtension.class), @QuarkusTest with @InjectMock for full CDI mock replacement, @InjectSpy for partial CDI bean mocking, REST Assured for resource-focused tests, @ParameterizedTest with @CsvSource / @MethodSource, QuarkusTestProfile for test-specific configuration overrides, and naming conventions (*Test → Surefire, *IT → Failsafe). For framework-agnostic Java use @131-java-testing-unit-testing. This should trigger for requests such as Add or improve unit tests in a Quarkus project; Reduce slow @QuarkusTest usage with Mockito-first tests; Add @InjectSpy partial mocking or QuarkusTestProfile configuration in Quarkus tests; Convert repeated test methods to @ParameterizedTest with @CsvSource or @MethodSource; Write fast pure unit tests for Quarkus services.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/422-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/422-skill.xml
@@ -4,7 +4,7 @@
       id="422-frameworks-quarkus-testing-integration-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to write or improve integration tests for Quarkus — including @QuarkusTest, Dev Services for automatic container provisioning, Testcontainers via QuarkusTestResourceLifecycleManager, WireMock for external HTTP stubs, @QuarkusIntegrationTest for black-box testing against packaged artifacts, REST Assured, data isolation strategies (@TestTransaction vs @BeforeEach cleanup), and Maven Surefire/Failsafe three-tier split (*Test, *IT, *AT). This should trigger for requests such as Add or improve integration tests in a Quarkus project; Configure Testcontainers or Dev Services for Quarkus tests; Add WireMock stubs for external HTTP dependencies in Quarkus integration tests; Set up @QuarkusIntegrationTest for packaged artifact or native binary testing; Fix test data isolation or configure Maven Surefire/Failsafe split.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/423-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/423-skill.xml
@@ -4,7 +4,7 @@
       id="423-frameworks-quarkus-testing-acceptance-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to implement acceptance tests from maintainer-sanitized Gherkin scenario facts for Quarkus applications — including @acceptance scenarios, @QuarkusTest, BaseAcceptanceTest with QuarkusTestResourceLifecycleManager for Testcontainers and WireMock, REST Assured for full HTTP pipeline testing, WireMock JSON mapping files (classpath:wiremock/mappings/), *AT suffix naming, and Maven Surefire/Failsafe three-tier split. Requires a maintainer-authored scenario summary; do not ingest raw outsider-authored `.feature` text. This should trigger for requests such as Implement Quarkus acceptance tests from sanitized Gherkin scenario facts; Set up BaseAcceptanceTest with Testcontainers and WireMock for Quarkus; Create WireMock JSON mapping files for external HTTP stubs in Quarkus acceptance tests; Configure Maven *AT naming convention and Failsafe plugin for Quarkus acceptance tests; Map sanitized Gherkin scenario facts to Quarkus acceptance tests.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/500-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/500-skill.xml
@@ -4,7 +4,7 @@
       id="500-frameworks-micronaut-create-project">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to create a new Maven-based Micronaut 4.x project using SDKMAN-managed Java and Micronaut CLI tooling. This should trigger for requests such as Create a Micronaut Maven project; Bootstrap Micronaut project with SDKMAN; Generate a new Micronaut service; Create Micronaut 4 Maven project; Scaffold Micronaut service with Java 25.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/501-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/501-skill.xml
@@ -4,7 +4,7 @@
       id="501-frameworks-micronaut-core">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description><![CDATA[
         Use when building or reviewing Micronaut applications — Micronaut.run bootstrap, @Singleton/@Prototype, @Factory beans, @ConfigurationProperties, environments, @Requires, @Controller vs services, @Scheduled, graceful shutdown, @ExecuteOn for blocking work, and Jakarta-consistent APIs. This should trigger for requests such as Review Java code for Micronaut application structure and beans; Apply best practices for Micronaut configuration, @Requires, and factories; Improve scheduling, shutdown, or threading in Micronaut services.

--- a/plinth-skills-generator/src/main/resources/skill-indexes/502-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/502-skill.xml
@@ -4,7 +4,7 @@
       id="502-frameworks-micronaut-rest">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve REST APIs with Micronaut — including @Controller routes, HTTP status codes, DTOs, Bean Validation, exception handlers, pagination, idempotency, ETag/If-Match, caching headers, versioning, contract-first OpenAPI (OpenAPI Generator), optional runtime OpenAPI via micronaut-openapi, and security annotations. This should trigger for requests such as Review or improve Micronaut @Controller REST APIs; Add validation, error handling, or align controllers with the OpenAPI contract on Micronaut HTTP layer; Design Micronaut controllers and DTO validation; Add Micronaut exception handlers and Problem Details responses; Improve pagination filtering or OpenAPI alignment in Micronaut APIs.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/503-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/503-skill.xml
@@ -4,7 +4,7 @@
       id="503-frameworks-micronaut-validation">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve validation in Micronaut applications — including Bean Validation on @Controller methods, @Body @Valid, query/path parameter validation, @ConfigurationProperties validation, custom constraints, nested DTO validation, and ExceptionHandler mapping for constraint violations. This should trigger for requests such as Add validation support in Micronaut; Review Micronaut validation rules; Improve request validation in Micronaut REST APIs; Add custom validation constraints in Micronaut; Validate Micronaut configuration properties.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/504-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/504-skill.xml
@@ -4,7 +4,7 @@
       id="504-frameworks-micronaut-security">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to design, review, or improve security in Micronaut applications — including micronaut-security authentication, @Secured and intercept-url-map rules, JWT/session strategies, SecurityService checks, CORS, CSRF awareness for browser apps, rejection handlers, and sensitive-data-safe logging. This should trigger for requests such as Add Micronaut security support; Review Micronaut security configuration; Improve API authorization in Micronaut; Add JWT security in Micronaut; Harden Micronaut route authorization rules.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/511-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/511-skill.xml
@@ -4,7 +4,7 @@
       id="511-frameworks-micronaut-jdbc">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need programmatic JDBC in Micronaut — pooled DataSource, parameterized SQL, io.micronaut.transaction.annotation.Transactional, batching, and domain exception translation. This should trigger for requests such as Review JDBC or SQL data access in a Micronaut project; Improve transactions and parameter binding for Micronaut JDBC; Translate SQLException to domain exceptions or stream large result sets; Fix self-invocation bypassing @Transactional in Micronaut; Review Hikari or pooled datasource usage in Micronaut JDBC.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/512-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/512-skill.xml
@@ -4,7 +4,7 @@
       id="512-frameworks-micronaut-data">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need data access with Micronaut Data — @MappedEntity, CrudRepository/PageableRepository, @Query with parameters, @Transactional services, projections, @Version, and @MicronautTest with TestPropertyProvider and Testcontainers. For raw java.sql access without generated repositories, use @511-frameworks-micronaut-jdbc. This should trigger for requests such as Review or implement Micronaut Data repositories and entities; Add transactions, pagination, or projections in Micronaut persistence layer; Model Micronaut Data entities and repositories; Review Micronaut Data transactions and pageable queries; Improve projections or optimistic locking with Micronaut Data.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/513-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/513-skill.xml
@@ -4,7 +4,7 @@
       id="513-frameworks-micronaut-db-migrations-flyway">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or review Flyway database migrations in a Micronaut application — micronaut-flyway, db/migration scripts, flyway.datasources.* configuration, and alignment with JDBC or Micronaut Data. This should trigger for requests such as Add or review Flyway migrations in a Micronaut project; Configure micronaut-flyway or db/migration layout; Add versioned Flyway SQL migrations for Micronaut; Review Micronaut database migration ordering; Configure Flyway datasources in a Micronaut project.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/514-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/514-skill.xml
@@ -4,7 +4,7 @@
       id="514-frameworks-micronaut-kafka">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need Kafka messaging in Micronaut — including @KafkaClient and @KafkaListener design, @Serdeable serialization, topic/partition strategy, TestPropertyProvider integration tests, retries and dead-letter processing, and error handling. This should trigger for requests such as Add Kafka in Micronaut; Review Micronaut Kafka listeners; Improve retry and failure handling for Micronaut Kafka; Configure Micronaut Kafka clients listeners or SerDes; Add Micronaut Kafka retry or dead-letter handling.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/515-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/515-skill.xml
@@ -4,7 +4,7 @@
       id="515-frameworks-micronaut-mongodb">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need MongoDB persistence in Micronaut — including @MongoRepository design, document modeling, indexes, query patterns, and error handling. This should trigger for requests such as Add MongoDB in Micronaut; Review Micronaut Data Mongo design; Improve error handling for Micronaut Mongo operations; Model MongoDB documents for a Micronaut service; Configure Micronaut MongoDB codecs indexes or transactions.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/516-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/516-skill.xml
@@ -4,7 +4,7 @@
       id="516-frameworks-micronaut-mongodb-migrations-mongock">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or review Mongock MongoDB data migrations in a Micronaut application — including Mongock runner/driver selection, Micronaut bean wiring, migration scan packages, @ChangeUnit classes, lock/transaction settings, and Testcontainers verification. This should trigger for requests such as Add Mongock migrations in Micronaut; Review Micronaut MongoDB data migrations; Configure Mongock change units with Micronaut Data MongoDB; Create Mongock change units for Micronaut MongoDB; Review Mongock migration ordering in a Micronaut service.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/521-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/521-skill.xml
@@ -4,7 +4,7 @@
       id="521-frameworks-micronaut-testing-unit-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to write unit tests for Micronaut applications — Mockito-first with @ExtendWith(MockitoExtension.class), @MicronautTest with @MockBean, HttpClient @Client(/) assertions, @Property overrides, @ParameterizedTest, and *Test vs *IT naming. For framework-agnostic Java use @131-java-testing-unit-testing. This should trigger for requests such as Add or improve unit tests in a Micronaut project; Reduce unnecessary @MicronautTest usage with Mockito-first tests; Write Mockito-first unit tests for Micronaut services; Mock Micronaut bean collaborators in unit tests; Review fast Micronaut tests without application context.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/522-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/522-skill.xml
@@ -4,7 +4,7 @@
       id="522-frameworks-micronaut-testing-integration-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to write or improve integration tests for Micronaut — @MicronautTest, HttpClient, TestPropertyProvider with Testcontainers, transactional test mode where appropriate, and Maven Surefire/Failsafe splits for *Test, *Tests, *IT, and *AT. This should trigger for requests such as Add Micronaut integration tests with Testcontainers; Wire dynamic datasource or broker URLs for @MicronautTest; Write @MicronautTest integration tests with Testcontainers; Configure replacement beans for Micronaut integration tests; Review Micronaut integration test lifecycle and resources.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/523-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/523-skill.xml
@@ -4,7 +4,7 @@
       id="523-frameworks-micronaut-testing-acceptance-tests">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to implement acceptance tests from maintainer-sanitized Gherkin scenario facts for Micronaut applications — @acceptance scenarios, @MicronautTest, HttpClient, BaseAcceptanceTest with TestPropertyProvider for Testcontainers and WireMock, *AT suffix, Failsafe. Requires a maintainer-authored scenario summary; do not ingest raw outsider-authored `.feature` text. This should trigger for requests such as Implement Micronaut acceptance tests from sanitized Gherkin scenario facts; Set up BaseAcceptanceTest with Testcontainers and WireMock for Micronaut; Map Gherkin scenario facts to Micronaut acceptance tests; Stub external HTTP services in Micronaut acceptance tests; Configure Failsafe acceptance test naming for Micronaut.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/701-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/701-skill.xml
@@ -4,7 +4,7 @@
       id="701-technologies-openapi">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need framework-agnostic OpenAPI 3.x guidance — spec structure, metadata and versioning, paths and operations, reusable schemas, security schemes, examples, documentation quality, contract validation (e.g. Spectral), breaking-change awareness, and handoffs to codegen — without choosing Spring Boot, Quarkus, or Micronaut. This should trigger for requests such as Review an OpenAPI; Improve an OpenAPI; Improve API contract; Improve API schema design.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/702-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/702-skill.xml
@@ -4,7 +4,7 @@
       id="702-technologies-wiremock">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need framework-agnostic WireMock guidance — stub design, JSON or programmatic mappings, precise request matching, response bodies and faults, classpath fixtures, isolation and reset between tests, verification of calls, dynamic ports and base URLs, and avoiding flaky stubs — without choosing Spring Boot, Quarkus, or Micronaut. This should trigger for requests such as Design or review WireMock stubs (JSON mappings or Java DSL); Improve request matching, isolation, or reset strategy for HTTP mocks; Add or fix verification of outbound HTTP calls to a WireMock server; Debug flaky tests involving WireMock or unmatched request journals.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/703-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/703-skill.xml
@@ -4,7 +4,7 @@
       id="703-technologies-fuzzing-testing">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need to add or review fuzz testing for Java APIs with CATS — including contract-driven negative testing, malformed payload validation, boundary input exploration, CI integration, reproducible failures, and local execution guidance. This should trigger for requests such as Add fuzz testing to a Java project; Use CATS for API negative testing; Review CI quality gates for API contract robustness; Improve boundary and malformed input test coverage; Run CATS fuzz tests against an OpenAPI contract.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/704-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/704-skill.xml
@@ -4,7 +4,7 @@
       id="704-technologies-sql">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need framework-agnostic SQL guidance — schema naming, relational table design, query readability, indexes, transactions, database security, migrations, testing, and monitoring — without choosing Spring Boot, Quarkus, or Micronaut. This should trigger for requests such as Review SQL schema or migrations; Improve SQL query performance and readability; Design relational tables and indexes; Review database transaction, security, or monitoring practices.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/705-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/705-skill.xml
@@ -4,7 +4,7 @@
       id="705-technologies-nosql-mongodb">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need framework-agnostic MongoDB and non-relational database query guidance — document schema design, collection modeling, JSON Schema validation, indexes, aggregation pipelines, query performance, consistency trade-offs, transactions, and operational safety — without choosing Spring Boot, Quarkus, or Micronaut. This should trigger for requests such as Design MongoDB document schemas; Review MongoDB queries and indexes; Improve aggregation pipeline performance; Model non-relational data access patterns; Review NoSQL consistency and transaction trade-offs.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/706-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/706-skill.xml
@@ -4,7 +4,7 @@
       id="706-technologies-containers-docker">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need framework-agnostic Docker and container image guidance for Java projects - Dockerfile design, multi-stage Maven builds, jlink custom runtimes, micro runtime distributions such as Alpaquita, JVM container ergonomics, non-root execution, image metadata, .dockerignore, reproducible builds, vulnerability scanning, SBOM awareness, and production-safe container defaults. This should trigger for requests such as Review Java Dockerfile; Improve Docker image security; Add jlink runtime to a Java container; Add containerization to a Java project; Optimize Java container image size; Review Docker build reproducibility.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/707-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/707-skill.xml
@@ -4,7 +4,7 @@
       id="707-technologies-hexagonal-architecture">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when you need framework-agnostic Hexagonal architecture guidance for Java projects - ports and adapters boundaries, application core independence, driving and driven adapters, dependency direction, infrastructure leakage detection, optional architecture tests, and evidence-backed remediation. This should trigger for requests such as Review Hexagonal architecture; Review ports and adapters boundaries; Enforce dependency direction; Add ArchUnit architecture tests; Detect infrastructure leakage in domain code; Improve ports and adapters boundaries.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/801-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/801-skill.xml
@@ -4,7 +4,7 @@
       id="801-regulations-eu-ai-act">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise systems that use AI, LLMs, AI agents, RAG, tool calling, workflow automation, or model-based decision support and need EU AI Act regulatory awareness. This should trigger for requests such as Review a Java AI system for EU AI Act controls; Design governance for an AI agent with enterprise tools; Add human oversight and auditability to LLM workflows; Assess RAG or model-driven decision support before production release.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/802-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/802-skill.xml
@@ -4,7 +4,7 @@
       id="802-regulations-dora">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise systems that may support financial entities, critical ICT services, third-party ICT provider integrations, or operational resilience obligations under DORA. This should trigger for requests such as Review a Java platform for DORA ICT risk controls; Design operational resilience evidence for a financial service; Add incident, continuity, backup, recovery, or third-party ICT controls; Assess resilience testing and monitoring before production release.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/803-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/803-skill.xml
@@ -4,7 +4,7 @@
       id="803-regulations-gdpr">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise systems that process personal data and need GDPR-aware engineering controls. This should trigger for requests such as Review a Java service for GDPR privacy controls; Design data-subject rights workflows; Add retention, deletion, pseudonymization, or privacy-safe logging; Assess data transfer, DPIA, breach evidence, or processor/controller boundary concerns before production release.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/804-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/804-skill.xml
@@ -4,7 +4,7 @@
       id="804-regulations-eu-nis2">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise systems that may support essential or important entities, critical-sector services, managed service providers, supply-chain dependencies, or cybersecurity incident escalation obligations under NIS2. This should trigger for requests such as Review a Java platform for NIS2 cybersecurity controls; Design operational evidence for critical-sector services; Add incident detection, escalation, continuity, or supply-chain security controls; Assess cybersecurity risk management before production release.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/805-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/805-skill.xml
@@ -4,7 +4,7 @@
       id="805-regulations-eu-cyber-resilience-act">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise products, services, libraries, agents, plugins, connected components, or platform modules that may qualify as products with digital elements and need EU Cyber Resilience Act secure-by-design, vulnerability handling, security update, SBOM, product documentation, or release-readiness controls.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/806-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/806-skill.xml
@@ -4,7 +4,7 @@
       id="806-regulations-eu-data-act">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise systems that expose, exchange, store, process, export, or port data across users, businesses, connected products, cloud providers, APIs, event streams, AI data pipelines, data spaces, or SaaS platforms and need EU Data Act engineering controls. This should trigger for requests such as Review a Java platform for EU Data Act controls; Design data access and portability evidence; Add data-sharing request workflows, export formats, interoperability, metadata, audit logs, cloud-switching support, non-personal data safeguards, or trade-secret handoffs; Assess Data Act engineering readiness before production release.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/807-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/807-skill.xml
@@ -4,7 +4,7 @@
       id="807-regulations-eu-digital-services-act">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise systems that may support intermediary services, hosting services, online platforms, marketplaces, content moderation, recommender systems, advertising delivery, complaint workflows, transparency reporting, or systemic-risk evidence under the EU Digital Services Act. This should trigger for requests such as Review a Java online platform for DSA controls; Design notice-and-action or appeal workflows; Add recommender, ad transparency, moderation, audit, researcher access, or privacy-safe observability evidence; Assess online-platform transparency controls before production release.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/808-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/808-skill.xml
@@ -4,7 +4,7 @@
       id="808-regulations-eu-digital-markets-act">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise systems that may support EU Digital Markets Act gatekeeper-platform concerns, core platform services, interoperability, business-user data access, consent-dependent data combination, ranking, self-preferencing, advertising transparency, or anti-circumvention controls. This should trigger for requests such as Review a Java platform for DMA controls; Design interoperability and business-user data access evidence; Add ranking, consent, preference, or anti-circumvention audit controls; Assess gatekeeper-platform engineering evidence before production release.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/810-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/810-skill.xml
@@ -4,7 +4,7 @@
       id="810-regulations-eu-mifid-ii">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing Java enterprise evidence for MiFID II investment services, investment activities, client classification, suitability, appropriateness, order-handling evidence, best-execution evidence, algorithmic-trading governance evidence, market-access governance evidence, transaction evidence, record keeping, monitoring, or compliance-owner handoff. This should trigger for requests such as Review a Java investment-service platform for MiFID II evidence; Assess suitability, appropriateness, order-handling evidence, or best-execution evidence; Document audit, monitoring, or clock-synchronisation gaps for algorithmic-trading governance; Assess investment-service engineering evidence before production release.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/811-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/811-skill.xml
@@ -4,7 +4,7 @@
       id="811-regulations-eu-market-abuse-regulation">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise systems that may support EU Market Abuse Regulation concerns, market surveillance, suspicious order and transaction reports, insider dealing controls, unlawful disclosure controls, market manipulation detection, inside information disclosure workflows, insider-list evidence, PDMR transaction notifications, alert explainability, model or rule provenance, reviewer decisions, or compliance escalation. This should trigger for requests such as Review a Java trading surveillance system for MAR controls; Design suspicious order and transaction monitoring evidence; Add alert explainability and reviewer-decision audit trails; Assess AI-assisted market-abuse detection before production release.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/812-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/812-skill.xml
@@ -4,7 +4,7 @@
       id="812-regulations-eu-product-liability-directive">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise software products, AI-enabled products, RAG assistants, AI agents, generated instructions, related services, automated updates, vulnerability handling, corrective updates, warnings, instructions, or product-safety evidence under Directive (EU) 2024/2853, the EU Product Liability Directive.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-indexes/813-skill.xml
+++ b/plinth-skills-generator/src/main/resources/skill-indexes/813-skill.xml
@@ -4,7 +4,7 @@
       id="813-regulations-iso-42001">
   <metadata>
     <author>Juan Antonio Breña Moral</author>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <license>Apache-2.0</license>
     <description>Use when reviewing, designing, or modifying Java enterprise systems that use GenAI, LLMs, AI-assisted coding, RAG, AI agents, generated code, generated dependencies, prompt workflows, external model providers, or AI-enabled business logic and need ISO/IEC 42001 AI management system-aware engineering guidance.</description>
   </metadata>

--- a/plinth-skills-generator/src/main/resources/skill-references/001-commands-inventory.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/001-commands-inventory.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Create a Checklist with embedded commands inventory for Java</title>
         <description>Use when you need to generate a checklist document with embedded commands inventory, following the embedded template exactly and producing INVENTORY-COMMANDS-JAVA.md in the project root.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/002-agents-inventory.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/002-agents-inventory.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Create a Checklist with embedded agents inventory for Java</title>
         <description>Use when you need to generate a checklist document with embedded agents inventory, following the embedded template exactly and producing INVENTORY-AGENTS-JAVA.md in the project root.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/003-skills-inventory.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/003-skills-inventory.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Create a Checklist with all Java steps to use with system prompts for Java</title>
         <description>Use when you need to generate a checklist document with Java system prompts from skills.xml, following the embedded section template and producing INVENTORY-SKILLS-JAVA.md.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/004-commands-installation.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/004-commands-installation.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Embedded commands installer</title>
         <description>Use when you need to install the embedded project commands into command directories (.github/commands, .claude/commands, .cursor/command, .codex/commands), selecting the destination interactively and copying the embedded command definitions from project assets.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/005-agents-installation.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/005-agents-installation.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Embedded agents installer</title>
         <description>Use when you need to install the embedded robot agents into .github/agents, .claude/agents, .cursor/agents, or .codex/agents, selecting the destination interactively and copying the embedded agent definitions from project assets.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/012-agile-epic.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/012-agile-epic.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Create Agile Epics</title>
         <description>Use when the user wants to create an agile epic, define large bodies of work, break down features into user stories, or document strategic initiatives.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/013-agile-feature.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/013-agile-feature.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Create Agile Features from an Epic</title>
         <description>Use when the user wants to derive detailed feature documentation from an existing epic, split an epic into feature files, or plan features with scope and acceptance criteria.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/014-agile-user-story.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/014-agile-user-story.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Create Agile User Stories</title>
         <description>Use when the user wants to create a user story.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/021-problem-framing.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/021-problem-framing.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Problem Framing</title>
         <description>Establish a Problem statement, Current state, Desired state, Stakeholders, and Success criteria for a problem or issue under exploration, before root-cause, assumption, context, or quality-attribute analysis begins.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/022-root-cause-analysis.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/022-root-cause-analysis.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Root Cause Analysis</title>
         <description>Identify root causes rather than symptoms for a framed problem, using Five Whys, Fishbone (Ishikawa), Current Reality Tree, and constraint identification.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/023-assumption-analysis.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/023-assumption-analysis.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Assumption Analysis</title>
         <description>Make explicit Assumptions, list Unknowns, and define a Validation plan for a problem under exploration, before design or planning commits to an approach.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/024-context-mapping.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/024-context-mapping.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Context Mapping</title>
         <description>Identify Existing systems, Integrations, Ownership, and External dependencies relevant to a problem under exploration, before design assumes a system boundary.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/025-quality-attribute-discovery.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/025-quality-attribute-discovery.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Quality Attribute Discovery</title>
         <description>Identify and prioritize the quality attributes a future solution must satisfy, before architecture and design decisions begin.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/030-architecture-adr-general.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/030-architecture-adr-general.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java ADR Generator with interactive conversational approach</title>
         <description>Use when you need to generate Architecture Decision Records (ADRs) for a Java project through an interactive, conversational process that systematically gathers context, stakeholders, options, and outcomes to produce well-structured ADR documents.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/031-architecture-adr-functional-requirements.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/031-architecture-adr-functional-requirements.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Create ADRs for Functional Requirements (CLI and/or REST API)</title>
         <description>Use when the user wants to document CLI and/or REST API architecture, capture functional requirements in an ADR, create ADRs for command-line tools or HTTP services, or design interfaces with documented decisions.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/032-architecture-adr-non-functional-requirements.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/032-architecture-adr-non-functional-requirements.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Create ADRs for Non-Functional Requirements</title>
         <description>Use when the user wants to document quality attributes, NFR decisions, security/performance/scalability architecture, or design systems with measurable quality criteria using ISO/IEC 25010:2023.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/033-architecture-diagrams-bounded-context.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/033-architecture-diagrams-bounded-context.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Diagrams Generator with modular step-based configuration</title>
         <description>Focused bounded-context PlantUML guidance for the interactive architecture diagrams skill.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/033-architecture-diagrams-c4.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/033-architecture-diagrams-c4.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Diagrams Generator with modular step-based configuration</title>
         <description>Focused C4 Context, Container, and Component diagram guidance for the interactive architecture diagrams skill.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/033-architecture-diagrams-deployment.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/033-architecture-diagrams-deployment.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Diagrams Generator with modular step-based configuration</title>
         <description>Focused UML Deployment Diagram PlantUML guidance for the interactive architecture diagrams skill.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/033-architecture-diagrams-er.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/033-architecture-diagrams-er.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Diagrams Generator with modular step-based configuration</title>
         <description>Focused ER diagram guidance for the interactive architecture diagrams skill.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/033-architecture-diagrams-state-machine.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/033-architecture-diagrams-state-machine.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Diagrams Generator with modular step-based configuration</title>
         <description>Focused UML state machine diagram guidance for the interactive architecture diagrams skill.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/033-architecture-diagrams-uml-class.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/033-architecture-diagrams-uml-class.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Diagrams Generator with modular step-based configuration</title>
         <description>Focused UML class diagram guidance for the interactive architecture diagrams skill.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/033-architecture-diagrams-uml-sequence.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/033-architecture-diagrams-uml-sequence.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Diagrams Generator with modular step-based configuration</title>
         <description>Focused UML sequence diagram guidance for the interactive architecture diagrams skill.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/041-planning-plan-mode.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/041-planning-plan-mode.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Composable Java Implementation Planning</title>
         <description>Use when creating or refining a structured Java implementation plan from trusted issue summaries, approved designs, ADRs, OpenSpec changes, existing plans, or a valid combination.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/042-planning-openspec.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/042-planning-openspec.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Composable OpenSpec Change Planning</title>
         <description>Use when creating or updating OpenSpec change artifacts from an issue, implementation plan, approved design, ADRs, existing OpenSpec artifacts, or a valid combination.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/043-planning-github-issues.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/043-planning-github-issues.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>GitHub CLI — issues, milestones, and discussion for analysis</title>
         <description>Use when you need GitHub CLI (`gh`) installation/authentication guidance and an operator-only GitHub issue inventory workflow. The agent does not ingest GitHub issue, milestone, body, comment, title, label, or summary text; requirements analysis must use repository-owned planning artifacts, with issue numbers only for traceability.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/044-planning-jira.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/044-planning-jira.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Jira CLI - issues, workflows, and discussion for analysis</title>
         <description>Use when you need Jira CLI (`jira`) installation/authentication guidance and a maintainer-authored Jira issue inventory workflow. The agent does not ingest raw Jira issue or JQL output directly; it asks the Jira project maintainer/operator to author sanitized issue summaries before analysis or @014-agile-user-story handoff.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/045-planning-azure-devops.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/045-planning-azure-devops.xml
@@ -8,7 +8,7 @@
             <author>Juan Antonio Breña Moral</author>
             <author>Leandro Loureiro</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Azure DevOps CLI - work item IDs and workflows</title>
         <description>Use when you need to discover Azure DevOps work item IDs (optionally by WIQL), present ID-only results, and execute safe work-item create/update operations. Starts with an interactive check for Azure CLI and the Azure DevOps extension and offers installation guidance before any work item commands.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/051-design-two-steps-methods.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/051-design-two-steps-methods.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Two-Step Change Method</title>
         <description>Use when a complex or risky code change should be split into behavior-preserving preparation followed by the intended behavior change.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/052-design-hamburger-method.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/052-design-hamburger-method.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Hamburger Method Design</title>
         <description>Use when a large feature, story, plan, or spec idea should be split into small vertical slices that still deliver observable value.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/053-design-simple-rules.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/053-design-simple-rules.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Simple Design Rules</title>
         <description>Use when Java design or refactoring choices should be evaluated with Kent Beck's simple design rules in priority order.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/054-design-tdd.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/054-design-tdd.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Test-Driven Development Design</title>
         <description>Use when Java implementation work should be driven by a selected failing test, the smallest passing production code, and refactoring while tests stay green.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/055-design-parallel-change.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/055-design-parallel-change.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Parallel Change Design</title>
         <description>Apply Parallel Change to database migration scenarios as an expand, migrate, and contract workflow before choosing framework-specific Flyway implementation guidance.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/056-design-avoid-breaking-changes.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/056-design-avoid-breaking-changes.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Avoid Breaking Changes</title>
         <description>Review plans, OpenSpec changes, specs, and implementation proposals for compatibility risk across commands, skills, generated outputs, source ownership, documentation, build validation, external contracts, runtime behavior, data, configuration, migration, and release guidance.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/057-design-feature-toggles.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/057-design-feature-toggles.xml
@@ -6,7 +6,7 @@
             <author>Juan Antonio Breña Moral</author>
             <author>Sangwon Park</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Feature Toggles Design</title>
         <description>Examples for designing, implementing, testing, operating, and cleaning up feature toggles in Java enterprise systems without creating avoidable release, rollback, security, or maintenance risk.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/058-design-bdd.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/058-design-bdd.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Behavior-Driven Development Design</title>
         <description>Example-driven reference for explaining and reviewing Gherkin document structure, keywords, scenarios, outlines, arguments, tags, comments, and localization.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/059-design-atdd.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/059-design-atdd.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Acceptance Test-Driven Development Alignment Review</title>
         <description>Example-driven reference for classifying and reporting alignment between OpenSpec execution goals, acceptance criteria, and implementation or verification tasks.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/110-java-maven-best-practices.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/110-java-maven-best-practices.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Best Practices</title>
         <description>Use when you need to improve your Maven pom.xml using best practices.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-archunit.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-archunit.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Add Maven dependencies for improved code quality</title>
         <description>ArchUnit Maven dependency guidance for the interactive Maven dependencies skill.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-javamoney.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-javamoney.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Add Maven dependencies for improved code quality</title>
         <description>JavaMoney Maven dependency guidance for the interactive Maven dependencies skill.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-jspecify.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-jspecify.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Add Maven dependencies for improved code quality</title>
         <description>JSpecify, Error Prone, and NullAway Maven dependency guidance for the interactive Maven dependencies skill.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-vavr.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/111-java-maven-dependencies-vavr.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Add Maven dependencies for improved code quality</title>
         <description>VAVR Maven dependency guidance for the interactive Maven dependencies skill.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-flatten-maven-plugin.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-flatten-maven-plugin.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Flatten Maven plugin guidance for library publishing POMs.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-git-commit-id-maven-plugin.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-git-commit-id-maven-plugin.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Git Commit ID Maven plugin guidance for build traceability metadata.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-jib-maven-plugin.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-jib-maven-plugin.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Jib Maven plugin guidance for container image builds.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-compiler-plugin.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-compiler-plugin.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Maven Compiler plugin guidance for source and target release configuration.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-dependency-plugin.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-dependency-plugin.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Maven Dependency Plugin guidance for declared and undeclared dependency analysis.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-enforcer-plugin.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-enforcer-plugin.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Maven Enforcer plugin guidance for dependency convergence, Java/Maven requirements, and build safety rules.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-failsafe-plugin.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-failsafe-plugin.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Maven Failsafe plugin guidance for integration test execution.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-jxr-plugin.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-jxr-plugin.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Maven JXR plugin guidance for source cross-reference reports.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-surefire-plugin.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-surefire-plugin.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Maven Surefire plugin guidance for unit test execution.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-surefire-report-plugin.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-maven-surefire-report-plugin.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Maven Surefire Report plugin guidance for HTML unit test reports.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-cyclomatic-complexity.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-cyclomatic-complexity.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Cyclomatic complexity profile guidance using PMD and JXR reports.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-jacoco.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-jacoco.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>JaCoCo profile guidance for coverage reporting and thresholds.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-jmh.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-jmh.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>JMH profile guidance for Java microbenchmark support.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-pitest.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-pitest.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>PiTest profile guidance for mutation testing.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-security.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-security.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Security profile guidance for OWASP Dependency Check.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-sonar.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-sonar.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Sonar profile guidance for SonarQube and SonarCloud analysis.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-static-analysis.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-profile-static-analysis.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Static analysis profile guidance for SpotBugs and PMD.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-spotless-maven-plugin.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-spotless-maven-plugin.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Spotless Maven plugin guidance for source formatting.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-versions-maven-plugin.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/112-java-maven-plugins-versions-maven-plugin.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven Plugins: pom.xml Configuration Best Practices</title>
         <description>Versions Maven plugin guidance for dependency and plugin version management.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/113-java-maven-documentation.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/113-java-maven-documentation.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Create DEVELOPER.md for the Maven projects</title>
         <description>Use when you need to create a DEVELOPER.md file for a Maven project documenting plugin goals, Maven profiles, and submodules.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/114-maven-central-search.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/114-maven-central-search.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven version workflow router</title>
         <description>Guides explicit Maven artifact discovery, coordinate verification, version browsing, repository URL construction, and artifact download links using maintainer-approved structured evidence, local resolver output, or approved package-intelligence tooling.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/114-maven-project-version-updates.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/114-maven-project-version-updates.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Maven version workflow router</title>
         <description>Guides interpretation of project-local Versions Maven Plugin report output and local resolver evidence for dependencies, build plugins, and Maven property version updates in the user’s own pom.xml.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-classes-interfaces.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-classes-interfaces.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Object-Oriented Design Guidelines</title>
         <description>Class and interface design guidance covering accessibility, mutability, composition, and inheritance.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-code-smells.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-code-smells.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Object-Oriented Design Guidelines</title>
         <description>Guidance for identifying and refactoring common object-oriented design code smells.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-enums-annotations.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-enums-annotations.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Object-Oriented Design Guidelines</title>
         <description>Enum and annotation guidance for expressive, type-safe Java object-oriented design.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-exceptions.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-exceptions.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Object-Oriented Design Guidelines</title>
         <description>Object-oriented exception design guidance covering exceptional conditions, exception types, messages, and handling.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-methods.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-methods.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Object-Oriented Design Guidelines</title>
         <description>Method design guidance covering validation, defensive copies, signatures, collections, and Optional.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-object-creation.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-object-creation.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Object-Oriented Design Guidelines</title>
         <description>Object creation guidance covering factories, builders, singletons, dependency injection, and unnecessary objects.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-oop-concepts.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-oop-concepts.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Object-Oriented Design Guidelines</title>
         <description>Encapsulation, inheritance, and polymorphism guidance for Java object-oriented design.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-principles.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/121-java-object-oriented-design-principles.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Object-Oriented Design Guidelines</title>
         <description>SOLID, DRY, and YAGNI guidance for Java object-oriented design.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/122-java-type-design.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/122-java-type-design.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Type Design Thinking in Java</title>
         <description>Use when you need to review, improve, or refactor Java code for type design quality — including establishing clear type hierarchies, applying consistent naming conventions, eliminating primitive obsession with domain-specific value objects, leveraging generic type parameters, creating type-safe wrappers, designing fluent interfaces, ensuring precision-appropriate numeric types (BigDecimal for financial calculations), and improving type contrast through interfaces and method signature alignment.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/123-cross-cutting-integration-patterns.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/123-cross-cutting-integration-patterns.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Design and Integration Patterns</title>
         <description>Use when designing or reviewing cross-cutting integration patterns — anti-corruption layers, strangler fig migration, bulkheads, timeouts, retries, backoff, circuit breakers, correlation ids, trace propagation, inbox, outbox, and reliable service boundaries.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/123-database-persistence-patterns.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/123-database-persistence-patterns.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Design and Integration Patterns</title>
         <description>Use when designing or reviewing database and persistence patterns — repositories, unit of work, data mapper, aggregate boundaries, optimistic locking, migrations, CQRS read models, soft delete, multi-tenancy, sharding, connection pools, and N+1 avoidance.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/123-java-design-patterns.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/123-java-design-patterns.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Design and Integration Patterns</title>
         <description>Use when applying classic Java design patterns in application code — creational, structural, and behavioral patterns with practical Java 25 examples and explicit guidance against over-engineering.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/123-kafka-event-driven-patterns.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/123-kafka-event-driven-patterns.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Design and Integration Patterns</title>
         <description>Use when designing or reviewing Kafka and event-driven patterns — event schemas, partitioning keys, consumer groups, idempotent consumers, retry topics, dead-letter topics, outbox, CDC, sagas, CQRS projections, and event sourcing.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/123-rest-api-patterns.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/123-rest-api-patterns.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Design and Integration Patterns</title>
         <description>Use when designing or reviewing REST API patterns — resource-oriented endpoints, DTO boundaries, idempotency, pagination, optimistic concurrency, Problem Details, API gateways, and resilient client interaction.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/124-java-secure-coding.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/124-java-secure-coding.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Secure coding guidelines</title>
         <description>Use when you need to apply Java secure coding best practices — including validating untrusted inputs, defending against injection attacks with parameterized queries, minimizing attack surface via least privilege, applying strong cryptographic algorithms, handling exceptions securely without exposing sensitive data, managing secrets at runtime, avoiding unsafe deserialization, and encoding output to prevent XSS.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/125-java-concurrency.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/125-java-concurrency.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java rules for Concurrency objects</title>
         <description>Use when you need to apply Java concurrency best practices — including thread safety fundamentals, ExecutorService thread pool management, concurrent design patterns like Producer-Consumer, asynchronous programming with CompletableFuture, immutability and safe publication, deadlock avoidance, virtual threads, structured concurrency, scoped values, backpressure, cancellation discipline, and observability for concurrent systems.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/126-java-exception-handling.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/126-java-exception-handling.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Exception Handling Guidelines</title>
         <description>Use when you need to apply Java exception handling best practices — including using specific exception types, managing resources with try-with-resources, securing exception messages, preserving error context via exception chaining, validating inputs early with fail-fast principles, handling thread interruption correctly, documenting exceptions with @throws, enforcing logging policy, translating exceptions at API boundaries, managing retries and idempotency, enforcing timeouts, attaching suppressed exceptions, and propagating failures in async/reactive code.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/128-java-generics.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/128-java-generics.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Generics Best Practices</title>
         <description>Use when you need to review, improve, or refactor Java code for generics quality — including avoiding raw types, applying PECS wildcards, using bounded type parameters, designing effective generic methods, leveraging type inference with the diamond operator, handling type erasure, preventing heap pollution with @SafeVarargs, and integrating generics with Records, sealed types, and pattern matching.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/130-java-testing-strategies-a-trip.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/130-java-testing-strategies-a-trip.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java testing strategies</title>
         <description>Focused A-TRIP guidance for evaluating Java test quality, reliability, and maintainability.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/130-java-testing-strategies-correct.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/130-java-testing-strategies-correct.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java testing strategies</title>
         <description>Focused CORRECT guidance for Java boundary-condition analysis.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/130-java-testing-strategies-right-bicep.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/130-java-testing-strategies-right-bicep.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java testing strategies</title>
         <description>Focused RIGHT-BICEP guidance for deciding what behavior and risks Java tests should cover.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/130-java-testing-strategies.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/130-java-testing-strategies.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java testing strategies</title>
         <description>Use when you need to apply testing strategies for Java code — including RIGHT-BICEP to guide test creation, A-TRIP for test quality characteristics, or CORRECT for verifying boundary conditions. Focused on conceptual frameworks rather than framework-specific annotations.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/131-java-testing-unit-testing.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/131-java-testing-unit-testing.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Unit testing guidelines</title>
         <description>Use when you need to review, improve, or write Java unit tests for framework-agnostic applications (no Spring Boot, Quarkus, Micronaut) — including migrating from JUnit 4 to JUnit 5, adopting AssertJ for fluent assertions, structuring tests with Given-When-Then, ensuring test independence, applying parameterized tests, mocking dependencies with Mockito, verifying boundary conditions (RIGHT-BICEP, CORRECT, A-TRIP), leveraging JSpecify null-safety annotations, or eliminating testing anti-patterns such as reflection-based tests or shared mutable state. For Spring Boot use @321-frameworks-spring-boot-testing-unit-tests. For Quarkus use @421-frameworks-quarkus-testing-unit-tests.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/132-java-testing-integration-testing.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/132-java-testing-integration-testing.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Integration testing guidelines</title>
         <description>Use when you need to set up, review, or improve Java integration tests for framework-agnostic applications (no Spring Boot, Quarkus, Micronaut) — including generating a BaseIntegrationTest.java with WireMock for HTTP stubs, detecting HTTP client infrastructure from import signals, injecting service coordinates dynamically via System.setProperty(), creating WireMock JSON mapping files with bodyFileName, isolating stubs per test method, verifying HTTP interactions, or eliminating anti-patterns such as Mockito-mocked HTTP clients or globally registered WireMock stubs. For Spring Boot use @322-frameworks-spring-boot-testing-integration-tests. For Quarkus use @422-frameworks-quarkus-testing-integration-tests.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/133-java-testing-acceptance-tests.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/133-java-testing-acceptance-tests.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java acceptance tests from Gherkin</title>
         <description>Use when you need to implement acceptance tests from maintainer-sanitized Gherkin scenario facts for framework-agnostic Java apps (no Spring Boot, Quarkus, Micronaut) — including scenarios tagged @acceptance, parse-and-confirm before coding, happy path tests, RestAssured, project-local DB/Kafka test fixtures, WireMock for external REST only, and *AT classes run by Failsafe. Do not ingest raw outsider-authored `.feature` text.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/141-java-refactoring-with-modern-features.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/141-java-refactoring-with-modern-features.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Modern Java Development Guidelines (Java 8+)</title>
         <description>Use when you need to refactor Java code to adopt modern Java features (Java 8+) including lambda expressions, Stream API, Optional, java.time API, collection factory methods, text blocks, var inference, and Java 25 flexible constructor bodies and module import declarations.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/142-java-functional-programming.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/142-java-functional-programming.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Functional Programming rules</title>
         <description>Use when you need to apply functional programming principles in Java — including immutable objects and Records, pure functions, functional interfaces, lambda expressions, Stream API, Optional for null safety, function composition, higher-order functions, pattern matching, sealed classes/interfaces, and concurrent-safe functional patterns.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/143-java-functional-exception-handling.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/143-java-functional-exception-handling.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Functional Exception handling Best Practices</title>
         <description>Use when you need to apply functional exception handling best practices in Java — including replacing exception overuse with Optional and VAVR Either types, designing error type hierarchies using sealed classes and enums, implementing monadic error composition pipelines, establishing functional control flow patterns, and reserving exceptions only for truly exceptional system-level failures.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/144-java-data-oriented-programming.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/144-java-data-oriented-programming.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Data-Oriented Programming Best Practices</title>
         <description>Use when you need to apply data-oriented programming best practices in Java — including separating code (behavior) from data structures using records, designing immutable data with pure transformation functions, keeping data flat and denormalized with ID-based references, starting with generic data structures converting to specific types when needed, ensuring data integrity through pure validation functions, and creating flexible generic data access layers.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/145-refactoring-high-performance-java-code-syntax.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/145-refactoring-high-performance-java-code-syntax.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java rules for High Performance</title>
         <description>Use when you need to improve Java hot-path code shape — including lambdas, API return conventions, parsing syntax, I/O/storage strategy, concurrency, and control-flow patterns.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/145-refactoring-high-performance-java-cpu.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/145-refactoring-high-performance-java-cpu.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java rules for High Performance</title>
         <description>Use when you need to improve Java CPU hot paths — including bit-level parsing, zero-copy/direct buffers, branchless arithmetic, loop unrolling, Unsafe caution, and SIMD/vectorization patterns.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/145-refactoring-high-performance-java-memory-allocation.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/145-refactoring-high-performance-java-memory-allocation.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java rules for High Performance</title>
         <description>Use when you need to improve Java memory behavior in hot paths — including allocation reduction, primitive data choices, escape analysis, collection sizing, data layout, and deduplication patterns.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/151-java-performance-jmeter.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/151-java-performance-jmeter.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Run performance tests based on JMeter</title>
         <description>Use when you need to set up JMeter performance testing for a Java project — including creating the run-jmeter.sh script from the exact template, configuring load tests with loops, threads, and ramp-up, or running performance tests from the project root.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/152-java-performance-gatling.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/152-java-performance-gatling.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Run performance tests based on Gatling</title>
         <description>Use when you need to set up Gatling performance testing for a Java Maven project — including adding Gatling dependencies and the Gatling Maven plugin, creating Java simulations, running gatling:test, configuring a simulation class, and reviewing generated reports.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/161-java-profiling-detect.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/161-java-profiling-detect.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Profiling Workflow / Step 1 / Collect data to measure potential issues</title>
         <description>Use when you need to set up Java application profiling to detect and measure performance issues — including trusted preinstalled async-profiler v4.x setup, problem-driven profiling (CPU, memory, threading, GC, I/O), interactive profiling scripts, or collecting profiling data with flamegraphs and JFR recordings.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/162-java-profiling-analyze.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/162-java-profiling-analyze.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Profiling Workflow / Step 2 / Analyze profiling data</title>
         <description>Use when you need to analyze Java profiling data collected during the detection phase — including interpreting flamegraphs, memory allocation patterns, CPU hotspots, threading issues, systematic problem categorization, evidence documentation, or prioritizing fixes using Impact/Effort scoring.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/163-java-profiling-refactor.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/163-java-profiling-refactor.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Profiling Workflow / Step 3 / Refactor code to fix issues</title>
         <description>Use when you need to refactor Java code based on trusted profiling analysis findings — including reviewing repository-owned or maintainer-sanitized profiling-problem-analysis and profiling-solutions documents, identifying specific performance bottlenecks, and implementing targeted code changes to address them.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/164-java-profiling-verify.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/164-java-profiling-verify.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Profiling Workflow / Step 4 / Verify results</title>
         <description>Use when you need to verify Java performance optimizations by comparing profiling results before and after refactoring — including baseline validation, post-refactoring report generation, quantitative before/after metrics comparison, side-by-side flamegraph analysis, or creating profiling-comparison-analysis and profiling-final-results documentation.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/170-java-documentation.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/170-java-documentation.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Documentation Generator with modular step-based configuration</title>
         <description>Use when you need to generate or improve Java project documentation — including README.md files, package-info.java files, and Javadoc enhancements — through a modular, step-based interactive process that adapts to your specific documentation needs.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/181-java-observability-logging.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/181-java-observability-logging.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Logging Best Practices</title>
         <description>Use when you need to implement or improve Java logging and observability — including selecting SLF4J with Logback/Log4j2, applying proper log levels, parameterized logging, secure logging without sensitive data exposure, environment-specific configuration, log aggregation, and monitoring.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/182-java-observability-metrics-micrometer.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/182-java-observability-metrics-micrometer.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Metrics Observability with Micrometer</title>
         <description>Use when you need to implement or improve Java metrics observability with Micrometer — including meter design, naming/tag conventions, cardinality control, timers/counters/gauges/distribution summaries, percentiles/histograms, Actuator/Prometheus integration, and metrics validation through tests.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/183-java-observability-tracing-opentelemetry.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/183-java-observability-tracing-opentelemetry.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Distributed Tracing with OpenTelemetry</title>
         <description>Use when you need to implement or improve distributed tracing with OpenTelemetry in Java — including trace/span modeling, context propagation, semantic conventions, span attributes/events/status, sampling strategy, baggage usage, privacy safeguards, and backend integration with OTLP collectors.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/200-agents-md.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/200-agents-md.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>AGENTS.md Generator for Java repositories</title>
         <description>Use when you need to generate an AGENTS.md file for a Java repository — covering project conventions, tech stack, file structure, commands, Git workflow, and contributor boundaries — through a modular, step-based interactive process that adapts to your specific project needs.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/300-frameworks-spring-boot-create-project.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/300-frameworks-spring-boot-create-project.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Create Spring Boot Maven Project</title>
         <description>Use when creating a new Maven-based Spring Boot 4.0.x project with SDKMAN-managed Java and Spring Boot CLI tooling.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/301-frameworks-spring-boot-core.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/301-frameworks-spring-boot-core.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Spring Boot Core Guidelines</title>
         <description>Use when you need to review, improve, or build Spring Boot 4.0.x applications — including proper usage of @SpringBootApplication, component annotations (@Controller, @Service, @Repository), bean definition and scoping, configuration classes and @ConfigurationProperties (with @Validated), component scanning, conditional configuration and profiles, constructor injection, @Primary and @Qualifier for multiple beans of the same type, bean minimization, graceful shutdown, virtual threads, Jakarta EE namespace consistency, scheduled tasks, and @TestConfiguration.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/302-frameworks-spring-boot-rest.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/302-frameworks-spring-boot-rest.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java REST API Design Principles</title>
         <description>Use when you need to design, review, or improve REST APIs with Spring Boot — including HTTP methods, resource URIs, status codes, DTOs, versioning, deprecation and sunset headers, content negotiation (JSON and vendor media types), ISO-8601 instants in DTOs, pagination/sorting/filtering, Bean Validation at the boundary, idempotency, ETag concurrency, HTTP caching, error handling, security, contract-first OpenAPI (OpenAPI Generator), controller advice, and problem details for errors.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/303-frameworks-spring-boot-validation.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/303-frameworks-spring-boot-validation.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Spring Boot Validation Guidelines</title>
         <description>Use when you need to design, review, or improve validation in Spring Boot applications — including Bean Validation on request DTOs, @Valid/@Validated at API boundaries, constraint groups, custom constraints, @ConfigurationProperties validation, nested DTO validation, and consistent validation error handling.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/304-frameworks-spring-boot-security.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/304-frameworks-spring-boot-security.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Spring Boot Security Guidelines</title>
         <description>Use when you need to design, review, or improve security in Spring Boot applications — including SecurityFilterChain, OAuth2/JWT resource server patterns, form login basics, method security (@PreAuthorize), CSRF and CORS for APIs, session fixation, security headers, exception handling, password encoding, and sensitive-data-safe logging.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/305-frameworks-spring-boot-modulith.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/305-frameworks-spring-boot-modulith.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Spring Boot - Spring Modulith</title>
         <description>Use when you need to design, review, or improve modular monoliths with Spring Modulith in Spring Boot applications - including module package structure, ApplicationModules verification, named interfaces, allowed dependencies, domain events, @ApplicationModuleTest, Scenario-based module tests, generated documentation, actuator exposure, observability, and event publication registry choices.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/311-frameworks-spring-jdbc.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/311-frameworks-spring-jdbc.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Spring JDBC — JdbcClient (Spring Framework 7+)</title>
         <description>Use when you need to write or review programmatic JDBC with Spring — including JdbcClient (Spring Framework 7+) as the default API, JdbcTemplate only where batch/streaming APIs require JdbcOperations, NamedParameterJdbcTemplate for legacy named-param code, parameterized SQL, RowMapper mapping to records, batch operations, transactions, safe handling of generated keys, DataAccessException handling, read-only transactions, streaming large result sets, and @JdbcTest slice testing.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/312-frameworks-spring-data-jdbc.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/312-frameworks-spring-data-jdbc.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Spring Data JDBC with Records</title>
         <description>Use when you need to use Spring Data JDBC with Java records — including entity design with records, repository pattern, immutable updates, aggregate relationships, custom queries, transaction management, and avoiding N+1 problems. For programmatic JDBC (`JdbcTemplate`, `NamedParameterJdbcTemplate`), hand-written SQL, and maximum control without repository abstraction, use `@311-frameworks-spring-jdbc`. For Flyway-backed DDL and versioned schema changes, use `@313-frameworks-spring-db-migrations-flyway`.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/313-frameworks-spring-db-migrations-flyway-antipatterns.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/313-frameworks-spring-db-migrations-flyway-antipatterns.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Spring — Database migrations (Flyway)</title>
         <description>Review Spring Boot Flyway migrations for data loss, data reinterpretation, repeatable migration surprises, and branch-ordering risks before recommending SQL changes.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/313-frameworks-spring-db-migrations-flyway-parallel-change.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/313-frameworks-spring-db-migrations-flyway-parallel-change.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Spring — Database migrations (Flyway)</title>
         <description>Apply Martin Fowler's Parallel Change technique to Spring Boot Flyway migrations as an expand, migrate, contract workflow.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/313-frameworks-spring-db-migrations-flyway.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/313-frameworks-spring-db-migrations-flyway.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Spring — Database migrations (Flyway)</title>
         <description>Use when you need to add or review Flyway database migrations in a Spring Boot application — including Maven dependencies, `classpath:db/migration` scripts, versioning (`V{version}__{description}.sql`), configuration via `spring.flyway.*`, baseline and repair for existing databases, validation in CI, and coordination with JDBC (`@311-frameworks-spring-jdbc`) or Spring Data JDBC (`@312-frameworks-spring-data-jdbc`). Focus on Flyway; for ORM schema generation use the stack’s Hibernate integration instead of mixing approaches blindly.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/314-frameworks-spring-kafka.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/314-frameworks-spring-kafka.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Spring Boot — Kafka messaging</title>
         <description>Use when you need Kafka with Spring Boot — including Maven dependencies (`spring-boot-starter-kafka`), typed event records, KafkaTemplate producers, @KafkaListener consumers, JSON serialization with Boot auto-configuration, retries and dead-letter topics, idempotent consumers, and integration testing with Testcontainers `@ServiceConnection` or `@EmbeddedKafka`. This should trigger for requests such as Add Kafka in Spring Boot; Review Spring Kafka consumers; Improve retries and DLT in Spring Kafka.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/315-frameworks-spring-mongodb.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/315-frameworks-spring-mongodb.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Spring Boot — MongoDB</title>
         <description>Use when you need MongoDB with Spring Data MongoDB — including Maven dependencies, document modeling with @Document and @CompoundIndex, MongoRepository, MongoTemplate for complex queries, @Version optimistic locking, and explicit error handling for DuplicateKeyException and OptimisticLockingFailureException. This should trigger for requests such as Add MongoDB in Spring Boot; Review Spring Data Mongo repositories; Improve error handling for Mongo writes.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/316-frameworks-spring-mongodb-migrations-mongock-antipatterns.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/316-frameworks-spring-mongodb-migrations-mongock-antipatterns.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Spring - MongoDB migrations (Mongock)</title>
         <description>Review Spring Boot Mongock migrations for unsafe MongoDB document changes, non-idempotent operations, domain-model coupling, lock risks, and missing migration verification.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/316-frameworks-spring-mongodb-migrations-mongock-parallel-change.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/316-frameworks-spring-mongodb-migrations-mongock-parallel-change.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Spring - MongoDB migrations (Mongock)</title>
         <description>Apply Parallel Change to Spring Boot Mongock migrations as an expand, migrate, contract workflow for MongoDB document evolution.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/316-frameworks-spring-mongodb-migrations-mongock.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/316-frameworks-spring-mongodb-migrations-mongock.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Spring - MongoDB migrations (Mongock)</title>
         <description>Use when you need to add or review Mongock MongoDB data migrations in a Spring Boot application - including runner/driver selection per Spring Boot version, standalone runner wiring, migration scan packages, `@ChangeUnit` classes, lock and transaction behavior, and optional policy-approved MongoDB integration verification. For general Spring Data MongoDB persistence use `@315-frameworks-spring-mongodb`.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/321-frameworks-spring-boot-testing-unit-tests.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/321-frameworks-spring-boot-testing-unit-tests.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Spring Boot Unit Testing with Mockito</title>
         <description>Use when you need to write unit tests for Spring Boot applications — including pure unit tests with @ExtendWith(MockitoExtension.class) for @Service/@Component, slice tests with @WebMvcTest and @MockBean/@MockitoBean for controllers, @JsonTest for JSON serialization, parameterized tests with @CsvSource/@MethodSource, test profiles, and @TestConfiguration. For framework-agnostic Java use @131-java-testing-unit-testing. For integration tests use @322-frameworks-spring-boot-testing-integration-tests.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/322-frameworks-spring-boot-testing-integration-tests.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/322-frameworks-spring-boot-testing-integration-tests.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Spring Boot Integration Testing</title>
         <description>Use when you need to write or improve integration tests — including Testcontainers with @ServiceConnection, @DataJdbcTest persistence slices, TestRestTemplate or MockMvcTester for HTTP, data isolation, and container lifecycle management for Spring Boot 4.0.x.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/323-frameworks-spring-boot-testing-acceptance-tests.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/323-frameworks-spring-boot-testing-acceptance-tests.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Spring Boot acceptance tests from Gherkin</title>
         <description>Use when you need to implement acceptance tests from a Gherkin .feature file for Spring Boot applications — including finding scenarios tagged @acceptance, implementing happy path tests with TestRestTemplate, @SpringBootTest, Testcontainers for DB/Kafka, and WireMock for external REST stubs.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/400-frameworks-quarkus-create-project.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/400-frameworks-quarkus-create-project.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Create Quarkus Maven Project</title>
         <description>Use when creating a new Maven-based Quarkus 3.x project with SDKMAN-managed Java and Quarkus CLI tooling.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/401-frameworks-quarkus-core.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/401-frameworks-quarkus-core.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Quarkus Core Guidelines</title>
         <description>Use when you need to review, improve, or build Quarkus applications — including mandatory @QuarkusMain entry points with static main methods, CDI scopes (@ApplicationScoped, @Singleton, @Dependent), constructor injection, @ConfigMapping and SmallRye Config, profiles (%dev, %test, %prod), build-time vs runtime configuration, lifecycle (@Startup, @PreDestroy), metrics integration patterns, and test-friendly bean design.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/402-frameworks-quarkus-rest.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/402-frameworks-quarkus-rest.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Quarkus REST API Guidelines</title>
         <description>Use when you need to design, review, or improve REST APIs with Quarkus REST (Jakarta REST) — including resource classes, HTTP methods, status codes, request/response DTOs, ISO-8601 instants in DTOs, Bean Validation, exception mappers, optional runtime OpenAPI exposure (SmallRye), contract-first generation from OpenAPI (Quarkus OpenAPI Generator or OpenAPI Generator `jaxrs-spec`), content negotiation, pagination, and security-aware boundaries.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/403-frameworks-quarkus-validation.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/403-frameworks-quarkus-validation.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Quarkus Validation Guidelines</title>
         <description>Use when you need to design, review, or improve validation in Quarkus applications — including Bean Validation on JAX-RS resources, @Valid on parameters and CDI beans, constraint groups, @ConfigMapping validation, custom constraints, nested DTO validation, and RFC 7807 validation errors via quarkus-http-problem.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/404-frameworks-quarkus-security.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/404-frameworks-quarkus-security.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Quarkus Security Guidelines</title>
         <description>Use when you need to design, review, or improve security in Quarkus applications — including Quarkus Security with JWT/OIDC, basic auth, @RolesAllowed / @Authenticated / @PermitAll, SecurityIdentity, permission checks, path-based authorization in configuration, exception mapping for auth failures, and sensitive-data-safe logging.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/411-frameworks-quarkus-jdbc.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/411-frameworks-quarkus-jdbc.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Quarkus JDBC — programmatic SQL</title>
         <description>Use when you need to write or review programmatic JDBC in Quarkus — including Agroal-backed DataSource injection, PreparedStatement with bind parameters, mapping rows to Java records, transactions (@Transactional), batch updates, SQL text blocks and upserts with domain exception translation, and optional NamedParameterJdbcTemplate when spring-jdbc is on the classpath. Prefer explicit SQL without ORM.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/412-frameworks-quarkus-panache.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/412-frameworks-quarkus-panache.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Hibernate ORM with Panache</title>
         <description>Use when you need data access with Quarkus Hibernate ORM Panache — including PanacheEntity / PanacheEntityBase, PanacheRepository, named queries, JPQL, native SQL, transactions, pagination, and immutable-friendly patterns. This is the Quarkus analogue to Spring Data for relational persistence; prefer Panache APIs over verbose persistence boilerplate. For Flyway-backed DDL and versioned schema changes, use `@413-frameworks-quarkus-db-migrations-flyway`.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/413-frameworks-quarkus-db-migrations-flyway-antipatterns.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/413-frameworks-quarkus-db-migrations-flyway-antipatterns.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Quarkus — Database migrations (Flyway)</title>
         <description>Review Quarkus Flyway migrations for data loss, data reinterpretation, repeatable migration surprises, and branch-ordering risks before recommending SQL changes.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/413-frameworks-quarkus-db-migrations-flyway-parallel-change.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/413-frameworks-quarkus-db-migrations-flyway-parallel-change.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Quarkus — Database migrations (Flyway)</title>
         <description>Apply Martin Fowler's Parallel Change technique to Quarkus Flyway migrations as an expand, migrate, contract workflow.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/413-frameworks-quarkus-db-migrations-flyway.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/413-frameworks-quarkus-db-migrations-flyway.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Quarkus — Database migrations (Flyway)</title>
         <description>Use when you need to add or review Flyway database migrations in a Quarkus application — including the `quarkus-flyway` extension, `classpath:db/migration` scripts, `V{version}__{description}.sql` naming, `quarkus.flyway.*` configuration, migrate-at-start behavior, and coordination with JDBC (`@411-frameworks-quarkus-jdbc`) or Hibernate ORM with Panache (`@412-frameworks-quarkus-panache`). Focus on Flyway-driven schema evolution, not hand-applied DDL in production.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/414-frameworks-quarkus-kafka.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/414-frameworks-quarkus-kafka.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Quarkus — Kafka messaging</title>
         <description>Use when you need Kafka in Quarkus with SmallRye Reactive Messaging — including Maven extension, channel/topic design, typed @Channel Emitter producers, @Incoming consumers with Uni, build-time Jackson serialization, failure strategies (dead-letter-queue, retry), idempotency, Dev Services, and Testcontainers integration tests. This should trigger for requests such as Add Kafka in Quarkus; Review Reactive Messaging consumers; Improve failure handling for Quarkus Kafka.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/415-frameworks-quarkus-mongodb.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/415-frameworks-quarkus-mongodb.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Quarkus — MongoDB</title>
         <description>Use when you need MongoDB in Quarkus with MongoDB Panache — including Maven extension, entity/repository design with @MongoEntity, PanacheMongoEntity active record vs PanacheMongoRepository, parameterized queries, service-layer persistence boundaries, optional transaction support where infrastructure allows it, and explicit error handling for duplicate key and transient failures. This should trigger for requests such as Add MongoDB in Quarkus; Review Quarkus Mongo Panache entities; Improve Mongo error handling in Quarkus services.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/416-frameworks-quarkus-mongodb-migrations-mongock-antipatterns.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/416-frameworks-quarkus-mongodb-migrations-mongock-antipatterns.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Quarkus - MongoDB migrations (Mongock)</title>
         <description>Review Quarkus Mongock migrations for unsafe MongoDB document changes, non-idempotent operations, Panache/domain coupling, lock risks, and missing migration verification.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/416-frameworks-quarkus-mongodb-migrations-mongock-parallel-change.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/416-frameworks-quarkus-mongodb-migrations-mongock-parallel-change.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Quarkus - MongoDB migrations (Mongock)</title>
         <description>Apply Parallel Change to Quarkus Mongock migrations as an expand, migrate, contract workflow for MongoDB document evolution.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/416-frameworks-quarkus-mongodb-migrations-mongock.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/416-frameworks-quarkus-mongodb-migrations-mongock.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Quarkus - MongoDB migrations (Mongock)</title>
         <description>Use when you need to add or review Mongock MongoDB data migrations in a Quarkus application - including the Quarkiverse Mongock extension, Quarkus MongoDB client configuration, `quarkus.mongock.*` settings, `@ChangeUnit` classes, lock and transaction behavior, and Quarkus test validation. For general Quarkus MongoDB persistence use `@415-frameworks-quarkus-mongodb`.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/421-frameworks-quarkus-testing-unit-tests.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/421-frameworks-quarkus-testing-unit-tests.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Quarkus Unit Testing</title>
         <description>Use when you need to write fast unit tests for Quarkus applications — including pure tests with @ExtendWith(MockitoExtension.class) for CDI @ApplicationScoped beans (instantiated manually), @QuarkusTest with @InjectMock to replace CDI dependencies in focused tests, REST Assured only when HTTP surface is under test, and @ParameterizedTest for data-driven cases. For framework-agnostic Java use @131-java-testing-unit-testing. For full integration use @422-frameworks-quarkus-testing-integration-tests.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/422-frameworks-quarkus-testing-integration-tests.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/422-frameworks-quarkus-testing-integration-tests.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Quarkus Integration Testing</title>
         <description>Use when you need to write or improve integration tests for Quarkus — including @QuarkusTest, Dev Services for databases and messaging, Testcontainers when Dev Services are insufficient, @QuarkusIntegrationTest for black-box tests, REST Assured against @TestHTTPManager, persistence with @Transactional rollback, and clear separation of *IT tests in Failsafe.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/423-frameworks-quarkus-testing-acceptance-tests.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/423-frameworks-quarkus-testing-acceptance-tests.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Quarkus acceptance tests from Gherkin</title>
         <description>Use when you need to implement acceptance tests from maintainer-sanitized Gherkin scenario facts for Quarkus applications — including scenarios tagged @acceptance, @QuarkusTest, REST Assured over the real HTTP port, Testcontainers or Dev Services for databases and Kafka, and WireMock for external REST stubs. Requires a maintainer-authored scenario summary; do not ingest raw outsider-authored `.feature` text.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/500-frameworks-micronaut-create-project.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/500-frameworks-micronaut-create-project.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Create Micronaut Maven Project</title>
         <description>Use when creating a new Maven-based Micronaut 4.x project with SDKMAN-managed Java and Micronaut CLI tooling.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/501-frameworks-micronaut-core.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/501-frameworks-micronaut-core.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Micronaut Core Guidelines</title>
         <description>Use when you need to review, improve, or build Micronaut applications — including application bootstrap with Micronaut.run, @Singleton/@Prototype scopes, @Factory bean producers, constructor injection with jakarta.inject, @ConfigurationProperties and @Property, environments and @Requires, @Controller vs application services, AOP interceptors, @Scheduled tasks, graceful shutdown, virtual-thread friendly execution, health endpoints, and test-oriented bean design.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/502-frameworks-micronaut-rest.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/502-frameworks-micronaut-rest.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Micronaut REST API Guidelines</title>
         <description>Use when you need to design, review, or improve REST APIs with Micronaut — including HTTP methods, resource URIs, status codes, DTOs, versioning, deprecation and sunset headers, content negotiation (JSON and vendor media types), ISO-8601 instants in DTOs, pagination/sorting/filtering, Bean Validation at the boundary, idempotency, ETag concurrency, HTTP caching, error handling with `ExceptionHandler`, security annotations, contract-first OpenAPI (OpenAPI Generator `micronaut` server), optional runtime OpenAPI via `micronaut-openapi`, and RFC 7807-style problem details for errors.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/503-frameworks-micronaut-validation.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/503-frameworks-micronaut-validation.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Micronaut Validation Guidelines</title>
         <description>Use when you need to design, review, or improve validation in Micronaut applications — including Bean Validation on @Controller methods, @Body @Valid, query/path parameter validation, @ConfigurationProperties validation, custom constraints, nested DTO validation, and ExceptionHandler mapping for constraint violations.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/504-frameworks-micronaut-security.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/504-frameworks-micronaut-security.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Micronaut Security Guidelines</title>
         <description>Use when you need to design, review, or improve security in Micronaut applications — including micronaut-security authentication, @Secured and intercept-url-map rules, JWT/session strategies, SecurityService checks, CORS, CSRF awareness for browser apps, rejection handlers, and sensitive-data-safe logging.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/511-frameworks-micronaut-jdbc.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/511-frameworks-micronaut-jdbc.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Micronaut JDBC — programmatic SQL</title>
         <description>Use when you need to write or review programmatic JDBC in Micronaut — including Hikari-backed DataSource injection, PreparedStatement with bind parameters, mapping rows to Java records, transactions (io.micronaut.transaction.annotation.Transactional), batch updates, SQL text blocks, and domain-specific exception translation. Prefer explicit SQL without Micronaut Data when you need full control.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/512-frameworks-micronaut-data.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/512-frameworks-micronaut-data.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Micronaut Data Guidelines</title>
         <description>Use when you need data access with Micronaut Data — including JDBC (and JPA where applicable) repositories, @MappedEntity design, CrudRepository and custom @Query methods, pagination with Pageable, transactions with @Transactional, immutable-friendly entities and DTO projections, optimistic locking, compile-time query validation, and test setup with @MicronautTest and TestPropertyProvider. For hand-written java.sql repositories and maximum SQL control, use `@511-frameworks-micronaut-jdbc`. For Flyway-backed DDL and versioned schema changes, use `@513-frameworks-micronaut-db-migrations-flyway`.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/513-frameworks-micronaut-db-migrations-flyway-antipatterns.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/513-frameworks-micronaut-db-migrations-flyway-antipatterns.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Micronaut — Database migrations (Flyway)</title>
         <description>Review Micronaut Flyway migrations for data loss, data reinterpretation, repeatable migration surprises, and branch-ordering risks before recommending SQL changes.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/513-frameworks-micronaut-db-migrations-flyway-parallel-change.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/513-frameworks-micronaut-db-migrations-flyway-parallel-change.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Micronaut — Database migrations (Flyway)</title>
         <description>Apply Martin Fowler's Parallel Change technique to Micronaut Flyway migrations as an expand, migrate, contract workflow.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/513-frameworks-micronaut-db-migrations-flyway.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/513-frameworks-micronaut-db-migrations-flyway.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Micronaut — Database migrations (Flyway)</title>
         <description>Use when you need to add or review Flyway database migrations in a Micronaut application — including `micronaut-flyway` (or Flyway integration aligned with your Micronaut BOM), `classpath:db/migration` scripts, `V{version}__{description}.sql` naming, per-datasource Flyway configuration, and coordination with JDBC (`@511-frameworks-micronaut-jdbc`) or Micronaut Data (`@512-frameworks-micronaut-data`). Focus on repeatable, versioned schema evolution.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/514-frameworks-micronaut-kafka.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/514-frameworks-micronaut-kafka.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Micronaut — Kafka messaging</title>
         <description>Use when you need Kafka in Micronaut — including Maven dependency and annotation processor, @Serdeable event records, @KafkaClient typed producers, @KafkaListener consumers with OffsetStrategy and ErrorStrategyValue, dead-letter routing, idempotency, and integration testing with @MicronautTest, TestPropertyProvider, and Testcontainers. This should trigger for requests such as Add Kafka in Micronaut; Review Micronaut Kafka listeners; Improve retry and failure handling for Micronaut Kafka.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/515-frameworks-micronaut-mongodb.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/515-frameworks-micronaut-mongodb.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Micronaut — MongoDB</title>
         <description>Use when you need MongoDB persistence in Micronaut — including Maven dependency, @MappedEntity document design, @MongoRepository with typed finders and @MongoFindQuery, @Singleton service boundaries, optional @Transactional use where MongoDB transaction support is configured, and explicit error handling for MongoWriteException and DataAccessException. This should trigger for requests such as Add MongoDB in Micronaut; Review Micronaut Data Mongo entities; Improve error handling for Micronaut Mongo operations.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/516-frameworks-micronaut-mongodb-migrations-mongock-antipatterns.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/516-frameworks-micronaut-mongodb-migrations-mongock-antipatterns.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Micronaut - MongoDB migrations (Mongock)</title>
         <description>Review Micronaut Mongock migrations for unsafe MongoDB document changes, non-idempotent operations, Micronaut Data coupling, lock risks, and missing migration verification.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/516-frameworks-micronaut-mongodb-migrations-mongock-parallel-change.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/516-frameworks-micronaut-mongodb-migrations-mongock-parallel-change.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Micronaut - MongoDB migrations (Mongock)</title>
         <description>Apply Parallel Change to Micronaut Mongock migrations as an expand, migrate, contract workflow for MongoDB document evolution.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/516-frameworks-micronaut-mongodb-migrations-mongock.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/516-frameworks-micronaut-mongodb-migrations-mongock.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Micronaut - MongoDB migrations (Mongock)</title>
         <description>Use when you need to add or review Mongock MongoDB data migrations in a Micronaut application - including Mongock runner/driver selection, Micronaut bean wiring, migration scan packages, `@ChangeUnit` classes, lock and transaction behavior, and Testcontainers validation. For general Micronaut MongoDB persistence use `@515-frameworks-micronaut-mongodb`.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/521-frameworks-micronaut-testing-unit-tests.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/521-frameworks-micronaut-testing-unit-tests.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Micronaut Unit Testing</title>
         <description>Use when you need to write unit tests for Micronaut applications — including pure JUnit 5 + Mockito with @ExtendWith(MockitoExtension.class) for @Singleton services, @MicronautTest with @MockBean for HTTP/controller slices, @Client HttpClient against EmbeddedServer, JSON assertions with AssertJ, @ParameterizedTest with @CsvSource/@MethodSource, property overrides with @Property, and naming conventions (*Test → Surefire, *IT → Failsafe). For framework-agnostic Java use @131-java-testing-unit-testing. For integration tests use @522-frameworks-micronaut-testing-integration-tests.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/522-frameworks-micronaut-testing-integration-tests.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/522-frameworks-micronaut-testing-integration-tests.xml
@@ -5,7 +5,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Micronaut Integration Testing</title>
         <description>Use when you need to write or improve integration tests for Micronaut — including @MicronautTest with full or partial context, HttpClient against EmbeddedServer, Testcontainers with TestPropertyProvider for JDBC and brokers, data isolation, @MicronautTest(transactional = true) rollback where appropriate, and Maven Surefire/Failsafe splits for *Test, *Tests, *IT, and *AT.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/523-frameworks-micronaut-testing-acceptance-tests.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/523-frameworks-micronaut-testing-acceptance-tests.xml
@@ -6,7 +6,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Micronaut acceptance tests from Gherkin</title>
         <description>Use when you need to implement acceptance tests from maintainer-sanitized Gherkin scenario facts for Micronaut applications — including scenarios tagged @acceptance, @MicronautTest with HttpClient against the embedded server, Testcontainers wired via TestPropertyProvider, and WireMock for external REST stubs. Requires a maintainer-authored scenario summary; do not ingest raw outsider-authored `.feature` text.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/701-technologies-openapi.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/701-technologies-openapi.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>OpenAPI 3.x best practices</title>
         <description>Use when you need framework-agnostic OpenAPI 3.x guidance — spec structure, metadata and versioning, paths and operations, reusable schemas, security schemes, examples, documentation quality, contract validation (e.g. Spectral), breaking-change awareness, and handoffs to codegen — without choosing Spring Boot, Quarkus, or Micronaut.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/702-technologies-wiremock.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/702-technologies-wiremock.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>WireMock best practices</title>
         <description>Use when you need framework-agnostic WireMock guidance — stub design, JSON or programmatic mappings, precise request matching, response bodies and faults, classpath fixtures, isolation and reset between tests, verification of calls, dynamic ports and base URLs, and avoiding flaky stubs — without choosing Spring Boot, Quarkus, or Micronaut.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/703-technologies-fuzzing-testing.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/703-technologies-fuzzing-testing.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java fuzz testing with CATS</title>
         <description>Use when you need to add or review fuzz testing for Java APIs with CATS — including contract-driven negative testing, malformed payload validation, boundary input exploration, CI integration, reproducible failures, and local execution guidance.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/704-technologies-sql.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/704-technologies-sql.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>SQL best practices</title>
         <description>Use when you need framework-agnostic SQL guidance — schema naming, relational table design, query readability, indexes, transactions, database security, migrations, testing, and monitoring — without choosing Spring Boot, Quarkus, or Micronaut.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/705-technologies-nosql-mongodb.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/705-technologies-nosql-mongodb.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Non-relational database query best practices</title>
         <description>Use when you need framework-agnostic MongoDB and non-relational database query guidance — document schema design, collection modeling, JSON Schema validation, indexes, aggregation pipelines, query performance, consistency trade-offs, transactions, and operational safety.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/706-technologies-containers-docker.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/706-technologies-containers-docker.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java container image best practices with Docker</title>
         <description>Use when you need framework-agnostic Docker and container image guidance for Java projects - Dockerfile design, multi-stage Maven builds, jlink custom runtimes, micro runtime distributions such as Alpaquita, JVM container ergonomics, non-root execution, image metadata, .dockerignore, reproducible builds, vulnerability scanning, SBOM awareness, and production-safe container defaults.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/707-technologies-hexagonal-architecture.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/707-technologies-hexagonal-architecture.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>Java Hexagonal architecture boundary review</title>
         <description>Use when you need framework-agnostic Hexagonal architecture guidance for Java projects - ports and adapters boundaries, application core independence, driving and driven adapters, dependency direction, infrastructure leakage detection, optional architecture tests, and evidence-backed remediation.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/801-regulations-eu-ai-act-chapters-summary.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/801-regulations-eu-ai-act-chapters-summary.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>EU AI Act Regulation for Java Enterprise Development with AI Systems and AI Agents</title>
         <description>Use as a chapter-by-chapter summary of Regulation (EU) 2024/1689 to enrich Java enterprise AI system and AI agent reviews with EU AI Act context.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/801-regulations-eu-ai-act-engineering-examples.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/801-regulations-eu-ai-act-engineering-examples.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>EU AI Act Regulation for Java Enterprise Development with AI Systems and AI Agents</title>
         <description>Use as Java-focused EU AI Act engineering examples for AI capability classification, agent tool gates, audit evidence, RAG governance, release readiness, and incident routing.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/802-regulations-dora-chapters-summary.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/802-regulations-dora-chapters-summary.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>DORA Regulation for Java Enterprise Digital Operational Resilience</title>
         <description>Use as a chapter-by-chapter and article-by-article summary of Regulation (EU) 2022/2554 to enrich Java enterprise operational-resilience reviews with DORA context.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/802-regulations-dora-engineering-examples.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/802-regulations-dora-engineering-examples.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>DORA Regulation for Java Enterprise Digital Operational Resilience</title>
         <description>Use as Java-focused DORA engineering examples for ICT inventory, incident routing, recovery evidence, third-party ICT provider risk, resilience release gates, and Java release-policy controls.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/803-regulations-gdpr-chapters-summary.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/803-regulations-gdpr-chapters-summary.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>GDPR Regulation for Java Enterprise Personal Data Protection</title>
         <description>Use as a chapter-by-chapter and article-by-article summary of Regulation (EU) 2016/679 to enrich Java enterprise privacy engineering reviews with GDPR context.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/803-regulations-gdpr-engineering-examples.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/803-regulations-gdpr-engineering-examples.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>GDPR Regulation for Java Enterprise Personal Data Protection</title>
         <description>Use as Java-focused GDPR engineering examples for personal-data inventory, DTO minimization, rights workflows, retention and deletion, transfer review, privacy-safe logging, and field-level privacy policy controls.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/804-regulations-eu-nis2-chapters-summary.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/804-regulations-eu-nis2-chapters-summary.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>NIS2 Regulation for Java Enterprise Cybersecurity Risk Management</title>
         <description>Use as a chapter-by-chapter and article-by-article summary of Directive (EU) 2022/2555 to enrich Java enterprise cybersecurity and operational-resilience reviews with NIS2 context.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/804-regulations-eu-nis2-engineering-examples.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/804-regulations-eu-nis2-engineering-examples.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>NIS2 Regulation for Java Enterprise Cybersecurity Risk Management</title>
         <description>Use as Java-focused NIS2 engineering examples for asset inventory, incident escalation, vulnerability evidence, continuity, supply-chain security, and secure release gates.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-chapters-summary.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-chapters-summary.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>EU Cyber Resilience Act Regulation for Java Product Security Engineering</title>
         <description>Use as a chapter-by-chapter, article-by-article, and annex-level summary of Regulation (EU) 2024/2847 to enrich Java product security reviews with Cyber Resilience Act context.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-engineering-examples.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/805-regulations-eu-cyber-resilience-act-engineering-examples.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>EU Cyber Resilience Act Regulation for Java Product Security Engineering</title>
         <description>Use as Java-focused Cyber Resilience Act engineering examples for secure-by-design development, vulnerability handling, coordinated disclosure, security updates, SBOM evidence, product security documentation, support-period signaling, and release gates.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/806-regulations-eu-data-act-chapters-summary.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/806-regulations-eu-data-act-chapters-summary.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>EU Data Act Regulation for Java Enterprise Data Access and Portability Engineering</title>
         <description>Use as a chapter-by-chapter and article-by-article summary of Regulation (EU) 2023/2854 to enrich Java enterprise data access, portability, interoperability, and cloud-switching reviews with EU Data Act context.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/806-regulations-eu-data-act-engineering-examples.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/806-regulations-eu-data-act-engineering-examples.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>EU Data Act Regulation for Java Enterprise Data Access and Portability Engineering</title>
         <description>Use as Java-focused EU Data Act engineering examples for data inventory, access authorization, portability APIs, export formats, metadata, audit logs, cloud switching, non-personal data safeguards, trade-secret handoffs, and data-sharing request workflows.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-chapters-summary.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-chapters-summary.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>EU Digital Services Act Regulation for Java Online Platform Engineering</title>
         <description>Use as a chapter-by-chapter and article-by-article summary of Regulation (EU) 2022/2065 to enrich Java online platform, moderation, transparency, recommender, advertising, and systemic-risk engineering reviews with Digital Services Act context.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-engineering-examples.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/807-regulations-eu-digital-services-act-engineering-examples.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>EU Digital Services Act Regulation for Java Online Platform Engineering</title>
         <description>Use as Java-focused Digital Services Act engineering examples for content decision audit logs, moderation workflow state, notice tracking, recommender explanation, ad transparency, user controls, appeals, systemic-risk evidence, auditor and researcher access, incident escalation, and privacy-safe observability.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/808-regulations-eu-digital-markets-act-chapters-summary.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/808-regulations-eu-digital-markets-act-chapters-summary.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>EU Digital Markets Act Regulation for Java Enterprise Gatekeeper Platform Controls</title>
         <description>Use as a chapter-by-chapter and article-by-article summary of Regulation (EU) 2022/1925 to enrich Java enterprise platform reviews with Digital Markets Act context.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/808-regulations-eu-digital-markets-act-engineering-examples.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/808-regulations-eu-digital-markets-act-engineering-examples.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>EU Digital Markets Act Regulation for Java Enterprise Gatekeeper Platform Controls</title>
         <description>Use as Java-focused Digital Markets Act engineering examples for interoperability interfaces, business-user data access, consent evidence, ranking audit signals, export workflows, anti-circumvention controls, and compliance evidence handoff.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/810-regulations-eu-mifid-ii-chapters-summary.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/810-regulations-eu-mifid-ii-chapters-summary.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>MiFID II Regulation for Java Enterprise Investment Service Controls</title>
         <description>Use as a title-by-title and article-group summary of Directive 2014/65/EU to enrich Java enterprise investment-service reviews with MiFID II context.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/810-regulations-eu-mifid-ii-engineering-examples.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/810-regulations-eu-mifid-ii-engineering-examples.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>MiFID II Regulation for Java Enterprise Investment Service Controls</title>
         <description>Use as Java-focused MiFID II engineering examples for investment-service scope triage, client classification, suitability, appropriateness, order-handling evidence, best-execution evidence, algorithmic-trading governance controls, record keeping, monitoring, and compliance evidence handoff.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/811-regulations-eu-market-abuse-regulation-chapters-summary.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/811-regulations-eu-market-abuse-regulation-chapters-summary.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>EU Market Abuse Regulation for Java Enterprise Market Surveillance Controls</title>
         <description>Use as a chapter-by-chapter and article-by-article summary of Regulation (EU) No 596/2014 to enrich Java enterprise trading, surveillance, disclosure, and investigation reviews with Market Abuse Regulation context.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/811-regulations-eu-market-abuse-regulation-engineering-examples.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/811-regulations-eu-market-abuse-regulation-engineering-examples.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>EU Market Abuse Regulation for Java Enterprise Market Surveillance Controls</title>
         <description>Use as Java-focused Market Abuse Regulation engineering examples for suspicious order and transaction monitoring, market-data lineage, insider-list workflows, disclosure workflows, alert explainability, model and rule provenance, reviewer decisions, false-positive handling, and compliance evidence handoff.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/812-regulations-eu-product-liability-directive-chapters-summary.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/812-regulations-eu-product-liability-directive-chapters-summary.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>EU Product Liability Directive Regulation for Java Product Engineering</title>
         <description>Use as a chapter-by-chapter and article-by-article summary of Directive (EU) 2024/2853 to enrich Java software product, AI-enabled product, generated-instruction, update, warning, and product-safety reviews with Product Liability Directive context.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/812-regulations-eu-product-liability-directive-engineering-examples.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/812-regulations-eu-product-liability-directive-engineering-examples.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>EU Product Liability Directive Regulation for Java Product Engineering</title>
         <description>Use as Java-focused Product Liability Directive engineering examples for software and AI product-liability evidence, generated instructions, AI-agent tool actions, automated updates, warnings, vulnerability handling, corrective updates, incident records, and release gates.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/813-regulations-iso-42001-chapters-summary.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/813-regulations-iso-42001-chapters-summary.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>ISO/IEC 42001 AI Management System Guidance for GenAI Java Engineering</title>
         <description>Use as an ISO/IEC 42001 AI management system summary to enrich GenAI-oriented Java engineering reviews with lifecycle governance, evidence, risk treatment, and owner-handoff context.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/813-regulations-iso-42001-engineering-examples.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/813-regulations-iso-42001-engineering-examples.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <license>Apache-2.0</license>
         <title>ISO/IEC 42001 AI Management System Guidance for GenAI Java Engineering</title>
         <description>Use as Java-focused ISO/IEC 42001 engineering examples for GenAI development controls, generated code review, dependency provenance, prompt and data boundaries, AI-enabled business logic, monitoring, and corrective action.</description>

--- a/plinth-skills-generator/src/main/resources/skill-references/behaviour-article-writer.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/behaviour-article-writer.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <title>Behaviour Article Writer</title>
     </metadata>
 

--- a/plinth-skills-generator/src/main/resources/skill-references/behaviour-consultative-interaction.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/behaviour-consultative-interaction.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <title>Behaviour Consultative Interaction Technique</title>
     </metadata>
 

--- a/plinth-skills-generator/src/main/resources/skill-references/behaviour-progressive-learning.xml
+++ b/plinth-skills-generator/src/main/resources/skill-references/behaviour-progressive-learning.xml
@@ -7,7 +7,7 @@
         <authors>
             <author>Juan Antonio Breña Moral</author>
         </authors>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <title>Behaviour Progressive Learning</title>
     </metadata>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>info.jab</groupId>
     <artifactId>plinth</artifactId>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <packaging>pom</packaging>
     <name>plinth</name>
     <description>An opinionated AI-native workflow for evolving modern Java Enterprise SDLC practices through reusable Skills, Agents, Commands &amp; MCP servers.</description>

--- a/site-generator/pom.xml
+++ b/site-generator/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>info.jab</groupId>
         <artifactId>plinth</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Summary
- Add a `[0.18.0]` section to `CHANGELOG.md`, comparing commits between the `0.17.0` tag and this branch, following Keep a Changelog 1.1.0 conventions
- Record the changelog-generation prompt's target version (0.18.0 vs. 0.17.0) in `documentation/MAINTENANCE.md`

## Test plan
- [x] `jbang markdown-validator/src/main/java/info/jab/mv/MarkdownValidator.java .` passes (Markdown-only documentation change)