### PR TITLE
docs(blog): rename benchmark post file to match its title

### DIFF
--- a/docs/archive.html
+++ b/docs/archive.html
@@ -105,8 +105,8 @@
 <a href="blog/2026/07/why-functional-and-technical-specifications-matter.html" class="list-group-item">
   30 - Why Functional and Technical Specifications Matter for AI-Assisted Development
 </a>
-<a href="blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html" class="list-group-item">
-  28 - Validating hypotheses about Plinth workflow with a Benchmark
+<a href="blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html" class="list-group-item">
+  30 - Validating hypotheses about Plinth workflow with a Benchmark Part 1
 </a>
 <a href="blog/2026/07/release-0.17.0.html" class="list-group-item">
   13 - What&apos;s new in Plinth 0.17.0?

--- a/docs/blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html
+++ b/docs/blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
-  <title>Validating hypotheses about Plinth workflow with a Benchmark - Plinth</title>
+  <title>Validating hypotheses about Plinth workflow with a Benchmark Part 1 - Plinth</title>
   <meta name="author" content="" />
   <meta name="description" content="">
   <link rel="alternate" type="application/atom+xml" href="../../../feed.xml" title="Plinth"/>
@@ -76,10 +76,10 @@
 <div class="row">
 <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
 <div class="post-heading">
-<h1>Validating hypotheses about Plinth workflow with a Benchmark</h1>
+<h1>Validating hypotheses about Plinth workflow with a Benchmark Part 1</h1>
 <span class="post-meta">
   <i class="fa fa-calendar-o"></i>
-  2026-07-28
+  2026-07-30
     &nbsp;
     <i class="fa fa-pencil"></i>
     MyRobot
@@ -319,6 +319,7 @@ test/.../architecture/HexagonalArchitectureTest.java
 <ul>
 <li><strong>Hypothesis 3 — written architectural decisions improve consistency: supported.</strong> Package-naming chaos (six different schemes across 14 <code>scenario1</code> runs) collapses to one dominant scheme the moment <code>scenario2</code>'s ADR states the base package explicitly. The hexagonal scaffold in <code>scenario4</code> follows the same pattern: it's mandated in <code>design.md</code>, not an emergent agent preference — 14 of 22 <code>scenario4</code> runs produced it once that decision existed in writing, versus zero hits across every <code>scenario1</code>–<code>scenario3</code> run.</li>
 </ul>
+<p>In next release, the Benchmark will add other scenarios.</p>
 <h2>Add your own runs</h2>
 <p>The harness is designed to grow: drop a new <code>metrics-v1</code>-shaped result into the matching <code>scenarioN/results/</code> folder and it becomes part of the next pass over this data. If you run this benchmark with a tool or model not yet represented here — or if you can fill in the token/cost gaps for <code>cursor</code> or <code>codex</code>, or close the <code>copilot</code>/<code>github-copilot</code> <code>scenario2</code> gap with a second, consistently-labeled sample — that's exactly the kind of contribution that would sharpen the same-tool ladders in the next update.</p>
 <p>Share findings or raise questions about the harness itself on <a href="https://github.com/jabrena/plinth/discussions">GitHub Discussions</a>.</p>

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/plinth/</id>
   <title>Plinth</title>
-  <updated>2026-07-29T22:14:04+0200</updated>
+  <updated>2026-07-30T09:58:24+0200</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/plinth/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/plinth//feed.xml' />
   <entry>
@@ -16,11 +16,11 @@ When you ask an AI agent to &amp;quot;add rate limiting to the API&amp;quot; and
 But what does &amp;quot;rate limiting&amp;quot; mean here? Per user, per API key, per IP? What happens when the limit is hit — a 429, a queue, a silent drop? Is this a business rule with a specific number att...</summary>
   </entry>
   <entry>
-    <id>https://jabrena.github.io/plinth//blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html</id>
-    <title>Validating hypotheses about Plinth workflow with a Benchmark</title>
+    <id>https://jabrena.github.io/plinth//blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html</id>
+    <title>Validating hypotheses about Plinth workflow with a Benchmark Part 1</title>
     <link></link>
-    <link rel="alternate" type="text/html" href="https://jabrena.github.io/plinth//blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html" />
-    <updated>2026-07-28T00:00:00+0200</updated>
+    <link rel="alternate" type="text/html" href="https://jabrena.github.io/plinth//blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html" />
+    <updated>2026-07-30T00:00:00+0200</updated>
     <summary>The questions behind the benchmark
 During the last months, the project has evolved from a complete Skills folder for Java to provide an AI-native development workflow for Java, more or less this project lives in the Third generation (Systemp prompts -&amp;gt; Skills -&amp;gt; AI-Native development Workflow). During this time, any inquisitive user could ask for evidences about what is the real value using t...</summary>
   </entry>

--- a/docs/index.html
+++ b/docs/index.html
@@ -145,11 +145,11 @@ But what does &quot;rate limiting&quot; mean here? Per user, per API key, per IP
 </div>
 </article>
 <article class="post-preview">
-<h3 class="post-title"><a href="blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html">Validating hypotheses about Plinth workflow with a Benchmark</a></h3>
+<h3 class="post-title"><a href="blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html">Validating hypotheses about Plinth workflow with a Benchmark Part 1</a></h3>
 
 <p class="post-meta">
   <i class="fa fa-calendar-o"></i>
-  2026-07-28
+  2026-07-30
     &nbsp;
     <i class="fa fa-pencil"></i>
     MyRobot
@@ -170,7 +170,7 @@ But what does &quot;rate limiting&quot; mean here? Per user, per API key, per IP
     The questions behind the benchmark
 During the last months, the project has evolved from a complete Skills folder for Java to provide an AI-native development workflow for Java, more or less this project lives in the Third generation (Systemp prompts -&gt; Skills -&gt; AI-Native development Workflow). During this time, any inquisitive user could ask for evidences about what is the real value using t...
     <p></p>
-    <a href="blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html" class="post-read-more">[Read More]</a>
+    <a href="blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html" class="post-read-more">[Read More]</a>
   </div>
 </div>
 </article>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -9,8 +9,8 @@
         <lastmod>2026-07-30</lastmod>
     </url>
     <url>
-        <loc>https://jabrena.github.io/plinth/blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html</loc>
-        <lastmod>2026-07-28</lastmod>
+        <loc>https://jabrena.github.io/plinth/blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html</loc>
+        <lastmod>2026-07-30</lastmod>
     </url>
     <url>
         <loc>https://jabrena.github.io/plinth/blog/2026/07/release-0.17.0.html</loc>

--- a/docs/tags/agents.html
+++ b/docs/tags/agents.html
@@ -115,11 +115,11 @@ But what does &quot;rate limiting&quot; mean here? Per user, per API key, per IP
 </div>
 </article>
 <article class="post-preview">
-<h2 class="post-title"><a href="../blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html">Validating hypotheses about Plinth workflow with a Benchmark</a></h2>
+<h2 class="post-title"><a href="../blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html">Validating hypotheses about Plinth workflow with a Benchmark Part 1</a></h2>
 
 <p class="post-meta">
   <i class="fa fa-calendar-o"></i>
-  2026-07-28
+  2026-07-30
     &nbsp;
     <i class="fa fa-pencil"></i>
     MyRobot
@@ -140,7 +140,7 @@ But what does &quot;rate limiting&quot; mean here? Per user, per API key, per IP
     The questions behind the benchmark
 During the last months, the project has evolved from a complete Skills folder for Java to provide an AI-native development workflow for Java, more or less this project lives in the Third generation (Systemp prompts -&gt; Skills -&gt; AI-Native development Workflow). During this time, any inquisitive user could ask for evidences about what is the real value using t...
     <p></p>
-    <a href="../blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html" class="post-read-more">[Read More]</a>
+    <a href="../blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html" class="post-read-more">[Read More]</a>
   </div>
 </div>
 </article>

--- a/docs/tags/blog.html
+++ b/docs/tags/blog.html
@@ -115,11 +115,11 @@ But what does &quot;rate limiting&quot; mean here? Per user, per API key, per IP
 </div>
 </article>
 <article class="post-preview">
-<h2 class="post-title"><a href="../blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html">Validating hypotheses about Plinth workflow with a Benchmark</a></h2>
+<h2 class="post-title"><a href="../blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html">Validating hypotheses about Plinth workflow with a Benchmark Part 1</a></h2>
 
 <p class="post-meta">
   <i class="fa fa-calendar-o"></i>
-  2026-07-28
+  2026-07-30
     &nbsp;
     <i class="fa fa-pencil"></i>
     MyRobot
@@ -140,7 +140,7 @@ But what does &quot;rate limiting&quot; mean here? Per user, per API key, per IP
     The questions behind the benchmark
 During the last months, the project has evolved from a complete Skills folder for Java to provide an AI-native development workflow for Java, more or less this project lives in the Third generation (Systemp prompts -&gt; Skills -&gt; AI-Native development Workflow). During this time, any inquisitive user could ask for evidences about what is the real value using t...
     <p></p>
-    <a href="../blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html" class="post-read-more">[Read More]</a>
+    <a href="../blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html" class="post-read-more">[Read More]</a>
   </div>
 </div>
 </article>

--- a/docs/tags/java.html
+++ b/docs/tags/java.html
@@ -84,11 +84,11 @@
 
 <div class="posts-list">
 <article class="post-preview">
-<h2 class="post-title"><a href="../blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html">Validating hypotheses about Plinth workflow with a Benchmark</a></h2>
+<h2 class="post-title"><a href="../blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html">Validating hypotheses about Plinth workflow with a Benchmark Part 1</a></h2>
 
 <p class="post-meta">
   <i class="fa fa-calendar-o"></i>
-  2026-07-28
+  2026-07-30
     &nbsp;
     <i class="fa fa-pencil"></i>
     MyRobot
@@ -109,7 +109,7 @@
     The questions behind the benchmark
 During the last months, the project has evolved from a complete Skills folder for Java to provide an AI-native development workflow for Java, more or less this project lives in the Third generation (Systemp prompts -&gt; Skills -&gt; AI-Native development Workflow). During this time, any inquisitive user could ask for evidences about what is the real value using t...
     <p></p>
-    <a href="../blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html" class="post-read-more">[Read More]</a>
+    <a href="../blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html" class="post-read-more">[Read More]</a>
   </div>
 </div>
 </article>

--- a/docs/tags/openspec.html
+++ b/docs/tags/openspec.html
@@ -115,11 +115,11 @@ But what does &quot;rate limiting&quot; mean here? Per user, per API key, per IP
 </div>
 </article>
 <article class="post-preview">
-<h2 class="post-title"><a href="../blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html">Validating hypotheses about Plinth workflow with a Benchmark</a></h2>
+<h2 class="post-title"><a href="../blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html">Validating hypotheses about Plinth workflow with a Benchmark Part 1</a></h2>
 
 <p class="post-meta">
   <i class="fa fa-calendar-o"></i>
-  2026-07-28
+  2026-07-30
     &nbsp;
     <i class="fa fa-pencil"></i>
     MyRobot
@@ -140,7 +140,7 @@ But what does &quot;rate limiting&quot; mean here? Per user, per API key, per IP
     The questions behind the benchmark
 During the last months, the project has evolved from a complete Skills folder for Java to provide an AI-native development workflow for Java, more or less this project lives in the Third generation (Systemp prompts -&gt; Skills -&gt; AI-Native development Workflow). During this time, any inquisitive user could ask for evidences about what is the real value using t...
     <p></p>
-    <a href="../blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html" class="post-read-more">[Read More]</a>
+    <a href="../blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html" class="post-read-more">[Read More]</a>
   </div>
 </div>
 </article>

--- a/docs/tags/performance.html
+++ b/docs/tags/performance.html
@@ -84,11 +84,11 @@
 
 <div class="posts-list">
 <article class="post-preview">
-<h2 class="post-title"><a href="../blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html">Validating hypotheses about Plinth workflow with a Benchmark</a></h2>
+<h2 class="post-title"><a href="../blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html">Validating hypotheses about Plinth workflow with a Benchmark Part 1</a></h2>
 
 <p class="post-meta">
   <i class="fa fa-calendar-o"></i>
-  2026-07-28
+  2026-07-30
     &nbsp;
     <i class="fa fa-pencil"></i>
     MyRobot
@@ -109,7 +109,7 @@
     The questions behind the benchmark
 During the last months, the project has evolved from a complete Skills folder for Java to provide an AI-native development workflow for Java, more or less this project lives in the Third generation (Systemp prompts -&gt; Skills -&gt; AI-Native development Workflow). During this time, any inquisitive user could ask for evidences about what is the real value using t...
     <p></p>
-    <a href="../blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html" class="post-read-more">[Read More]</a>
+    <a href="../blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html" class="post-read-more">[Read More]</a>
   </div>
 </div>
 </article>

--- a/docs/tags/skills.html
+++ b/docs/tags/skills.html
@@ -115,11 +115,11 @@ But what does &quot;rate limiting&quot; mean here? Per user, per API key, per IP
 </div>
 </article>
 <article class="post-preview">
-<h2 class="post-title"><a href="../blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html">Validating hypotheses about Plinth workflow with a Benchmark</a></h2>
+<h2 class="post-title"><a href="../blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html">Validating hypotheses about Plinth workflow with a Benchmark Part 1</a></h2>
 
 <p class="post-meta">
   <i class="fa fa-calendar-o"></i>
-  2026-07-28
+  2026-07-30
     &nbsp;
     <i class="fa fa-pencil"></i>
     MyRobot
@@ -140,7 +140,7 @@ But what does &quot;rate limiting&quot; mean here? Per user, per API key, per IP
     The questions behind the benchmark
 During the last months, the project has evolved from a complete Skills folder for Java to provide an AI-native development workflow for Java, more or less this project lives in the Third generation (Systemp prompts -&gt; Skills -&gt; AI-Native development Workflow). During this time, any inquisitive user could ask for evidences about what is the real value using t...
     <p></p>
-    <a href="../blog/2026/07/what-benchmark-runs-reveal-about-spec-richness.html" class="post-read-more">[Read More]</a>
+    <a href="../blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html" class="post-read-more">[Read More]</a>
   </div>
 </div>
 </article>

--- a/site-generator/content/blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.md
+++ b/site-generator/content/blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.md
@@ -1,5 +1,5 @@
-title=Validating hypotheses about Plinth workflow with a Benchmark
-date=2026-07-28
+title=Validating hypotheses about Plinth workflow with a Benchmark Part 1
+date=2026-07-30
 type=post
 tags=blog,agents,skills,openspec,performance,java
 author=MyRobot
@@ -270,6 +270,8 @@ Putting the per-scenario view and the same-tool ladders together, here's how the
 > This analysis is very relevant because if you don´t ask the AI-Agent tool to review your skills, models will solve the issues in their way in many cases.
 
 - **Hypothesis 3 — written architectural decisions improve consistency: supported.** Package-naming chaos (six different schemes across 14 `scenario1` runs) collapses to one dominant scheme the moment `scenario2`'s ADR states the base package explicitly. The hexagonal scaffold in `scenario4` follows the same pattern: it's mandated in `design.md`, not an emergent agent preference — 14 of 22 `scenario4` runs produced it once that decision existed in writing, versus zero hits across every `scenario1`–`scenario3` run.
+
+In next release, the Benchmark will add other scenarios.
 
 ## Add your own runs
 


### PR DESCRIPTION
## Summary
- Renamed `what-benchmark-runs-reveal-about-spec-richness.md` to `validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.md` to match the post's current front-matter title.
- Regenerated `docs/` via the `site-update` Maven profile so the sitemap, feed, index, and tag pages all point to the new URL.

## Test plan
- [x] `./mvnw clean generate-resources -pl site-generator -P site-update`
- [x] Verified no remaining references to the old filename in `docs/`